### PR TITLE
fix: Complete E2E test propagation delays for all set_leader calls

### DIFF
--- a/hive-protocol/tests/squad_formation_e2e.rs
+++ b/hive-protocol/tests/squad_formation_e2e.rs
@@ -860,6 +860,9 @@ async fn test_e2e_timestamped_state_updates() {
     }
     set_leader_result.unwrap();
 
+    // Give Ditto time to propagate the update before we start polling
+    tokio::time::sleep(Duration::from_millis(1000)).await;
+
     // Verify peer1 sees its own update
     let peer1_cell = cell_store1.get_cell(&cell_id).await.unwrap().unwrap();
     println!(
@@ -912,6 +915,9 @@ async fn test_e2e_timestamped_state_updates() {
         println!("  ✗ set_leader(node_beta) failed: {:?}", e);
     }
     set_beta_result.unwrap();
+
+    // Give Ditto time to propagate the update before we start polling
+    tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Verify peer2 sees its own update
     let peer2_cell_after = cell_store2.get_cell(&cell_id).await.unwrap().unwrap();
@@ -1135,6 +1141,9 @@ async fn test_e2e_complete_formation_convergence() {
         .set_leader(&cell_id, "node_2".to_string())
         .await
         .unwrap();
+
+    // Give Ditto time to propagate the update before we start polling
+    tokio::time::sleep(Duration::from_millis(1000)).await;
 
     // Step 4: Validation of final state
     println!("  5. Validating final state convergence...");


### PR DESCRIPTION
## Summary

Completes the fix for E2E test flakiness by adding 1-second Ditto mesh propagation delays after three additional `set_leader()` calls that were missing them.

This PR builds on #88 which fixed two tests. This PR fixes the remaining three `set_leader()` calls to ensure comprehensive coverage.

## Changes

Added `tokio::time::sleep(Duration::from_millis(1000)).await;` after `set_leader()` calls in:

- `test_e2e_timestamped_state_updates` (2 calls at lines 864, 919)
- `test_e2e_complete_formation_convergence` (1 call at line 1145)

## Root Cause

`set_leader()` performs read-modify-write operations that create new CRDT document versions. Ditto's P2P mesh network requires time to propagate these updates to peer nodes before polling can reliably observe them.

Without the delay, tests can poll before propagation completes, leading to flaky failures where peers read stale/None values.

## Testing

- ✅ All 571 tests pass in `make pre-commit`
- ✅ Previously flaky tests now pass consistently
- ✅ Pre-commit hook validation passed

## Related

- Closes the remaining test flakiness from #88
- Follows same pattern established in #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)