### PR TITLE
fix: Emit PeerLost event and refactor to P2P terminology

### DIFF
--- a/docs/adr/023-peer-discovery-architecture.md
+++ b/docs/adr/023-peer-discovery-architecture.md
@@ -1,0 +1,219 @@
+# ADR-023: Peer Discovery Architecture - Beacon-Based vs DHT
+
+**Status**: Accepted
+**Date**: 2025-11-22
+**Deciders**: Kit Plummer, Claude Code
+**Related**: ADR-017 (P2P Mesh Management)
+
+## Context
+
+HIVE requires peer discovery mechanisms to enable nodes to find and connect to each other in the P2P mesh network. Discovery needs vary by operational scale:
+
+### Tactical/Local Scale (meters to kilometers)
+- Squad members discovering squad leader
+- Platoon elements coordinating within local area
+- Rapid response to topology changes
+- **Geographic proximity is critical**
+
+### Strategic/Wide-Area Scale (kilometers to global)
+- Cross-region coordination
+- Remote command element access
+- Disaster recovery/failover
+- **Logical connectivity matters more than physical proximity**
+
+### Requirements
+1. **Local Discovery**: Fast, low-latency discovery based on geographic proximity
+2. **Resilience**: No single point of failure
+3. **Minimal Overhead**: Tactical networks have bandwidth constraints
+4. **Optional Global Discovery**: Support for wide-area scenarios without impacting local performance
+5. **P2P Principles**: Align with standard distributed systems terminology and patterns
+
+## Decision
+
+We adopt a **multi-tier discovery architecture**:
+
+### Tier 1: Beacon-Based Local Discovery (Primary - Implemented)
+
+Use geographic beacon broadcasts for local/tactical discovery:
+
+**Mechanism**:
+- Nodes periodically broadcast `GeographicBeacon` messages containing:
+  - Node ID
+  - Position (lat/lon + geohash)
+  - Hierarchy level (Platform, Squad, Platoon, Company)
+  - Capabilities/resources
+  - TTL (default: 30 seconds)
+- Beacons stored in local `BeaconStorage` (memory or persistent)
+- `BeaconObserver` filters by geohash prefix for proximity matching
+- `PeerSelector` chooses optimal peer based on:
+  - Geographic distance
+  - Hierarchy level compatibility
+  - Node capabilities (static vs mobile, resources)
+
+**When to Use**:
+- ✅ Tactical operations (< 10km radius)
+- ✅ Real-time coordination
+- ✅ Mobile units
+- ✅ Bandwidth-constrained environments
+
+**Trade-offs**:
+- ✅ Fast discovery (near real-time)
+- ✅ Geographic proximity guaranteed
+- ✅ Simple implementation
+- ❌ Limited to broadcast range
+- ❌ Doesn't scale to global/wide-area
+
+### Tier 2: DHT-Based Global Discovery (Future - Reserved)
+
+**Option for wide-area scenarios** using Kademlia DHT (libp2p-kad):
+
+**Mechanism**:
+- Distributed hash table for global peer lookups
+- XOR distance metric for routing (logical, not geographic)
+- O(log n) lookup performance
+- Self-healing on peer churn
+
+**When to Use**:
+- ✅ Wide-area operations (> 10km)
+- ✅ Cross-region coordination
+- ✅ Disaster recovery (finding distant peers)
+- ✅ Content distribution (maps, intel)
+
+**Trade-offs**:
+- ✅ Global reach
+- ✅ Scalable to thousands of nodes
+- ✅ Resilient to churn
+- ❌ Higher latency than beacons
+- ❌ Uses logical distance (not geographic)
+- ❌ Additional complexity
+
+### Integration Strategy
+
+Both tiers can coexist:
+
+```rust
+// Local discovery (default, always active)
+let beacon_observer = BeaconObserver::new(storage, local_geohash);
+let peer_selector = PeerSelector::new(config, position, hierarchy_level);
+
+// Global discovery (optional, configured per deployment)
+#[cfg(feature = "global-discovery")]
+let kad_dht = libp2p_kad::Kademlia::new(peer_id, store);
+```
+
+**Discovery Flow**:
+1. **Local First**: Check beacon storage for nearby peers
+2. **Global Fallback**: If no local peers found, query DHT (if enabled)
+3. **Caching**: Cache DHT results in local beacon storage
+
+## Rationale
+
+### Why Beacon-Based for Primary Discovery?
+
+1. **Geographic Proximity Matters**: Military operations require coordination with physically nearby units. Beacons use actual lat/lon distance.
+
+2. **Tactical Performance**: Sub-second discovery enables rapid topology formation critical for tactical scenarios.
+
+3. **Simplicity**: No external dependencies, no global state, works offline.
+
+4. **Bandwidth Efficient**: Periodic broadcasts (every 30s) with local storage minimize network overhead.
+
+5. **Aligns with P2P Principles**: Beacons are broadcast to local peers, not to a central server.
+
+### Why Reserve DHT for Future?
+
+1. **Not Needed for Phase 1**: Initial tactical use cases are local (<10km)
+
+2. **Complexity**: DHT adds routing, key management, and maintenance overhead
+
+3. **Can Add Later**: libp2p-kad can be integrated without changing beacon architecture
+
+4. **Clear Use Cases**: Wide-area disaster recovery, cross-region ops justify future addition
+
+### Why Not DHT-Only?
+
+DHT uses **XOR distance** (logical), not **geographic distance**:
+- A peer with XOR distance 1 could be on the other side of the world
+- For tactical mesh, we need the nearest *physical* peer, not *logical* peer
+- Beacons guarantee geographic proximity
+
+## Consequences
+
+### Positive
+
+1. **Fast Local Discovery**: <1 second to discover nearby peers
+2. **Geographic Accuracy**: Peer selection based on actual physical proximity
+3. **Tactical Suitability**: Optimized for squad/platoon coordination
+4. **P2P Nomenclature**: Clean peer-based terminology (not parent/child)
+5. **Future-Proof**: Can add DHT tier without breaking existing code
+
+### Negative
+
+1. **Limited Range**: Beacon broadcasts don't scale to global
+2. **No Cross-Region Discovery**: Requires DHT for wide-area
+3. **Potential Future Refactor**: If DHT added, need discovery abstraction
+
+### Neutral
+
+1. **Feature Flag for DHT**: `global-discovery` feature for optional DHT
+2. **Discovery Abstraction Needed**: When adding DHT, create `PeerDiscovery` trait
+
+## Implementation
+
+### Current (Phase 1)
+```
+hive-mesh/src/beacon/
+├── broadcaster.rs      # Periodic beacon broadcasts
+├── observer.rs         # Local beacon filtering
+└── storage.rs          # In-memory/persistent storage
+
+hive-mesh/src/topology/
+├── selection.rs        # PeerSelector (geographic + hierarchy)
+├── builder.rs          # TopologyBuilder (peer selection events)
+└── manager.rs          # TopologyManager (connection lifecycle)
+```
+
+### Future (Phase 2 - Optional)
+```
+hive-mesh/src/discovery/
+├── mod.rs              # PeerDiscovery trait (abstraction)
+├── beacon.rs           # BeaconDiscovery (Tier 1)
+└── dht.rs              # DhtDiscovery (Tier 2, optional)
+    └── uses libp2p-kad
+```
+
+## Alternatives Considered
+
+### 1. DHT-Only Discovery
+**Rejected**: XOR distance doesn't guarantee geographic proximity needed for tactical mesh.
+
+### 2. mDNS Discovery
+**Considered but Limited**: Works well on local networks but doesn't cross subnets. Beacons with geohash work across tactical radio networks.
+
+### 3. Central Discovery Server
+**Rejected**: Single point of failure, not P2P, requires infrastructure.
+
+### 4. Gossip Protocol
+**Deferred**: Useful for state dissemination, but beacons already provide peer discovery. Gossip may be added later for CRDT sync.
+
+## Related Work
+
+- **BitTorrent**: Uses DHT (Mainline) for global peer discovery + local peer exchange (PEX)
+- **IPFS**: Uses Kademlia DHT + mDNS for local + mdns for local
+- **Ethereum**: Kademlia DHT for global node discovery
+- **Polkadot**: libp2p-kad + mDNS
+
+HIVE follows similar pattern: **Local discovery (beacons) + optional global discovery (DHT)**.
+
+## References
+
+- ADR-017: P2P Mesh Management and Discovery
+- libp2p-kad: https://docs.rs/libp2p-kad/
+- Kademlia Paper: https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf
+- Geohash: https://en.wikipedia.org/wiki/Geohash
+
+## Decision Log
+
+- **2025-11-22**: Documented beacon-based discovery as primary mechanism
+- **2025-11-22**: Reserved DHT as future enhancement for wide-area scenarios
+- **2025-11-22**: Established multi-tier discovery architecture

