### PR TITLE
fix: Add protoc support for Phase 5 protobuf migration

### DIFF
--- a/cap-schema/build.rs
+++ b/cap-schema/build.rs
@@ -18,6 +18,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Enable derive for common traits
     config.type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
 
+    // Enable proto3 optional fields
+    config.protoc_arg("--experimental_allow_proto3_optional");
+
     // Generate code
     config.compile_protos(&proto_files, &["proto/"])?;
 

--- a/cap-sim/Dockerfile
+++ b/cap-sim/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     iperf3 \
     python3 \
     python3-pip \
+    protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory


### PR DESCRIPTION
# E8: Phase 5 Protobuf Migration Compatibility

Adds build-time support for the Phase 5 protobuf migration (PR #57) to enable E8 simulation testing to continue.

## Summary

Phase 5 migrated all domain models to protobuf schemas (3,153 lines removed, 71 new tests). This PR adds the necessary build dependencies to compile the new `cap-schema` protobuf definitions.

## Changes

### 1. cap-schema build.rs
- Added `--experimental_allow_proto3_optional` flag to protoc
- Required for proto3 optional fields in schema definitions
- Enables compilation of protobuf schemas during build

### 2. cap-sim/Dockerfile
- Added `protobuf-compiler` to apt-get dependencies
- Ensures Docker image can build simulation binaries with new schemas
- Required for ContainerLab network simulation tests

## Validation

✅ **Local Build**
```bash
cargo build --example cap_sim_node
# ✓ Compiles successfully
```

✅ **Docker Build**
```bash
make sim-build
# ✓ Image builds with both cap_sim_node and ditto_baseline binaries
```

✅ **No Code Changes Required**
- Simulation code unchanged thanks to `DataSyncBackend` trait abstraction
- Protobuf migration isolated from application logic
- E8 tests ready to run without modification

## Impact

- **Simulation Code**: ✅ No changes needed
- **E8 Tests**: ✅ Ready to run (pending Docker rebuild)
- **CI Build**: ✅ Should pass with protoc available

## Testing Checklist

- [x] Local cargo build succeeds
- [x] Docker image builds successfully
- [x] cap_sim_node binary created
- [x] ditto_baseline binary created
- [ ] CI passes (waiting for GitHub Actions)
- [ ] E8 bandwidth tests run successfully (post-merge validation)

## Related

- Implements: Phase 5 build compatibility
- Depends on: PR #57 (Phase 5: Complete Protobuf Migration)
- Enables: Continued E8 network simulation testing