### PR TITLE
Phase 2: Beacon System Foundation for P2P Mesh Intelligence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ members = [
     "hive-transport",
     "hive-persistence",
     "hive-sim",
-    "hive-discovery"
+    "hive-discovery",
+    "hive-mesh"
 ]
 
 [workspace.package]

--- a/hive-mesh/Cargo.toml
+++ b/hive-mesh/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "hive-mesh"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+# Workspace dependencies
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true}
+tracing = { workspace = true }
+chrono = { workspace = true }
+
+# Mesh-specific dependencies
+geohash = "0.13"
+
+# Internal dependencies
+hive-discovery = { path = "../hive-discovery" }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util", "macros"] }
+tracing-subscriber = { workspace = true }

--- a/hive-mesh/src/beacon/broadcaster.rs
+++ b/hive-mesh/src/beacon/broadcaster.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tracing::{debug, info};
+
+/// Broadcasts geographic beacons periodically
+///
+/// BeaconBroadcaster is responsible for periodically creating and broadcasting
+/// this node's presence to the mesh network via the storage backend.
+pub struct BeaconBroadcaster {
+    node_id: String,
+    broadcast_interval: Duration,
+    running: Arc<RwLock<bool>>,
+}
+
+impl BeaconBroadcaster {
+    /// Create a new beacon broadcaster
+    pub fn new(node_id: String, broadcast_interval: Duration) -> Self {
+        Self {
+            node_id,
+            broadcast_interval,
+            running: Arc::new(RwLock::new(false)),
+        }
+    }
+
+    /// Start broadcasting beacons
+    ///
+    /// This will run indefinitely until stop() is called
+    pub async fn start(&self) {
+        let mut running = self.running.write().await;
+        if *running {
+            debug!("Beacon broadcaster already running");
+            return;
+        }
+        *running = true;
+        drop(running);
+
+        info!(
+            "Starting beacon broadcaster for node {} with interval {:?}",
+            self.node_id, self.broadcast_interval
+        );
+
+        let mut interval = tokio::time::interval(self.broadcast_interval);
+        let running_clone = self.running.clone();
+
+        tokio::spawn(async move {
+            while *running_clone.read().await {
+                interval.tick().await;
+                // TODO: Broadcast beacon via storage backend
+                debug!("Beacon broadcast tick");
+            }
+        });
+    }
+
+    /// Stop broadcasting beacons
+    pub async fn stop(&self) {
+        let mut running = self.running.write().await;
+        *running = false;
+        info!("Stopped beacon broadcaster for node {}", self.node_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_broadcaster_lifecycle() {
+        let broadcaster =
+            BeaconBroadcaster::new("test-node".to_string(), Duration::from_millis(100));
+
+        broadcaster.start().await;
+        assert!(*broadcaster.running.read().await);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        broadcaster.stop().await;
+        assert!(!*broadcaster.running.read().await);
+    }
+}

--- a/hive-mesh/src/beacon/config.rs
+++ b/hive-mesh/src/beacon/config.rs
@@ -1,0 +1,329 @@
+use serde::{Deserialize, Serialize};
+
+/// Node mobility type
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NodeMobility {
+    /// Static node (command post, fixed infrastructure)
+    Static,
+    /// Mobile node (vehicle, soldier)
+    Mobile,
+    /// Semi-mobile (can relocate but not constantly moving)
+    SemiMobile,
+}
+
+/// Node resource profile
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeResources {
+    /// CPU cores available for mesh operations
+    pub cpu_cores: u8,
+
+    /// Memory available in MB
+    pub memory_mb: u32,
+
+    /// Network bandwidth capacity in Mbps
+    pub bandwidth_mbps: u32,
+
+    /// Current CPU usage percentage (0-100)
+    #[serde(default)]
+    pub cpu_usage_percent: u8,
+
+    /// Current memory usage percentage (0-100)
+    #[serde(default)]
+    pub memory_usage_percent: u8,
+
+    /// Battery level if applicable (0-100, None if AC powered)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub battery_percent: Option<u8>,
+}
+
+impl NodeResources {
+    /// Check if node has sufficient resources to be a parent
+    pub fn can_parent(&self, config: &ParentingRequirements) -> bool {
+        self.cpu_cores >= config.min_cpu_cores
+            && self.memory_mb >= config.min_memory_mb
+            && self.bandwidth_mbps >= config.min_bandwidth_mbps
+            && self.cpu_usage_percent < config.max_cpu_usage_percent
+            && self.memory_usage_percent < config.max_memory_usage_percent
+            && self.has_sufficient_battery(config.min_battery_percent)
+    }
+
+    fn has_sufficient_battery(&self, min_battery: Option<u8>) -> bool {
+        match (self.battery_percent, min_battery) {
+            (Some(battery), Some(min)) => battery >= min,
+            (None, _) => true,       // AC powered, always OK
+            (Some(_), None) => true, // No battery requirement
+        }
+    }
+}
+
+/// Requirements for a node to act as a parent
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParentingRequirements {
+    pub min_cpu_cores: u8,
+    pub min_memory_mb: u32,
+    pub min_bandwidth_mbps: u32,
+    pub max_cpu_usage_percent: u8,
+    pub max_memory_usage_percent: u8,
+    pub min_battery_percent: Option<u8>,
+}
+
+impl Default for ParentingRequirements {
+    fn default() -> Self {
+        Self {
+            min_cpu_cores: 2,
+            min_memory_mb: 512,
+            min_bandwidth_mbps: 10,
+            max_cpu_usage_percent: 80,
+            max_memory_usage_percent: 80,
+            min_battery_percent: Some(20),
+        }
+    }
+}
+
+/// Node profile combining mobility and resources
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeProfile {
+    /// Mobility type
+    pub mobility: NodeMobility,
+
+    /// Resource capacity
+    pub resources: NodeResources,
+
+    /// Whether this node can act as a parent
+    pub can_parent: bool,
+
+    /// Whether this node prefers to be a leaf (never parent)
+    pub prefer_leaf: bool,
+
+    /// Priority for parent selection (higher = more preferred)
+    pub parent_priority: u8,
+}
+
+impl NodeProfile {
+    /// Create a static node profile (command post, fixed infrastructure)
+    pub fn static_node(resources: NodeResources) -> Self {
+        Self {
+            mobility: NodeMobility::Static,
+            resources,
+            can_parent: true,
+            prefer_leaf: false,
+            parent_priority: 255, // Highest priority
+        }
+    }
+
+    /// Create a mobile node profile (vehicle, soldier)
+    pub fn mobile_node(resources: NodeResources) -> Self {
+        Self {
+            mobility: NodeMobility::Mobile,
+            resources,
+            can_parent: false, // Mobile nodes shouldn't parent by default
+            prefer_leaf: true,
+            parent_priority: 0, // Lowest priority
+        }
+    }
+
+    /// Create a semi-mobile node profile (relocatable but stable)
+    pub fn semi_mobile_node(resources: NodeResources) -> Self {
+        Self {
+            mobility: NodeMobility::SemiMobile,
+            resources,
+            can_parent: true, // Can parent if resources allow
+            prefer_leaf: false,
+            parent_priority: 128, // Medium priority
+        }
+    }
+
+    /// Check if this node should be considered as a parent candidate
+    pub fn is_parent_candidate(&self, requirements: &ParentingRequirements) -> bool {
+        if self.prefer_leaf || !self.can_parent {
+            return false;
+        }
+
+        // Static nodes are always good candidates if they meet resource requirements
+        if self.mobility == NodeMobility::Static {
+            return self.resources.can_parent(requirements);
+        }
+
+        // Mobile nodes should not parent
+        if self.mobility == NodeMobility::Mobile {
+            return false;
+        }
+
+        // Semi-mobile can parent if resources are sufficient
+        self.resources.can_parent(requirements)
+    }
+}
+
+/// Beacon configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BeaconConfig {
+    /// Geohash precision (5-9, default 7)
+    /// 5 = ~4.9km cells, 6 = ~1.2km, 7 = ~153m, 8 = ~38m, 9 = ~4.8m
+    pub geohash_precision: usize,
+
+    /// Whether to track all beacons regardless of distance
+    pub track_all: bool,
+
+    /// Maximum distance in meters to track (None = unlimited)
+    pub max_distance_meters: Option<f64>,
+
+    /// Broadcast interval
+    pub broadcast_interval_secs: u64,
+
+    /// Beacon TTL (time to live)
+    pub ttl_secs: u64,
+
+    /// Cleanup interval for janitor
+    pub cleanup_interval_secs: u64,
+}
+
+impl Default for BeaconConfig {
+    fn default() -> Self {
+        Self {
+            geohash_precision: 7,
+            track_all: false,
+            max_distance_meters: Some(5000.0), // 5km default
+            broadcast_interval_secs: 5,
+            ttl_secs: 30,
+            cleanup_interval_secs: 5,
+        }
+    }
+}
+
+impl BeaconConfig {
+    /// Tactical field operations - tight proximity, frequent updates
+    pub fn tactical() -> Self {
+        Self {
+            geohash_precision: 8, // ~38m cells
+            track_all: false,
+            max_distance_meters: Some(2000.0), // 2km
+            broadcast_interval_secs: 3,
+            ttl_secs: 15,
+            cleanup_interval_secs: 3,
+        }
+    }
+
+    /// Distributed cloud - no proximity filtering
+    pub fn distributed() -> Self {
+        Self {
+            geohash_precision: 5, // ~4.9km cells (doesn't matter much)
+            track_all: true,
+            max_distance_meters: None,
+            broadcast_interval_secs: 10,
+            ttl_secs: 60,
+            cleanup_interval_secs: 10,
+        }
+    }
+
+    /// Hybrid - balance between proximity and connectivity
+    pub fn hybrid() -> Self {
+        Self {
+            geohash_precision: 6, // ~1.2km cells
+            track_all: false,
+            max_distance_meters: Some(10000.0), // 10km
+            broadcast_interval_secs: 5,
+            ttl_secs: 30,
+            cleanup_interval_secs: 5,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_node_mobility_types() {
+        let static_resources = NodeResources {
+            cpu_cores: 4,
+            memory_mb: 2048,
+            bandwidth_mbps: 100,
+            cpu_usage_percent: 30,
+            memory_usage_percent: 40,
+            battery_percent: None, // AC powered
+        };
+
+        let mobile_resources = NodeResources {
+            cpu_cores: 2,
+            memory_mb: 512,
+            bandwidth_mbps: 20,
+            cpu_usage_percent: 50,
+            memory_usage_percent: 60,
+            battery_percent: Some(75),
+        };
+
+        let static_profile = NodeProfile::static_node(static_resources);
+        let mobile_profile = NodeProfile::mobile_node(mobile_resources);
+
+        let requirements = ParentingRequirements::default();
+
+        // Static node should be a parent candidate
+        assert!(static_profile.is_parent_candidate(&requirements));
+        assert_eq!(static_profile.parent_priority, 255);
+
+        // Mobile node should NOT be a parent candidate
+        assert!(!mobile_profile.is_parent_candidate(&requirements));
+        assert_eq!(mobile_profile.parent_priority, 0);
+    }
+
+    #[test]
+    fn test_resource_based_parenting() {
+        let low_resources = NodeResources {
+            cpu_cores: 1,
+            memory_mb: 256,
+            bandwidth_mbps: 5,
+            cpu_usage_percent: 90,
+            memory_usage_percent: 85,
+            battery_percent: Some(15),
+        };
+
+        let high_resources = NodeResources {
+            cpu_cores: 8,
+            memory_mb: 4096,
+            bandwidth_mbps: 1000,
+            cpu_usage_percent: 20,
+            memory_usage_percent: 30,
+            battery_percent: None,
+        };
+
+        let requirements = ParentingRequirements::default();
+
+        assert!(!low_resources.can_parent(&requirements));
+        assert!(high_resources.can_parent(&requirements));
+    }
+
+    #[test]
+    fn test_semi_mobile_profile() {
+        let resources = NodeResources {
+            cpu_cores: 4,
+            memory_mb: 1024,
+            bandwidth_mbps: 50,
+            cpu_usage_percent: 40,
+            memory_usage_percent: 50,
+            battery_percent: Some(80),
+        };
+
+        let profile = NodeProfile::semi_mobile_node(resources);
+        let requirements = ParentingRequirements::default();
+
+        // Semi-mobile with good resources should be parent candidate
+        assert!(profile.is_parent_candidate(&requirements));
+        assert_eq!(profile.parent_priority, 128);
+        assert_eq!(profile.mobility, NodeMobility::SemiMobile);
+    }
+
+    #[test]
+    fn test_beacon_config_presets() {
+        let tactical = BeaconConfig::tactical();
+        assert_eq!(tactical.geohash_precision, 8);
+        assert_eq!(tactical.max_distance_meters, Some(2000.0));
+
+        let distributed = BeaconConfig::distributed();
+        assert!(distributed.track_all);
+        assert_eq!(distributed.max_distance_meters, None);
+
+        let hybrid = BeaconConfig::hybrid();
+        assert_eq!(hybrid.geohash_precision, 6);
+        assert_eq!(hybrid.max_distance_meters, Some(10000.0));
+    }
+}

--- a/hive-mesh/src/beacon/janitor.rs
+++ b/hive-mesh/src/beacon/janitor.rs
@@ -1,0 +1,157 @@
+use super::types::GeographicBeacon;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::RwLock;
+use tracing::{debug, info};
+
+/// Cleans up expired beacons based on TTL
+///
+/// BeaconJanitor runs periodically to remove beacons that have exceeded
+/// their time-to-live, ensuring the beacon cache stays fresh.
+pub struct BeaconJanitor {
+    nearby_beacons: Arc<RwLock<HashMap<String, GeographicBeacon>>>,
+    ttl: Duration,
+    cleanup_interval: Duration,
+    running: Arc<RwLock<bool>>,
+}
+
+impl BeaconJanitor {
+    /// Create a new beacon janitor
+    ///
+    /// # Arguments
+    /// * `nearby_beacons` - Shared beacon cache to clean
+    /// * `ttl` - Time-to-live for beacons (e.g., 30 seconds)
+    /// * `cleanup_interval` - How often to run cleanup (e.g., 5 seconds)
+    pub fn new(
+        nearby_beacons: Arc<RwLock<HashMap<String, GeographicBeacon>>>,
+        ttl: Duration,
+        cleanup_interval: Duration,
+    ) -> Self {
+        Self {
+            nearby_beacons,
+            ttl,
+            cleanup_interval,
+            running: Arc::new(RwLock::new(false)),
+        }
+    }
+
+    /// Start the janitor cleanup loop
+    pub async fn start(&self) {
+        let mut running = self.running.write().await;
+        if *running {
+            debug!("Beacon janitor already running");
+            return;
+        }
+        *running = true;
+        drop(running);
+
+        info!(
+            "Starting beacon janitor with TTL {:?} and cleanup interval {:?}",
+            self.ttl, self.cleanup_interval
+        );
+
+        let nearby_beacons = self.nearby_beacons.clone();
+        let ttl_secs = self.ttl.as_secs();
+        let cleanup_interval = self.cleanup_interval;
+        let running_clone = self.running.clone();
+
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(cleanup_interval);
+
+            while *running_clone.read().await {
+                interval.tick().await;
+
+                // Cleanup expired beacons
+                let mut beacons = nearby_beacons.write().await;
+                let initial_count = beacons.len();
+
+                beacons.retain(|_, beacon| !beacon.is_expired(ttl_secs));
+
+                let removed_count = initial_count - beacons.len();
+                if removed_count > 0 {
+                    debug!("Removed {} expired beacons", removed_count);
+                }
+            }
+
+            info!("Beacon janitor stopped");
+        });
+    }
+
+    /// Stop the janitor
+    pub async fn stop(&self) {
+        let mut running = self.running.write().await;
+        *running = false;
+        info!("Stopped beacon janitor");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::beacon::types::{GeoPosition, HierarchyLevel};
+
+    #[tokio::test]
+    async fn test_janitor_lifecycle() {
+        let beacons = Arc::new(RwLock::new(HashMap::new()));
+        let janitor =
+            BeaconJanitor::new(beacons, Duration::from_secs(30), Duration::from_millis(100));
+
+        janitor.start().await;
+        assert!(*janitor.running.read().await);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        janitor.stop().await;
+        assert!(!*janitor.running.read().await);
+    }
+
+    #[tokio::test]
+    async fn test_janitor_cleanup() {
+        let beacons = Arc::new(RwLock::new(HashMap::new()));
+
+        // Add a fresh beacon
+        let fresh_beacon = GeographicBeacon::new(
+            "fresh".to_string(),
+            GeoPosition::new(37.0, -122.0),
+            HierarchyLevel::Platform,
+        );
+        beacons
+            .write()
+            .await
+            .insert("fresh".to_string(), fresh_beacon);
+
+        // Add an expired beacon (simulate by setting old timestamp)
+        let mut expired_beacon = GeographicBeacon::new(
+            "expired".to_string(),
+            GeoPosition::new(37.0, -122.0),
+            HierarchyLevel::Platform,
+        );
+        expired_beacon.timestamp = 0; // Very old timestamp
+        beacons
+            .write()
+            .await
+            .insert("expired".to_string(), expired_beacon);
+
+        assert_eq!(beacons.read().await.len(), 2);
+
+        // Start janitor with short TTL
+        let janitor = BeaconJanitor::new(
+            beacons.clone(),
+            Duration::from_secs(5),
+            Duration::from_millis(50),
+        );
+
+        janitor.start().await;
+
+        // Wait for cleanup to run
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        janitor.stop().await;
+
+        // Expired beacon should be removed
+        assert_eq!(beacons.read().await.len(), 1);
+        assert!(beacons.read().await.contains_key("fresh"));
+        assert!(!beacons.read().await.contains_key("expired"));
+    }
+}

--- a/hive-mesh/src/beacon/mod.rs
+++ b/hive-mesh/src/beacon/mod.rs
@@ -1,0 +1,11 @@
+mod broadcaster;
+mod config;
+mod janitor;
+mod observer;
+mod types;
+
+pub use broadcaster::BeaconBroadcaster;
+pub use config::{BeaconConfig, NodeMobility, NodeProfile, NodeResources, ParentingRequirements};
+pub use janitor::BeaconJanitor;
+pub use observer::BeaconObserver;
+pub use types::{GeoPosition, GeographicBeacon, HierarchyLevel};

--- a/hive-mesh/src/beacon/observer.rs
+++ b/hive-mesh/src/beacon/observer.rs
@@ -1,0 +1,115 @@
+use super::types::GeographicBeacon;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, info};
+
+/// Observes and tracks nearby geographic beacons
+///
+/// BeaconObserver subscribes to beacon updates from the storage backend
+/// and maintains a cache of nearby beacons based on geohash proximity.
+pub struct BeaconObserver {
+    my_geohash: String,
+    nearby_beacons: Arc<RwLock<HashMap<String, GeographicBeacon>>>,
+    running: Arc<RwLock<bool>>,
+}
+
+impl BeaconObserver {
+    /// Create a new beacon observer
+    pub fn new(my_geohash: String) -> Self {
+        Self {
+            my_geohash,
+            nearby_beacons: Arc::new(RwLock::new(HashMap::new())),
+            running: Arc::new(RwLock::new(false)),
+        }
+    }
+
+    /// Start observing beacons
+    pub async fn start(&self) {
+        let mut running = self.running.write().await;
+        if *running {
+            debug!("Beacon observer already running");
+            return;
+        }
+        *running = true;
+        drop(running);
+
+        info!("Starting beacon observer for geohash {}", self.my_geohash);
+
+        // TODO: Subscribe to beacon collection changes from storage backend
+    }
+
+    /// Stop observing beacons
+    pub async fn stop(&self) {
+        let mut running = self.running.write().await;
+        *running = false;
+        info!("Stopped beacon observer");
+    }
+
+    /// Get all nearby beacons
+    pub async fn get_nearby_beacons(&self) -> Vec<GeographicBeacon> {
+        self.nearby_beacons.read().await.values().cloned().collect()
+    }
+
+    /// Check if a geohash is nearby (same or adjacent cell)
+    #[allow(dead_code)]
+    fn is_nearby(&self, other_geohash: &str) -> bool {
+        use geohash::Direction;
+
+        if self.my_geohash == other_geohash {
+            return true;
+        }
+
+        // Check all 8 adjacent cells
+        let directions = [
+            Direction::N,
+            Direction::NE,
+            Direction::E,
+            Direction::SE,
+            Direction::S,
+            Direction::SW,
+            Direction::W,
+            Direction::NW,
+        ];
+
+        for dir in &directions {
+            if let Ok(neighbor) = geohash::neighbor(&self.my_geohash, *dir) {
+                if neighbor == other_geohash {
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_observer_lifecycle() {
+        let observer = BeaconObserver::new("9q8yy9m".to_string());
+
+        observer.start().await;
+        assert!(*observer.running.read().await);
+
+        observer.stop().await;
+        assert!(!*observer.running.read().await);
+    }
+
+    #[test]
+    fn test_is_nearby() {
+        let observer = BeaconObserver::new("9q8yy9m".to_string());
+
+        // Same geohash should be nearby
+        assert!(observer.is_nearby("9q8yy9m"));
+
+        // Adjacent geohashes should be nearby
+        assert!(observer.is_nearby(&geohash::neighbor("9q8yy9m", geohash::Direction::N).unwrap()));
+
+        // Distant geohash should not be nearby
+        assert!(!observer.is_nearby("u4pruyd")); // Sydney, Australia
+    }
+}

--- a/hive-mesh/src/beacon/types.rs
+++ b/hive-mesh/src/beacon/types.rs
@@ -1,0 +1,300 @@
+use serde::{Deserialize, Serialize};
+
+/// Geographic position with latitude, longitude, and optional altitude
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct GeoPosition {
+    /// Latitude in decimal degrees (-90 to 90)
+    pub lat: f64,
+
+    /// Longitude in decimal degrees (-180 to 180)
+    pub lon: f64,
+
+    /// Altitude in meters above sea level (optional)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub alt: Option<f64>,
+}
+
+impl GeoPosition {
+    pub fn new(lat: f64, lon: f64) -> Self {
+        Self {
+            lat,
+            lon,
+            alt: None,
+        }
+    }
+
+    pub fn with_altitude(mut self, alt: f64) -> Self {
+        self.alt = Some(alt);
+        self
+    }
+
+    /// Calculate Haversine distance to another position in meters
+    pub fn distance_to(&self, other: &GeoPosition) -> f64 {
+        let r = 6371000.0; // Earth radius in meters
+        let lat1 = self.lat.to_radians();
+        let lat2 = other.lat.to_radians();
+        let delta_lat = (other.lat - self.lat).to_radians();
+        let delta_lon = (other.lon - self.lon).to_radians();
+
+        let a = (delta_lat / 2.0).sin().powi(2)
+            + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
+        let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
+
+        r * c
+    }
+}
+
+/// Hierarchy level in military command structure
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum HierarchyLevel {
+    /// Individual platform (vehicle, soldier, etc.)
+    Platform = 0,
+    /// Squad level (typically 4-13 platforms)
+    Squad = 1,
+    /// Platoon level (typically 2-4 squads)
+    Platoon = 2,
+    /// Company level (typically 2-4 platoons)
+    Company = 3,
+}
+
+impl HierarchyLevel {
+    /// Get the parent level in the hierarchy
+    pub fn parent(&self) -> Option<HierarchyLevel> {
+        match self {
+            HierarchyLevel::Platform => Some(HierarchyLevel::Squad),
+            HierarchyLevel::Squad => Some(HierarchyLevel::Platoon),
+            HierarchyLevel::Platoon => Some(HierarchyLevel::Company),
+            HierarchyLevel::Company => None,
+        }
+    }
+
+    /// Get the child level in the hierarchy
+    pub fn child(&self) -> Option<HierarchyLevel> {
+        match self {
+            HierarchyLevel::Platform => None,
+            HierarchyLevel::Squad => Some(HierarchyLevel::Platform),
+            HierarchyLevel::Platoon => Some(HierarchyLevel::Squad),
+            HierarchyLevel::Company => Some(HierarchyLevel::Platoon),
+        }
+    }
+}
+
+impl std::fmt::Display for HierarchyLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HierarchyLevel::Platform => write!(f, "Platform"),
+            HierarchyLevel::Squad => write!(f, "Squad"),
+            HierarchyLevel::Platoon => write!(f, "Platoon"),
+            HierarchyLevel::Company => write!(f, "Company"),
+        }
+    }
+}
+
+/// Geographic beacon representing a node's presence and status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeographicBeacon {
+    /// Unique node identifier
+    pub node_id: String,
+
+    /// Geographic position
+    pub position: GeoPosition,
+
+    /// Geohash encoding of position (precision 7 = ~153m cells)
+    pub geohash: String,
+
+    /// Hierarchy level in command structure
+    pub hierarchy_level: HierarchyLevel,
+
+    /// Node capabilities (e.g., "ai-inference", "sensor-fusion", etc.)
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+
+    /// Whether node is operational
+    pub operational: bool,
+
+    /// Unix timestamp (seconds since epoch)
+    pub timestamp: u64,
+
+    /// Node mobility type
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mobility: Option<super::config::NodeMobility>,
+
+    /// Whether this node can act as a parent
+    #[serde(default)]
+    pub can_parent: bool,
+
+    /// Parent selection priority (0-255, higher = more preferred)
+    #[serde(default)]
+    pub parent_priority: u8,
+
+    /// Current resource metrics
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resources: Option<super::config::NodeResources>,
+
+    /// Optional metadata
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub metadata: std::collections::HashMap<String, String>,
+}
+
+impl GeographicBeacon {
+    /// Create a new beacon
+    pub fn new(node_id: String, position: GeoPosition, hierarchy_level: HierarchyLevel) -> Self {
+        use geohash::encode;
+        use geohash::Coord;
+
+        let geohash = encode(
+            Coord {
+                x: position.lon,
+                y: position.lat,
+            },
+            7,
+        )
+        .unwrap_or_else(|_| String::from("invalid"));
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        Self {
+            node_id,
+            position,
+            geohash,
+            hierarchy_level,
+            capabilities: Vec::new(),
+            operational: true,
+            timestamp,
+            mobility: None,
+            can_parent: false,
+            parent_priority: 0,
+            resources: None,
+            metadata: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Update the timestamp to current time
+    pub fn update_timestamp(&mut self) {
+        self.timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+    }
+
+    /// Add a capability
+    pub fn add_capability(&mut self, capability: String) {
+        if !self.capabilities.contains(&capability) {
+            self.capabilities.push(capability);
+        }
+    }
+
+    /// Check if beacon has a specific capability
+    pub fn has_capability(&self, capability: &str) -> bool {
+        self.capabilities.iter().any(|c| c == capability)
+    }
+
+    /// Get age of beacon in seconds
+    pub fn age_seconds(&self) -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+            .saturating_sub(self.timestamp)
+    }
+
+    /// Check if beacon is expired based on TTL
+    pub fn is_expired(&self, ttl_seconds: u64) -> bool {
+        self.age_seconds() > ttl_seconds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_geo_position_distance() {
+        // Test distance between two known points (approximately)
+        let pos1 = GeoPosition::new(37.7749, -122.4194); // San Francisco
+        let pos2 = GeoPosition::new(34.0522, -118.2437); // Los Angeles
+
+        let distance = pos1.distance_to(&pos2);
+
+        // Distance should be approximately 559 km
+        assert!(distance > 550_000.0 && distance < 570_000.0);
+    }
+
+    #[test]
+    fn test_hierarchy_level_parent_child() {
+        assert_eq!(
+            HierarchyLevel::Platform.parent(),
+            Some(HierarchyLevel::Squad)
+        );
+        assert_eq!(
+            HierarchyLevel::Squad.parent(),
+            Some(HierarchyLevel::Platoon)
+        );
+        assert_eq!(
+            HierarchyLevel::Platoon.parent(),
+            Some(HierarchyLevel::Company)
+        );
+        assert_eq!(HierarchyLevel::Company.parent(), None);
+
+        assert_eq!(HierarchyLevel::Platform.child(), None);
+        assert_eq!(
+            HierarchyLevel::Squad.child(),
+            Some(HierarchyLevel::Platform)
+        );
+        assert_eq!(HierarchyLevel::Platoon.child(), Some(HierarchyLevel::Squad));
+        assert_eq!(
+            HierarchyLevel::Company.child(),
+            Some(HierarchyLevel::Platoon)
+        );
+    }
+
+    #[test]
+    fn test_geographic_beacon_creation() {
+        let position = GeoPosition::new(37.7749, -122.4194);
+        let beacon = GeographicBeacon::new(
+            "test-node-1".to_string(),
+            position,
+            HierarchyLevel::Platform,
+        );
+
+        assert_eq!(beacon.node_id, "test-node-1");
+        assert_eq!(beacon.position.lat, 37.7749);
+        assert_eq!(beacon.hierarchy_level, HierarchyLevel::Platform);
+        assert!(beacon.operational);
+        assert!(!beacon.geohash.is_empty());
+    }
+
+    #[test]
+    fn test_beacon_capabilities() {
+        let position = GeoPosition::new(37.7749, -122.4194);
+        let mut beacon =
+            GeographicBeacon::new("test-node".to_string(), position, HierarchyLevel::Squad);
+
+        beacon.add_capability("ai-inference".to_string());
+        beacon.add_capability("sensor-fusion".to_string());
+
+        assert!(beacon.has_capability("ai-inference"));
+        assert!(beacon.has_capability("sensor-fusion"));
+        assert!(!beacon.has_capability("non-existent"));
+    }
+
+    #[test]
+    fn test_beacon_serialization() {
+        let position = GeoPosition::new(37.7749, -122.4194);
+        let beacon =
+            GeographicBeacon::new("test-node".to_string(), position, HierarchyLevel::Platform);
+
+        // Test serialization
+        let json = serde_json::to_string(&beacon).unwrap();
+        assert!(json.contains("test-node"));
+        assert!(json.contains("37.7749"));
+
+        // Test deserialization
+        let deserialized: GeographicBeacon = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.node_id, beacon.node_id);
+        assert_eq!(deserialized.position.lat, beacon.position.lat);
+    }
+}

--- a/hive-mesh/src/lib.rs
+++ b/hive-mesh/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod beacon;
+
+// Re-export main types
+pub use beacon::{
+    BeaconBroadcaster, BeaconJanitor, BeaconObserver, GeoPosition, GeographicBeacon, HierarchyLevel,
+};


### PR DESCRIPTION
## Summary

Implements Phase 2 (Week 3) of EPIC 2 - the beacon system foundation for Layer 2 (Topology Discovery) of the P2P Mesh Intelligence architecture (ADR-017).

## New Crate: hive-mesh

Created a new workspace member (~1000 LOC) providing geographic beacon broadcasting and tracking for proximity-based mesh topology formation.

### Implemented Components

**1. Core Beacon Types** (types.rs ~280 LOC)
- `GeoPosition` with Haversine distance calculation
- `HierarchyLevel` enum (Platform/Squad/Platoon/Company)
- `GeographicBeacon` with geohash encoding (precision 7 = ~153m cells)
- Full serialization support for CRDT replication
- Beacon aging and TTL expiration tracking

**2. Node Profiling System** (config.rs ~330 LOC)
- `NodeMobility` enum (Static/Mobile/SemiMobile)
- `NodeResources` tracking CPU, memory, bandwidth, battery
- `ParentingRequirements` for resource-based parent selection
- `NodeProfile` factory methods for different node types
- `BeaconConfig` with tactical/distributed/hybrid presets
- Static nodes prioritized for parenting, mobile nodes as leafs

**3. BeaconBroadcaster** (broadcaster.rs ~80 LOC)
- Periodic beacon broadcasting framework
- Async lifecycle management (start/stop)
- Ready for storage backend integration

**4. BeaconObserver** (observer.rs ~115 LOC)
- Geohash proximity filtering (8-directional neighbor checking)
- Nearby beacon cache management
- Ready for CRDT subscription integration

**5. BeaconJanitor** (janitor.rs ~155 LOC)
- Automatic TTL-based cleanup of expired beacons
- Configurable cleanup intervals
- Fully functional background task

### Key Features

**Resource-Aware Parenting**: Nodes evaluate CPU, memory, bandwidth, and battery before accepting parent role. Static nodes (command posts) are prioritized; mobile nodes (soldiers) prefer leaf positions.

**Flexible Geography**: Distance filtering is configurable - supports tactical (2km), hybrid (10km), and distributed (unlimited) modes.

**Military Hierarchy**: Native support for Platform → Squad → Platoon → Company hierarchy with parent/child navigation.

### Testing

- ✅ 14 unit tests covering all beacon components
- ✅ Geo distance calculations (Haversine)
- ✅ Hierarchy level navigation
- ✅ Beacon lifecycle and serialization
- ✅ Node mobility and resource-based parenting
- ✅ Beacon config presets
- ✅ Observer proximity detection
- ✅ Janitor TTL cleanup
- ✅ All tests passing (no flakiness)

## Architecture Alignment

This implements **Phase 2, Week 3** of ADR-017:
- ✅ GeographicBeacon with geohash
- ✅ BeaconBroadcaster framework
- ✅ BeaconObserver with proximity filtering
- ✅ BeaconJanitor for TTL management
- ✅ NodeProfile system for heterogeneous nodes
- ✅ Unit tests

## Next Steps (Phase 2, Week 4)

- Integrate with Ditto collections for CRDT-based beacon replication
- Add Containerlab integration tests (50 nodes)
- Implement beacon-driven topology formation

## Related

- EPIC 2 (#105)
- Issue #121
- ADR-017

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)