--- a/hive-mesh/src/lib.rs
+++ b/hive-mesh/src/lib.rs
@@ -6,6 +6,6 @@ pub use beacon::{
     BeaconBroadcaster, BeaconJanitor, BeaconObserver, GeoPosition, GeographicBeacon, HierarchyLevel,
 };
 pub use topology::{
-    ParentCandidate, ParentInfo, ParentSelector, SelectionConfig, TopologyBuilder, TopologyConfig,
+    PeerCandidate, PeerSelector, SelectedPeer, SelectionConfig, TopologyBuilder, TopologyConfig,
     TopologyEvent, TopologyState,
 };

--- a/hive-mesh/src/topology/builder.rs
+++ b/hive-mesh/src/topology/builder.rs
@@ -1,10 +1,10 @@
 //! Topology builder for beacon-driven mesh formation
 //!
 //! This module implements the TopologyBuilder which coordinates topology formation
-//! by observing nearby beacons, selecting parents, and maintaining hierarchy state.
+//! by observing nearby beacons, selecting peers, and maintaining topology state.
 
 use crate::beacon::{BeaconObserver, GeoPosition, GeographicBeacon, HierarchyLevel, NodeProfile};
-use crate::topology::selection::{ParentSelector, SelectionConfig};
+use crate::topology::selection::{PeerSelector, SelectionConfig};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -13,37 +13,38 @@ use tokio::task::JoinHandle;
 
 /// Topology change events
 #[derive(Debug, Clone)]
+#[allow(clippy::enum_variant_names)] // "Peer" prefix adds clarity to event names
 pub enum TopologyEvent {
-    /// Parent selected for the first time
-    ParentSelected {
-        parent_id: String,
-        parent_beacon: GeographicBeacon,
+    /// Peer selected for the first time
+    PeerSelected {
+        selected_peer_id: String,
+        peer_beacon: GeographicBeacon,
     },
-    /// Parent changed (re-parenting occurred)
-    ParentChanged {
-        old_parent_id: String,
-        new_parent_id: String,
-        new_parent_beacon: GeographicBeacon,
+    /// Selected peer changed (peer change occurred)
+    PeerChanged {
+        old_peer_id: String,
+        new_peer_id: String,
+        new_peer_beacon: GeographicBeacon,
     },
-    /// Parent lost (became unavailable)
-    ParentLost { parent_id: String },
-    /// Child node joined under this node as parent
-    ChildAdded { child_id: String },
-    /// Child node left
-    ChildRemoved { child_id: String },
+    /// Selected peer lost (became unavailable)
+    PeerLost { lost_peer_id: String },
+    /// Linked peer joined under this node
+    PeerAdded { linked_peer_id: String },
+    /// Linked peer left
+    PeerRemoved { linked_peer_id: String },
 }
 
 /// Current topology state
 #[derive(Debug, Clone, Default)]
 pub struct TopologyState {
-    /// Current parent node (if any)
-    pub parent: Option<ParentInfo>,
-    /// Current children nodes (node_id -> last_seen)
-    pub children: HashMap<String, Instant>,
+    /// Current selected peer (if any)
+    pub selected_peer: Option<SelectedPeer>,
+    /// Current linked peers (node_id -> last_seen)
+    pub linked_peers: HashMap<String, Instant>,
 }
 
 #[derive(Debug, Clone)]
-pub struct ParentInfo {
+pub struct SelectedPeer {
     pub node_id: String,
     pub beacon: GeographicBeacon,
     pub selected_at: Instant,
@@ -52,14 +53,14 @@ pub struct ParentInfo {
 /// Configuration for topology builder
 #[derive(Debug, Clone)]
 pub struct TopologyConfig {
-    /// Parent selection configuration
+    /// Peer selection configuration
     pub selection: SelectionConfig,
-    /// How often to re-evaluate parent selection (None = only on beacon changes)
+    /// How often to re-evaluate peer selection (None = only on beacon changes)
     pub reevaluation_interval: Option<Duration>,
-    /// Minimum time before re-parenting (prevents thrashing)
-    pub reparent_cooldown: Duration,
-    /// Time before considering parent lost if no beacon received
-    pub parent_timeout: Duration,
+    /// Minimum time before peer change (prevents thrashing)
+    pub peer_change_cooldown: Duration,
+    /// Time before considering peer lost if no beacon received
+    pub peer_timeout: Duration,
 }
 
 impl Default for TopologyConfig {
@@ -67,8 +68,8 @@ impl Default for TopologyConfig {
         Self {
             selection: SelectionConfig::default(),
             reevaluation_interval: Some(Duration::from_secs(30)),
-            reparent_cooldown: Duration::from_secs(60),
-            parent_timeout: Duration::from_secs(180), // 3 minutes
+            peer_change_cooldown: Duration::from_secs(60),
+            peer_timeout: Duration::from_secs(180), // 3 minutes
         }
     }
 }
@@ -77,9 +78,9 @@ impl Default for TopologyConfig {
 ///
 /// Coordinates topology formation by:
 /// - Observing nearby beacons
-/// - Selecting optimal parents
-/// - Managing parent/child relationships
-/// - Handling dynamic re-parenting
+/// - Selecting optimal peers
+/// - Managing peer relationships
+/// - Handling dynamic peer changes
 pub struct TopologyBuilder {
     config: TopologyConfig,
     #[allow(dead_code)]
@@ -149,19 +150,20 @@ impl TopologyBuilder {
                 // Evaluate topology
                 let current_pos = *position.lock().unwrap();
                 let selector =
-                    ParentSelector::new(config.selection.clone(), current_pos, hierarchy_level);
+                    PeerSelector::new(config.selection.clone(), current_pos, hierarchy_level);
 
                 // Get nearby beacons
                 let nearby = observer.get_nearby_beacons().await;
 
-                // Check current parent status
+                // Check current peer status
                 let mut state_lock = state.lock().unwrap();
-                let needs_parent = Self::check_parent_status(&mut state_lock, &config, &nearby);
+                let needs_peer =
+                    Self::check_peer_status(&mut state_lock, &config, &nearby, &event_tx);
 
-                if needs_parent {
-                    // Select new parent
-                    if let Some(candidate) = selector.select_parent(&nearby) {
-                        Self::update_parent(&mut state_lock, &event_tx, candidate.beacon);
+                if needs_peer {
+                    // Select new peer
+                    if let Some(candidate) = selector.select_peer(&nearby) {
+                        Self::update_selected_peer(&mut state_lock, &event_tx, candidate.beacon);
                     }
                 }
 
@@ -184,9 +186,9 @@ impl TopologyBuilder {
         self.state.lock().unwrap().clone()
     }
 
-    /// Get current parent
-    pub fn get_parent(&self) -> Option<ParentInfo> {
-        self.state.lock().unwrap().parent.clone()
+    /// Get current selected peer
+    pub fn get_selected_peer(&self) -> Option<SelectedPeer> {
+        self.state.lock().unwrap().selected_peer.clone()
     }
 
     /// Get event receiver for topology changes
@@ -201,10 +203,10 @@ impl TopologyBuilder {
         *self.position.lock().unwrap() = position;
     }
 
-    /// Force immediate re-evaluation of parent selection
-    pub async fn reevaluate_parent(&self) {
+    /// Force immediate re-evaluation of peer selection
+    pub async fn reevaluate_peer(&self) {
         let current_pos = *self.position.lock().unwrap();
-        let selector = ParentSelector::new(
+        let selector = PeerSelector::new(
             self.config.selection.clone(),
             current_pos,
             self.hierarchy_level,
@@ -213,89 +215,92 @@ impl TopologyBuilder {
         let nearby = self.observer.get_nearby_beacons().await;
         let mut state_lock = self.state.lock().unwrap();
 
-        if let Some(candidate) = selector.select_parent(&nearby) {
-            // Check if this is better than current parent
-            let should_switch = if let Some(ref current) = state_lock.parent {
+        if let Some(candidate) = selector.select_peer(&nearby) {
+            // Check if this is better than current selected peer
+            let should_switch = if let Some(ref current) = state_lock.selected_peer {
                 // Only switch if cooldown period has passed
                 let elapsed = current.selected_at.elapsed();
-                if elapsed < self.config.reparent_cooldown {
+                if elapsed < self.config.peer_change_cooldown {
                     false
                 } else {
-                    // Re-score current parent and compare
+                    // Re-score current selected peer and compare
                     let current_score = if let Some(current_beacon) =
                         nearby.iter().find(|b| b.node_id == current.node_id)
                     {
                         selector
-                            .select_parent(std::slice::from_ref(current_beacon))
+                            .select_peer(std::slice::from_ref(current_beacon))
                             .map(|c| c.score)
                             .unwrap_or(0.0)
                     } else {
-                        0.0 // Current parent not visible anymore
+                        0.0 // Current selected peer not visible anymore
                     };
 
                     candidate.score > current_score * 1.1 // 10% hysteresis
                 }
             } else {
-                true // No current parent, definitely select
+                true // No current selected peer, definitely select
             };
 
             if should_switch {
-                Self::update_parent(&mut state_lock, &self.event_tx, candidate.beacon);
+                Self::update_selected_peer(&mut state_lock, &self.event_tx, candidate.beacon);
             }
         }
     }
 
-    /// Check parent status and determine if new parent needed
-    fn check_parent_status(
+    /// Check peer status and determine if new peer needed
+    fn check_peer_status(
         state: &mut TopologyState,
         config: &TopologyConfig,
         nearby: &[GeographicBeacon],
+        event_tx: &mpsc::UnboundedSender<TopologyEvent>,
     ) -> bool {
-        if let Some(ref parent) = state.parent {
-            // Check if parent is still visible
-            if nearby.iter().any(|b| b.node_id == parent.node_id) {
-                // Parent still visible
+        if let Some(ref selected_peer) = state.selected_peer {
+            // Check if selected peer is still visible
+            if nearby.iter().any(|b| b.node_id == selected_peer.node_id) {
+                // Selected peer still visible
                 false
             } else {
                 // Check timeout
-                if parent.selected_at.elapsed() > config.parent_timeout {
-                    // Parent lost
-                    state.parent = None;
+                if selected_peer.selected_at.elapsed() > config.peer_timeout {
+                    // Selected peer lost - emit event before clearing state
+                    let lost_peer_id = selected_peer.node_id.clone();
+                    state.selected_peer = None;
+                    let _ = event_tx.send(TopologyEvent::PeerLost { lost_peer_id });
                     true
                 } else {
                     false
                 }
             }
         } else {
-            // No parent, need one
+            // No selected peer, need one
             true
         }
     }
 
-    /// Update current parent
-    fn update_parent(
+    /// Update current selected peer
+    fn update_selected_peer(
         state: &mut TopologyState,
         event_tx: &mpsc::UnboundedSender<TopologyEvent>,
-        new_parent_beacon: GeographicBeacon,
+        new_peer_beacon: GeographicBeacon,
     ) {
-        let new_parent_id = new_parent_beacon.node_id.clone();
+        let new_peer_id = new_peer_beacon.node_id.clone();
 
-        let event = if let Some(ref current) = state.parent {
-            TopologyEvent::ParentChanged {
-                old_parent_id: current.node_id.clone(),
-                new_parent_id: new_parent_id.clone(),
-                new_parent_beacon: new_parent_beacon.clone(),
+        let event = if let Some(ref current) = state.selected_peer {
+            TopologyEvent::PeerChanged {
+                old_peer_id: current.node_id.clone(),
+                new_peer_id: new_peer_id.clone(),
+                new_peer_beacon: new_peer_beacon.clone(),
             }
         } else {
-            TopologyEvent::ParentSelected {
-                parent_id: new_parent_id.clone(),
-                parent_beacon: new_parent_beacon.clone(),
+            TopologyEvent::PeerSelected {
+                selected_peer_id: new_peer_id.clone(),
+                peer_beacon: new_peer_beacon.clone(),
             }
         };
 
-        state.parent = Some(ParentInfo {
-            node_id: new_parent_id,
-            beacon: new_parent_beacon,
+        state.selected_peer = Some(SelectedPeer {
+            node_id: new_peer_id,
+            beacon: new_peer_beacon,
             selected_at: Instant::now(),
         });
 
@@ -325,8 +330,8 @@ mod tests {
         );
 
         let state = builder.get_state();
-        assert!(state.parent.is_none());
-        assert!(state.children.is_empty());
+        assert!(state.selected_peer.is_none());
+        assert!(state.linked_peers.is_empty());
     }
 
     #[tokio::test]

--- a/hive-mesh/src/topology/manager.rs
+++ b/hive-mesh/src/topology/manager.rs
@@ -20,8 +20,8 @@ use tracing::{debug, info, warn};
 /// # Architecture
 ///
 /// - Subscribes to topology events from TopologyBuilder
-/// - Reacts to ParentSelected/Changed/Lost events
-/// - Establishes parent connections via MeshTransport
+/// - Reacts to PeerSelected/Changed/Lost events
+/// - Establishes peer connections via MeshTransport
 /// - Tears down stale connections
 ///
 /// # Example
@@ -37,17 +37,17 @@ use tracing::{debug, info, warn};
 /// manager.start().await?;
 /// ```
 pub struct TopologyManager {
-    /// Topology builder for parent selection
+    /// Topology builder for peer selection
     builder: TopologyBuilder,
 
     /// Transport abstraction for connections
     transport: Arc<dyn MeshTransport>,
 
-    /// Current parent connection (if any)
-    parent_connection: Arc<RwLock<Option<Box<dyn MeshConnection>>>>,
+    /// Current peer connection (if any)
+    peer_connection: Arc<RwLock<Option<Box<dyn MeshConnection>>>>,
 
-    /// Current parent node ID (if any)
-    parent_id: Arc<RwLock<Option<NodeId>>>,
+    /// Current selected peer node ID (if any)
+    selected_peer_id: Arc<RwLock<Option<NodeId>>>,
 
     /// Background task handle
     task_handle: RwLock<Option<JoinHandle<()>>>,
@@ -58,14 +58,14 @@ impl TopologyManager {
     ///
     /// # Arguments
     ///
-    /// * `builder` - TopologyBuilder for parent selection
+    /// * `builder` - TopologyBuilder for peer selection
     /// * `transport` - Transport abstraction for connections
     pub fn new(builder: TopologyBuilder, transport: Arc<dyn MeshTransport>) -> Self {
         Self {
             builder,
             transport,
-            parent_connection: Arc::new(RwLock::new(None)),
-            parent_id: Arc::new(RwLock::new(None)),
+            peer_connection: Arc::new(RwLock::new(None)),
+            selected_peer_id: Arc::new(RwLock::new(None)),
             task_handle: RwLock::new(None),
         }
     }
@@ -83,11 +83,11 @@ impl TopologyManager {
         // Subscribe to topology events
         if let Some(rx) = self.builder.subscribe() {
             let transport = self.transport.clone();
-            let parent_connection = self.parent_connection.clone();
-            let parent_id = self.parent_id.clone();
+            let peer_connection = self.peer_connection.clone();
+            let selected_peer_id = self.selected_peer_id.clone();
 
             let handle = tokio::spawn(async move {
-                Self::event_loop(rx, transport, parent_connection, parent_id).await;
+                Self::event_loop(rx, transport, peer_connection, selected_peer_id).await;
             });
 
             *self.task_handle.write().unwrap() = Some(handle);
@@ -98,7 +98,7 @@ impl TopologyManager {
 
     /// Stop topology management
     ///
-    /// Stops the topology builder and disconnects from parent.
+    /// Stops the topology builder and disconnects from selected peer.
     pub async fn stop(&self) -> Result<(), Box<dyn std::error::Error>> {
         // Abort the event loop task
         if let Some(handle) = self.task_handle.write().unwrap().take() {
@@ -108,11 +108,11 @@ impl TopologyManager {
         // Stop the topology builder
         self.builder.stop().await;
 
-        // Disconnect from current parent
-        let current_parent_id = self.parent_id.write().unwrap().take();
-        if let Some(parent_id) = current_parent_id {
-            if let Err(e) = self.transport.disconnect(&parent_id).await {
-                warn!("Failed to disconnect from parent during stop: {}", e);
+        // Disconnect from current selected peer
+        let current_selected_peer_id = self.selected_peer_id.write().unwrap().take();
+        if let Some(selected_peer_id) = current_selected_peer_id {
+            if let Err(e) = self.transport.disconnect(&selected_peer_id).await {
+                warn!("Failed to disconnect from selected peer during stop: {}", e);
             }
         }
 
@@ -122,14 +122,14 @@ impl TopologyManager {
         Ok(())
     }
 
-    /// Get current parent node ID
-    pub fn get_parent_id(&self) -> Option<NodeId> {
-        self.parent_id.read().unwrap().clone()
+    /// Get current selected peer node ID
+    pub fn get_selected_peer_id(&self) -> Option<NodeId> {
+        self.selected_peer_id.read().unwrap().clone()
     }
 
-    /// Check if currently connected to a specific parent
-    pub fn is_connected_to_parent(&self, node_id: &NodeId) -> bool {
-        self.parent_id
+    /// Check if currently connected to a specific peer
+    pub fn is_connected_to_peer(&self, node_id: &NodeId) -> bool {
+        self.selected_peer_id
             .read()
             .unwrap()
             .as_ref()
@@ -148,90 +148,85 @@ impl TopologyManager {
     async fn event_loop(
         mut rx: mpsc::UnboundedReceiver<TopologyEvent>,
         transport: Arc<dyn MeshTransport>,
-        parent_connection: Arc<RwLock<Option<Box<dyn MeshConnection>>>>,
-        parent_id: Arc<RwLock<Option<NodeId>>>,
+        peer_connection: Arc<RwLock<Option<Box<dyn MeshConnection>>>>,
+        selected_peer_id: Arc<RwLock<Option<NodeId>>>,
     ) {
         while let Some(event) = rx.recv().await {
             match event {
-                TopologyEvent::ParentSelected {
-                    parent_id: new_parent_id,
+                TopologyEvent::PeerSelected {
+                    selected_peer_id: new_peer_id,
                     ..
                 } => {
-                    info!("Parent selected: {}", new_parent_id);
-                    let node_id = NodeId::new(new_parent_id.clone());
+                    info!("Peer selected: {}", new_peer_id);
+                    let node_id = NodeId::new(new_peer_id.clone());
 
-                    // Connect to the selected parent
+                    // Connect to the selected peer
                     match transport.connect(&node_id).await {
                         Ok(conn) => {
-                            *parent_connection.write().unwrap() = Some(conn);
-                            *parent_id.write().unwrap() = Some(node_id);
-                            info!("Successfully connected to parent: {}", new_parent_id);
+                            *peer_connection.write().unwrap() = Some(conn);
+                            *selected_peer_id.write().unwrap() = Some(node_id);
+                            info!("Successfully connected to peer: {}", new_peer_id);
                         }
                         Err(e) => {
-                            warn!("Failed to connect to parent {}: {}", new_parent_id, e);
+                            warn!("Failed to connect to peer {}: {}", new_peer_id, e);
                         }
                     }
                 }
 
-                TopologyEvent::ParentChanged {
-                    old_parent_id,
-                    new_parent_id,
+                TopologyEvent::PeerChanged {
+                    old_peer_id,
+                    new_peer_id,
                     ..
                 } => {
-                    info!("Parent changed: {} -> {}", old_parent_id, new_parent_id);
+                    info!("Selected peer changed: {} -> {}", old_peer_id, new_peer_id);
 
-                    // Disconnect from old parent
-                    let old_id = NodeId::new(old_parent_id.clone());
+                    // Disconnect from old peer
+                    let old_id = NodeId::new(old_peer_id.clone());
                     if let Err(e) = transport.disconnect(&old_id).await {
-                        warn!(
-                            "Failed to disconnect from old parent {}: {}",
-                            old_parent_id, e
-                        );
+                        warn!("Failed to disconnect from old peer {}: {}", old_peer_id, e);
                     }
 
-                    // Connect to new parent
-                    let new_id = NodeId::new(new_parent_id.clone());
+                    // Connect to new peer
+                    let new_id = NodeId::new(new_peer_id.clone());
                     match transport.connect(&new_id).await {
                         Ok(conn) => {
-                            *parent_connection.write().unwrap() = Some(conn);
-                            *parent_id.write().unwrap() = Some(new_id);
-                            info!("Successfully re-parented to: {}", new_parent_id);
+                            *peer_connection.write().unwrap() = Some(conn);
+                            *selected_peer_id.write().unwrap() = Some(new_id);
+                            info!("Successfully changed to peer: {}", new_peer_id);
                         }
                         Err(e) => {
-                            warn!("Failed to connect to new parent {}: {}", new_parent_id, e);
+                            warn!("Failed to connect to new peer {}: {}", new_peer_id, e);
                         }
                     }
                 }
 
-                TopologyEvent::ParentLost {
-                    parent_id: lost_parent_id,
-                } => {
-                    info!("Parent lost: {}", lost_parent_id);
+                TopologyEvent::PeerLost { lost_peer_id } => {
+                    info!("Selected peer lost: {}", lost_peer_id);
 
-                    // Clear parent connection
-                    *parent_connection.write().unwrap() = None;
-                    *parent_id.write().unwrap() = None;
+                    // Clear peer connection
+                    *peer_connection.write().unwrap() = None;
+                    *selected_peer_id.write().unwrap() = None;
 
-                    // Disconnect
-                    let node_id = NodeId::new(lost_parent_id.clone());
+                    // Disconnect from lost peer
+                    let node_id = NodeId::new(lost_peer_id.clone());
                     if let Err(e) = transport.disconnect(&node_id).await {
                         warn!(
-                            "Failed to disconnect from lost parent {}: {}",
-                            lost_parent_id, e
+                            "Failed to disconnect from lost peer {}: {}",
+                            lost_peer_id, e
                         );
                     }
 
-                    debug!("Cleared connection to lost parent: {}", lost_parent_id);
+                    debug!("Cleared connection to lost peer: {}", lost_peer_id);
                 }
 
-                TopologyEvent::ChildAdded { child_id } => {
-                    debug!("Child added: {}", child_id);
-                    // Future: Track child connections if needed
+                TopologyEvent::PeerAdded { linked_peer_id } => {
+                    debug!("Linked peer added: {}", linked_peer_id);
+                    // Future: Track linked peer connections if needed
                 }
 
-                TopologyEvent::ChildRemoved { child_id } => {
-                    debug!("Child removed: {}", child_id);
-                    // Future: Clean up child connections if needed
+                TopologyEvent::PeerRemoved { linked_peer_id } => {
+                    debug!("Linked peer removed: {}", linked_peer_id);
+                    // Future: Clean up linked peer connections if needed
                 }
             }
         }

--- a/hive-mesh/src/topology/mod.rs
+++ b/hive-mesh/src/topology/mod.rs
@@ -7,6 +7,6 @@ mod builder;
 mod manager;
 mod selection;
 
-pub use builder::{ParentInfo, TopologyBuilder, TopologyConfig, TopologyEvent, TopologyState};
+pub use builder::{SelectedPeer, TopologyBuilder, TopologyConfig, TopologyEvent, TopologyState};
 pub use manager::TopologyManager;
-pub use selection::{ParentCandidate, ParentSelector, SelectionConfig};
+pub use selection::{PeerCandidate, PeerSelector, SelectionConfig};

--- a/hive-mesh/src/topology/selection.rs
+++ b/hive-mesh/src/topology/selection.rs
@@ -1,18 +1,18 @@
-//! Parent selection algorithm for topology formation
+//! Peer selection algorithm for topology formation
 //!
-//! This module implements the logic for evaluating and selecting parent nodes
+//! This module implements the logic for evaluating and selecting peers
 //! based on node profiles, resources, geographic proximity, and hierarchy levels.
 
 use crate::beacon::{GeoPosition, GeographicBeacon, HierarchyLevel, NodeMobility};
 
-/// Candidate parent with selection score
+/// Candidate peer with selection score
 #[derive(Debug, Clone)]
-pub struct ParentCandidate {
+pub struct PeerCandidate {
     pub beacon: GeographicBeacon,
     pub score: f64,
 }
 
-/// Parent selection configuration
+/// Peer selection configuration
 #[derive(Debug, Clone)]
 pub struct SelectionConfig {
     /// Weight for mobility factor (0.0-1.0)
@@ -25,7 +25,7 @@ pub struct SelectionConfig {
     pub proximity_weight: f64,
     /// Maximum distance in meters (None = unlimited)
     pub max_distance_meters: Option<f64>,
-    /// Maximum number of children per parent (None = unlimited)
+    /// Maximum number of linked peers per node (None = unlimited)
     pub max_children_per_parent: Option<usize>,
 }
 
@@ -68,15 +68,15 @@ impl SelectionConfig {
     }
 }
 
-/// Parent selection algorithm
-pub struct ParentSelector {
+/// Peer selection algorithm
+pub struct PeerSelector {
     config: SelectionConfig,
     own_position: GeoPosition,
     own_level: HierarchyLevel,
 }
 
-impl ParentSelector {
-    /// Create a new parent selector
+impl PeerSelector {
+    /// Create a new peer selector
     pub fn new(
         config: SelectionConfig,
         own_position: GeoPosition,
@@ -89,14 +89,14 @@ impl ParentSelector {
         }
     }
 
-    /// Select the best parent from nearby beacons
+    /// Select the best peer from nearby beacons
     ///
-    /// Returns None if no suitable parent found
-    pub fn select_parent(&self, candidates: &[GeographicBeacon]) -> Option<ParentCandidate> {
-        let mut scored: Vec<ParentCandidate> = candidates
+    /// Returns None if no suitable peer found
+    pub fn select_peer(&self, candidates: &[GeographicBeacon]) -> Option<PeerCandidate> {
+        let mut scored: Vec<PeerCandidate> = candidates
             .iter()
-            .filter(|beacon| self.is_valid_parent(beacon))
-            .map(|beacon| ParentCandidate {
+            .filter(|beacon| self.is_valid_peer(beacon))
+            .map(|beacon| PeerCandidate {
                 beacon: beacon.clone(),
                 score: self.score_candidate(beacon),
             })
@@ -108,8 +108,8 @@ impl ParentSelector {
         scored.into_iter().next()
     }
 
-    /// Check if a beacon is a valid parent candidate
-    fn is_valid_parent(&self, beacon: &GeographicBeacon) -> bool {
+    /// Check if a beacon is a valid peer candidate
+    fn is_valid_peer(&self, beacon: &GeographicBeacon) -> bool {
         // Must be at least one level higher in hierarchy
         if !beacon.hierarchy_level.can_be_parent_of(&self.own_level) {
             return false;
@@ -123,7 +123,7 @@ impl ParentSelector {
             }
         }
 
-        // Check if node can be a parent
+        // Check if node can accept linked peers
         if !beacon.can_parent {
             return false;
         }
@@ -131,7 +131,7 @@ impl ParentSelector {
         true
     }
 
-    /// Score a candidate parent (higher is better)
+    /// Score a candidate peer (higher is better)
     fn score_candidate(&self, beacon: &GeographicBeacon) -> f64 {
         let mut score = 0.0;
 
@@ -216,14 +216,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_select_best_parent_prefers_static_nodes() {
-        let selector = ParentSelector::new(
+    fn test_select_best_peer_prefers_static_nodes() {
+        let selector = PeerSelector::new(
             SelectionConfig::default(),
             GeoPosition::new(37.7749, -122.4194),
             HierarchyLevel::Squad,
         );
 
-        let static_parent = create_test_beacon(
+        let static_peer = create_test_beacon(
             "static",
             GeoPosition::new(37.7750, -122.4195),
             HierarchyLevel::Platoon,
@@ -231,7 +231,7 @@ mod tests {
             50, // 50% resource usage
         );
 
-        let mobile_parent = create_test_beacon(
+        let mobile_peer = create_test_beacon(
             "mobile",
             GeoPosition::new(37.7751, -122.4196),
             HierarchyLevel::Platoon,
@@ -239,7 +239,7 @@ mod tests {
             30, // 30% resource usage (better resources)
         );
 
-        let result = selector.select_parent(&[static_parent, mobile_parent]);
+        let result = selector.select_peer(&[static_peer, mobile_peer]);
 
         assert!(result.is_some());
         let winner = result.unwrap();
@@ -247,15 +247,15 @@ mod tests {
     }
 
     #[test]
-    fn test_select_parent_respects_hierarchy() {
-        let selector = ParentSelector::new(
+    fn test_select_peer_respects_hierarchy() {
+        let selector = PeerSelector::new(
             SelectionConfig::default(),
             GeoPosition::new(37.7749, -122.4194),
             HierarchyLevel::Squad,
         );
 
-        // Platoon can be parent of Squad  (Platoon > Squad in hierarchy)
-        let valid_parent = create_test_beacon(
+        // Platoon can be selected peer of Squad  (Platoon > Squad in hierarchy)
+        let valid_peer = create_test_beacon(
             "valid",
             GeoPosition::new(37.7750, -122.4195),
             HierarchyLevel::Platoon,
@@ -263,8 +263,8 @@ mod tests {
             50,
         );
 
-        // Platform cannot be parent of Squad (Platform < Squad in hierarchy)
-        let invalid_parent = create_test_beacon(
+        // Platform cannot be selected peer of Squad (Platform < Squad in hierarchy)
+        let invalid_peer = create_test_beacon(
             "invalid",
             GeoPosition::new(37.7751, -122.4196),
             HierarchyLevel::Platform,
@@ -272,7 +272,7 @@ mod tests {
             30,
         );
 
-        let result = selector.select_parent(&[valid_parent.clone(), invalid_parent]);
+        let result = selector.select_peer(&[valid_peer.clone(), invalid_peer]);
 
         assert!(result.is_some());
         let winner = result.unwrap();
@@ -280,8 +280,8 @@ mod tests {
     }
 
     #[test]
-    fn test_select_parent_prefers_closer_nodes() {
-        let selector = ParentSelector::new(
+    fn test_select_peer_prefers_closer_nodes() {
+        let selector = PeerSelector::new(
             SelectionConfig {
                 proximity_weight: 0.9, // Heavy weight on proximity
                 mobility_weight: 0.1,
@@ -309,7 +309,7 @@ mod tests {
             30,
         );
 
-        let result = selector.select_parent(&[nearby, far]);
+        let result = selector.select_peer(&[nearby, far]);
 
         assert!(result.is_some());
         let winner = result.unwrap();
@@ -317,8 +317,8 @@ mod tests {
     }
 
     #[test]
-    fn test_select_parent_respects_distance_limit() {
-        let selector = ParentSelector::new(
+    fn test_select_peer_respects_distance_limit() {
+        let selector = PeerSelector::new(
             SelectionConfig {
                 max_distance_meters: Some(1_000.0), // 1km limit
                 ..Default::default()
@@ -335,13 +335,13 @@ mod tests {
             30,
         );
 
-        let result = selector.select_parent(&[too_far]);
+        let result = selector.select_peer(&[too_far]);
         assert!(result.is_none());
     }
 
     #[test]
-    fn test_select_parent_prefers_better_resources() {
-        let selector = ParentSelector::new(
+    fn test_select_peer_prefers_better_resources() {
+        let selector = PeerSelector::new(
             SelectionConfig {
                 resource_weight: 0.9, // Heavy weight on resources
                 mobility_weight: 0.1,
@@ -369,7 +369,7 @@ mod tests {
             20, // 20% resource usage
         );
 
-        let result = selector.select_parent(&[low_resources, high_resources]);
+        let result = selector.select_peer(&[low_resources, high_resources]);
 
         assert!(result.is_some());
         let winner = result.unwrap();


### PR DESCRIPTION
## Summary

This PR addresses Week 6 (Connection Maintenance) of Issue #122 by fixing a critical bug and refactoring to standard P2P terminology.

## Changes

### 1. Bug Fix: PeerLost Event Emission ✅

**Problem**: PeerLost events were never emitted when peer beacons timed out, leaving TopologyManager with stale connections.

**Fix**: Modified `check_peer_status()` in `builder.rs:249-276` to:
- Accept `event_tx` parameter
- Clone peer_id before clearing state  
- Emit `PeerLost` event on timeout

**Impact**: TopologyManager now properly handles peer failover and connection cleanup.

### 2. P2P Terminology Refactoring ✅

**Motivation**: Hierarchical nomenclature (parent/child, upstream/downstream) conflicted with P2P transport layer and standard distributed systems terminology.

**Changes**: 200+ instances across 5 files:
- `ParentInfo/UpstreamPeer` → `SelectedPeer`
- `ParentCandidate` → `PeerCandidate`
- `ParentSelector` → `PeerSelector`
- `children/downstream_peers` → `linked_peers`
- Events: `ParentSelected` → `PeerSelected`, etc.
- Config: `parent_timeout` → `peer_timeout`
- Functions: `get_parent()` → `get_selected_peer()`

**Impact**: Aligns with standard P2P systems (BitTorrent, Kademlia, libp2p).

### 3. Documentation: ADR-023 ✅

Added **ADR-023: Peer Discovery Architecture** documenting:
- Multi-tier approach: Beacon-based (local/tactical) + DHT (future/global)
- Why beacons for tactical: Geographic proximity, low latency
- When DHT makes sense: Wide-area, cross-region coordination
- How they coexist: Local-first with optional global fallback

## Test Results

✅ All 31 hive-mesh tests passing  
✅ All pre-commit checks passing (format, clippy, tests)  
✅ No functional changes - pure bug fix + naming refactor

## Files Changed

- `hive-mesh/src/lib.rs`
- `hive-mesh/src/topology/mod.rs`
- `hive-mesh/src/topology/builder.rs` (bug fix + refactor + clippy suppress)
- `hive-mesh/src/topology/manager.rs`
- `hive-mesh/src/topology/selection.rs`
- `docs/adr/023-peer-discovery-architecture.md` (new)

## Related

- Closes partial work on #122 (Phase 3: Topology Management - Week 6: Connection Maintenance)
- Relates to ADR-017 (P2P Mesh Management)