### PR TITLE
feat: Implement encryption and audit logging (#163)

### DIFF
--- a/hive-protocol/Cargo.toml
+++ b/hive-protocol/Cargo.toml
@@ -33,6 +33,10 @@ sha2 = "0.10"
 rand_core = { version = "0.6", features = ["getrandom"] }
 argon2 = "0.5"  # Password hashing (Phase 3: User Auth)
 hmac = "0.12"   # TOTP implementation (Phase 3: User Auth)
+# Encryption (Phase 4: Encryption & Audit)
+chacha20poly1305 = "0.10"  # AEAD encryption (ChaCha20-Poly1305)
+x25519-dalek = { version = "2", features = ["static_secrets"] }  # X25519 key exchange
+hkdf = "0.12"              # HKDF key derivation
 
 # CRDT Backends (E8 Evaluation - ADR-007)
 automerge = { version = "0.7.1", optional = true }  # Automerge CRDT library for evaluation
@@ -42,13 +46,13 @@ iroh = { version = "0.95", optional = true }  # QUIC-based P2P networking
 rocksdb = { version = "0.22", optional = true }  # Persistent storage
 lru = { version = "0.12", optional = true }  # LRU cache for hot documents
 toml = { version = "0.8", optional = true }  # Static peer configuration
-hex = { version = "0.4", optional = true }  # Hex encoding for PublicKeys
+hex = "0.4"  # Hex encoding for PublicKeys and encryption keys
 mdns-sd = { version = "0.11", optional = true }  # mDNS service discovery (ADR-011 Phase 3)
 rand = { version = "0.9", optional = true }  # Random number generation for retry jitter
 
 [features]
 default = []
-automerge-backend = ["automerge", "iroh", "rocksdb", "lru", "toml", "hex", "mdns-sd", "rand"]
+automerge-backend = ["automerge", "iroh", "rocksdb", "lru", "toml", "mdns-sd", "rand"]
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/hive-protocol/src/security/audit.rs
+++ b/hive-protocol/src/security/audit.rs
@@ -1,0 +1,877 @@
+//! # Audit Logging Module - Security Event Tracking for HIVE Protocol
+//!
+//! Implements ADR-006 Layer 7: Audit Logging.
+//!
+//! ## Overview
+//!
+//! Provides comprehensive logging of all security-relevant events for forensics
+//! and compliance with NIST SP 800-53 AU (Audit) controls.
+//!
+//! ## Event Types
+//!
+//! - **Authentication**: Device/user authentication attempts
+//! - **Authorization**: Permission grants and denials
+//! - **DataAccess**: Read/write operations on sensitive data
+//! - **CellFormation**: Cell join/leave/formation events
+//! - **KeyExchange**: Cryptographic key operations
+//! - **SecurityViolation**: Detected security anomalies
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_protocol::security::{AuditLogger, FileAuditLogger, AuditEventType};
+//!
+//! // Create file-based audit logger
+//! let logger = FileAuditLogger::new("/var/log/hive/audit.log")?;
+//!
+//! // Log authentication event
+//! logger.log_authentication(
+//!     "device:abc123",
+//!     true,
+//!     Some("challenge-response verified"),
+//! );
+//!
+//! // Log authorization denial
+//! logger.log_denial(
+//!     "device:abc123",
+//!     "SetCellLeader",
+//!     "cell:squad-1",
+//!     "role=Member, required=Leader",
+//! );
+//! ```
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use super::authorization::Permission;
+use super::error::SecurityError;
+
+/// Audit event types for categorization
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditEventType {
+    /// Device or user authentication attempt
+    Authentication,
+    /// Authorization check (permission grant/denial)
+    Authorization,
+    /// Data access operation (read)
+    DataAccess,
+    /// Data modification operation (write)
+    DataModification,
+    /// Cryptographic key exchange
+    KeyExchange,
+    /// Cell formation or membership change
+    CellFormation,
+    /// Leader election or change
+    LeaderElection,
+    /// Detected security violation
+    SecurityViolation,
+    /// Session management (create/expire/invalidate)
+    SessionManagement,
+    /// Encryption operation
+    Encryption,
+}
+
+impl std::fmt::Display for AuditEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuditEventType::Authentication => write!(f, "AUTHENTICATION"),
+            AuditEventType::Authorization => write!(f, "AUTHORIZATION"),
+            AuditEventType::DataAccess => write!(f, "DATA_ACCESS"),
+            AuditEventType::DataModification => write!(f, "DATA_MODIFICATION"),
+            AuditEventType::KeyExchange => write!(f, "KEY_EXCHANGE"),
+            AuditEventType::CellFormation => write!(f, "CELL_FORMATION"),
+            AuditEventType::LeaderElection => write!(f, "LEADER_ELECTION"),
+            AuditEventType::SecurityViolation => write!(f, "SECURITY_VIOLATION"),
+            AuditEventType::SessionManagement => write!(f, "SESSION_MANAGEMENT"),
+            AuditEventType::Encryption => write!(f, "ENCRYPTION"),
+        }
+    }
+}
+
+/// Security violation types
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecurityViolation {
+    /// Invalid signature detected
+    InvalidSignature,
+    /// Replay attack detected
+    ReplayAttack,
+    /// Unauthorized access attempt
+    UnauthorizedAccess,
+    /// Certificate validation failed
+    CertificateError,
+    /// Tampered message detected
+    TamperedMessage,
+    /// Rate limit exceeded
+    RateLimitExceeded,
+    /// Unknown device attempted join
+    UnknownDevice,
+    /// Expired credentials used
+    ExpiredCredentials,
+    /// Protocol violation
+    ProtocolViolation,
+}
+
+impl std::fmt::Display for SecurityViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SecurityViolation::InvalidSignature => write!(f, "INVALID_SIGNATURE"),
+            SecurityViolation::ReplayAttack => write!(f, "REPLAY_ATTACK"),
+            SecurityViolation::UnauthorizedAccess => write!(f, "UNAUTHORIZED_ACCESS"),
+            SecurityViolation::CertificateError => write!(f, "CERTIFICATE_ERROR"),
+            SecurityViolation::TamperedMessage => write!(f, "TAMPERED_MESSAGE"),
+            SecurityViolation::RateLimitExceeded => write!(f, "RATE_LIMIT_EXCEEDED"),
+            SecurityViolation::UnknownDevice => write!(f, "UNKNOWN_DEVICE"),
+            SecurityViolation::ExpiredCredentials => write!(f, "EXPIRED_CREDENTIALS"),
+            SecurityViolation::ProtocolViolation => write!(f, "PROTOCOL_VIOLATION"),
+        }
+    }
+}
+
+/// Audit log entry (JSON-serializable)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditLogEntry {
+    /// Unix timestamp (seconds since epoch)
+    pub timestamp: u64,
+    /// ISO 8601 formatted timestamp for readability
+    pub timestamp_iso: String,
+    /// Event type category
+    pub event_type: AuditEventType,
+    /// Entity performing the action (device ID or user ID)
+    pub entity_id: String,
+    /// Whether the action succeeded
+    pub success: bool,
+    /// Human-readable description
+    pub description: String,
+    /// Additional context (key-value pairs)
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub context: HashMap<String, String>,
+    /// Sequence number for ordering
+    pub sequence: u64,
+}
+
+impl AuditLogEntry {
+    /// Create new audit log entry
+    pub fn new(
+        event_type: AuditEventType,
+        entity_id: impl Into<String>,
+        success: bool,
+        description: impl Into<String>,
+        sequence: u64,
+    ) -> Self {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+
+        Self {
+            timestamp: now,
+            timestamp_iso: format_timestamp(now),
+            event_type,
+            entity_id: entity_id.into(),
+            success,
+            description: description.into(),
+            context: HashMap::new(),
+            sequence,
+        }
+    }
+
+    /// Add context key-value pair
+    pub fn with_context(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.context.insert(key.into(), value.into());
+        self
+    }
+
+    /// Serialize to JSON line
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_else(|_| {
+            format!(
+                "{{\"error\":\"serialization failed for seq {}\"}}",
+                self.sequence
+            )
+        })
+    }
+}
+
+/// Format Unix timestamp as ISO 8601
+fn format_timestamp(secs: u64) -> String {
+    // Simple ISO 8601 format without external dependencies
+    let dt = chrono::DateTime::from_timestamp(secs as i64, 0)
+        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
+    dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()
+}
+
+/// Audit logger trait for security event tracking
+pub trait AuditLogger: Send + Sync {
+    /// Log authentication event
+    fn log_authentication(&self, entity_id: &str, success: bool, reason: Option<&str>);
+
+    /// Log authorization grant
+    fn log_grant(&self, entity_id: &str, permission: Permission, target: &str);
+
+    /// Log authorization denial
+    fn log_denial(&self, entity_id: &str, permission: &str, target: &str, reason: &str);
+
+    /// Log data operation
+    fn log_operation(&self, entity_id: &str, operation: &str, target: &str, success: bool);
+
+    /// Log security violation
+    fn log_violation(&self, entity_id: &str, violation: SecurityViolation, details: &str);
+
+    /// Log cell formation event
+    fn log_cell_event(&self, entity_id: &str, cell_id: &str, action: &str, success: bool);
+
+    /// Log key exchange event
+    fn log_key_exchange(&self, entity_id: &str, peer_id: &str, success: bool);
+
+    /// Log session event (create, expire, invalidate)
+    fn log_session(&self, entity_id: &str, session_id: &str, action: &str, success: bool);
+
+    /// Log encryption event
+    fn log_encryption(&self, entity_id: &str, operation: &str, target: &str, success: bool);
+
+    /// Get the number of entries logged
+    fn entry_count(&self) -> u64;
+
+    /// Flush any buffered entries
+    fn flush(&self) -> Result<(), SecurityError>;
+}
+
+/// In-memory audit logger (for testing)
+#[derive(Debug)]
+pub struct MemoryAuditLogger {
+    entries: Arc<Mutex<Vec<AuditLogEntry>>>,
+    sequence: Arc<Mutex<u64>>,
+}
+
+impl MemoryAuditLogger {
+    /// Create new in-memory logger
+    pub fn new() -> Self {
+        Self {
+            entries: Arc::new(Mutex::new(Vec::new())),
+            sequence: Arc::new(Mutex::new(0)),
+        }
+    }
+
+    /// Get all logged entries
+    pub fn entries(&self) -> Vec<AuditLogEntry> {
+        self.entries.lock().unwrap().clone()
+    }
+
+    /// Get entries filtered by event type
+    pub fn entries_by_type(&self, event_type: AuditEventType) -> Vec<AuditLogEntry> {
+        self.entries
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|e| e.event_type == event_type)
+            .cloned()
+            .collect()
+    }
+
+    /// Clear all entries
+    pub fn clear(&self) {
+        self.entries.lock().unwrap().clear();
+    }
+
+    fn next_sequence(&self) -> u64 {
+        let mut seq = self.sequence.lock().unwrap();
+        *seq += 1;
+        *seq
+    }
+
+    fn add_entry(&self, entry: AuditLogEntry) {
+        self.entries.lock().unwrap().push(entry);
+    }
+}
+
+impl Default for MemoryAuditLogger {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AuditLogger for MemoryAuditLogger {
+    fn log_authentication(&self, entity_id: &str, success: bool, reason: Option<&str>) {
+        let description = match (success, reason) {
+            (true, Some(r)) => format!("Authentication succeeded: {}", r),
+            (true, None) => "Authentication succeeded".to_string(),
+            (false, Some(r)) => format!("Authentication failed: {}", r),
+            (false, None) => "Authentication failed".to_string(),
+        };
+
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authentication,
+            entity_id,
+            success,
+            description,
+            self.next_sequence(),
+        );
+        self.add_entry(entry);
+    }
+
+    fn log_grant(&self, entity_id: &str, permission: Permission, target: &str) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authorization,
+            entity_id,
+            true,
+            format!("Permission granted: {:?}", permission),
+            self.next_sequence(),
+        )
+        .with_context("permission", format!("{:?}", permission))
+        .with_context("target", target);
+        self.add_entry(entry);
+    }
+
+    fn log_denial(&self, entity_id: &str, permission: &str, target: &str, reason: &str) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authorization,
+            entity_id,
+            false,
+            format!("Permission denied: {} - {}", permission, reason),
+            self.next_sequence(),
+        )
+        .with_context("permission", permission)
+        .with_context("target", target)
+        .with_context("reason", reason);
+        self.add_entry(entry);
+    }
+
+    fn log_operation(&self, entity_id: &str, operation: &str, target: &str, success: bool) {
+        let event_type = if operation.starts_with("read")
+            || operation.starts_with("get")
+            || operation.starts_with("query")
+        {
+            AuditEventType::DataAccess
+        } else {
+            AuditEventType::DataModification
+        };
+
+        let entry = AuditLogEntry::new(
+            event_type,
+            entity_id,
+            success,
+            format!("{} on {}", operation, target),
+            self.next_sequence(),
+        )
+        .with_context("operation", operation)
+        .with_context("target", target);
+        self.add_entry(entry);
+    }
+
+    fn log_violation(&self, entity_id: &str, violation: SecurityViolation, details: &str) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::SecurityViolation,
+            entity_id,
+            false,
+            format!("Security violation: {} - {}", violation, details),
+            self.next_sequence(),
+        )
+        .with_context("violation_type", violation.to_string())
+        .with_context("details", details);
+        self.add_entry(entry);
+    }
+
+    fn log_cell_event(&self, entity_id: &str, cell_id: &str, action: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::CellFormation,
+            entity_id,
+            success,
+            format!("Cell {}: {}", action, cell_id),
+            self.next_sequence(),
+        )
+        .with_context("cell_id", cell_id)
+        .with_context("action", action);
+        self.add_entry(entry);
+    }
+
+    fn log_key_exchange(&self, entity_id: &str, peer_id: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::KeyExchange,
+            entity_id,
+            success,
+            format!("Key exchange with peer: {}", peer_id),
+            self.next_sequence(),
+        )
+        .with_context("peer_id", peer_id);
+        self.add_entry(entry);
+    }
+
+    fn log_session(&self, entity_id: &str, session_id: &str, action: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::SessionManagement,
+            entity_id,
+            success,
+            format!("Session {}: {}", action, session_id),
+            self.next_sequence(),
+        )
+        .with_context("session_id", session_id)
+        .with_context("action", action);
+        self.add_entry(entry);
+    }
+
+    fn log_encryption(&self, entity_id: &str, operation: &str, target: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Encryption,
+            entity_id,
+            success,
+            format!("Encryption {}: {}", operation, target),
+            self.next_sequence(),
+        )
+        .with_context("operation", operation)
+        .with_context("target", target);
+        self.add_entry(entry);
+    }
+
+    fn entry_count(&self) -> u64 {
+        self.entries.lock().unwrap().len() as u64
+    }
+
+    fn flush(&self) -> Result<(), SecurityError> {
+        Ok(()) // In-memory, nothing to flush
+    }
+}
+
+/// File-based audit logger (append-only for tamper resistance)
+pub struct FileAuditLogger {
+    writer: Arc<Mutex<BufWriter<File>>>,
+    sequence: Arc<Mutex<u64>>,
+    path: String,
+}
+
+impl FileAuditLogger {
+    /// Create new file-based audit logger
+    ///
+    /// The file is opened in append mode for tamper resistance.
+    pub fn new<P: AsRef<Path>>(path: P) -> Result<Self, SecurityError> {
+        let path_str = path.as_ref().to_string_lossy().to_string();
+
+        let file = OpenOptions::new().create(true).append(true).open(&path)?;
+
+        Ok(Self {
+            writer: Arc::new(Mutex::new(BufWriter::new(file))),
+            sequence: Arc::new(Mutex::new(0)),
+            path: path_str,
+        })
+    }
+
+    /// Get the log file path
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn next_sequence(&self) -> u64 {
+        let mut seq = self.sequence.lock().unwrap();
+        *seq += 1;
+        *seq
+    }
+
+    fn write_entry(&self, entry: &AuditLogEntry) {
+        let json = entry.to_json();
+        if let Ok(mut writer) = self.writer.lock() {
+            let _ = writeln!(writer, "{}", json);
+            // Flush after each entry for durability
+            let _ = writer.flush();
+        }
+    }
+}
+
+impl std::fmt::Debug for FileAuditLogger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileAuditLogger")
+            .field("path", &self.path)
+            .field("sequence", &self.sequence)
+            .finish()
+    }
+}
+
+impl AuditLogger for FileAuditLogger {
+    fn log_authentication(&self, entity_id: &str, success: bool, reason: Option<&str>) {
+        let description = match (success, reason) {
+            (true, Some(r)) => format!("Authentication succeeded: {}", r),
+            (true, None) => "Authentication succeeded".to_string(),
+            (false, Some(r)) => format!("Authentication failed: {}", r),
+            (false, None) => "Authentication failed".to_string(),
+        };
+
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authentication,
+            entity_id,
+            success,
+            description,
+            self.next_sequence(),
+        );
+        self.write_entry(&entry);
+    }
+
+    fn log_grant(&self, entity_id: &str, permission: Permission, target: &str) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authorization,
+            entity_id,
+            true,
+            format!("Permission granted: {:?}", permission),
+            self.next_sequence(),
+        )
+        .with_context("permission", format!("{:?}", permission))
+        .with_context("target", target);
+        self.write_entry(&entry);
+    }
+
+    fn log_denial(&self, entity_id: &str, permission: &str, target: &str, reason: &str) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authorization,
+            entity_id,
+            false,
+            format!("Permission denied: {} - {}", permission, reason),
+            self.next_sequence(),
+        )
+        .with_context("permission", permission)
+        .with_context("target", target)
+        .with_context("reason", reason);
+        self.write_entry(&entry);
+    }
+
+    fn log_operation(&self, entity_id: &str, operation: &str, target: &str, success: bool) {
+        let event_type = if operation.starts_with("read")
+            || operation.starts_with("get")
+            || operation.starts_with("query")
+        {
+            AuditEventType::DataAccess
+        } else {
+            AuditEventType::DataModification
+        };
+
+        let entry = AuditLogEntry::new(
+            event_type,
+            entity_id,
+            success,
+            format!("{} on {}", operation, target),
+            self.next_sequence(),
+        )
+        .with_context("operation", operation)
+        .with_context("target", target);
+        self.write_entry(&entry);
+    }
+
+    fn log_violation(&self, entity_id: &str, violation: SecurityViolation, details: &str) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::SecurityViolation,
+            entity_id,
+            false,
+            format!("Security violation: {} - {}", violation, details),
+            self.next_sequence(),
+        )
+        .with_context("violation_type", violation.to_string())
+        .with_context("details", details);
+        self.write_entry(&entry);
+    }
+
+    fn log_cell_event(&self, entity_id: &str, cell_id: &str, action: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::CellFormation,
+            entity_id,
+            success,
+            format!("Cell {}: {}", action, cell_id),
+            self.next_sequence(),
+        )
+        .with_context("cell_id", cell_id)
+        .with_context("action", action);
+        self.write_entry(&entry);
+    }
+
+    fn log_key_exchange(&self, entity_id: &str, peer_id: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::KeyExchange,
+            entity_id,
+            success,
+            format!("Key exchange with peer: {}", peer_id),
+            self.next_sequence(),
+        )
+        .with_context("peer_id", peer_id);
+        self.write_entry(&entry);
+    }
+
+    fn log_session(&self, entity_id: &str, session_id: &str, action: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::SessionManagement,
+            entity_id,
+            success,
+            format!("Session {}: {}", action, session_id),
+            self.next_sequence(),
+        )
+        .with_context("session_id", session_id)
+        .with_context("action", action);
+        self.write_entry(&entry);
+    }
+
+    fn log_encryption(&self, entity_id: &str, operation: &str, target: &str, success: bool) {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Encryption,
+            entity_id,
+            success,
+            format!("Encryption {}: {}", operation, target),
+            self.next_sequence(),
+        )
+        .with_context("operation", operation)
+        .with_context("target", target);
+        self.write_entry(&entry);
+    }
+
+    fn entry_count(&self) -> u64 {
+        *self.sequence.lock().unwrap()
+    }
+
+    fn flush(&self) -> Result<(), SecurityError> {
+        self.writer
+            .lock()
+            .map_err(|e| SecurityError::Internal(e.to_string()))?
+            .flush()?;
+        Ok(())
+    }
+}
+
+/// No-op audit logger (for testing/disabled logging)
+#[derive(Debug, Default)]
+pub struct NullAuditLogger;
+
+impl NullAuditLogger {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl AuditLogger for NullAuditLogger {
+    fn log_authentication(&self, _entity_id: &str, _success: bool, _reason: Option<&str>) {}
+    fn log_grant(&self, _entity_id: &str, _permission: Permission, _target: &str) {}
+    fn log_denial(&self, _entity_id: &str, _permission: &str, _target: &str, _reason: &str) {}
+    fn log_operation(&self, _entity_id: &str, _operation: &str, _target: &str, _success: bool) {}
+    fn log_violation(&self, _entity_id: &str, _violation: SecurityViolation, _details: &str) {}
+    fn log_cell_event(&self, _entity_id: &str, _cell_id: &str, _action: &str, _success: bool) {}
+    fn log_key_exchange(&self, _entity_id: &str, _peer_id: &str, _success: bool) {}
+    fn log_session(&self, _entity_id: &str, _session_id: &str, _action: &str, _success: bool) {}
+    fn log_encryption(&self, _entity_id: &str, _operation: &str, _target: &str, _success: bool) {}
+    fn entry_count(&self) -> u64 {
+        0
+    }
+    fn flush(&self) -> Result<(), SecurityError> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_audit_entry_creation() {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authentication,
+            "device:abc123",
+            true,
+            "Test entry",
+            1,
+        );
+
+        assert_eq!(entry.entity_id, "device:abc123");
+        assert!(entry.success);
+        assert_eq!(entry.event_type, AuditEventType::Authentication);
+        assert_eq!(entry.sequence, 1);
+        assert!(entry.timestamp > 0);
+    }
+
+    #[test]
+    fn test_audit_entry_with_context() {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authorization,
+            "device:abc123",
+            false,
+            "Access denied",
+            1,
+        )
+        .with_context("permission", "SetCellLeader")
+        .with_context("cell_id", "cell-1");
+
+        assert_eq!(entry.context.get("permission").unwrap(), "SetCellLeader");
+        assert_eq!(entry.context.get("cell_id").unwrap(), "cell-1");
+    }
+
+    #[test]
+    fn test_audit_entry_json_serialization() {
+        let entry = AuditLogEntry::new(
+            AuditEventType::Authentication,
+            "device:abc123",
+            true,
+            "Login successful",
+            42,
+        );
+
+        let json = entry.to_json();
+        assert!(json.contains("\"entity_id\":\"device:abc123\""));
+        assert!(json.contains("\"success\":true"));
+        assert!(json.contains("\"sequence\":42"));
+    }
+
+    #[test]
+    fn test_memory_audit_logger() {
+        let logger = MemoryAuditLogger::new();
+
+        logger.log_authentication("device:abc", true, Some("verified"));
+        logger.log_denial("device:abc", "SetLeader", "cell-1", "not authorized");
+        logger.log_operation("device:abc", "store_cell", "cell-1", true);
+
+        assert_eq!(logger.entry_count(), 3);
+
+        let auth_entries = logger.entries_by_type(AuditEventType::Authentication);
+        assert_eq!(auth_entries.len(), 1);
+        assert!(auth_entries[0].success);
+
+        let authz_entries = logger.entries_by_type(AuditEventType::Authorization);
+        assert_eq!(authz_entries.len(), 1);
+        assert!(!authz_entries[0].success);
+    }
+
+    #[test]
+    fn test_memory_logger_all_event_types() {
+        let logger = MemoryAuditLogger::new();
+
+        logger.log_authentication("dev1", true, None);
+        logger.log_grant("dev1", Permission::JoinCell, "cell-1");
+        logger.log_denial("dev1", "SetLeader", "cell-1", "not leader");
+        logger.log_operation("dev1", "read_cell", "cell-1", true);
+        logger.log_operation("dev1", "store_cell", "cell-1", true);
+        logger.log_violation("dev2", SecurityViolation::InvalidSignature, "bad sig");
+        logger.log_cell_event("dev1", "cell-1", "join", true);
+        logger.log_key_exchange("dev1", "dev2", true);
+        logger.log_session("user1", "sess-1", "create", true);
+        logger.log_encryption("dev1", "encrypt_for_cell", "cell-1", true);
+
+        assert_eq!(logger.entry_count(), 10);
+
+        // Verify each event type is logged
+        assert_eq!(
+            logger.entries_by_type(AuditEventType::Authentication).len(),
+            1
+        );
+        assert_eq!(
+            logger.entries_by_type(AuditEventType::Authorization).len(),
+            2
+        );
+        assert_eq!(logger.entries_by_type(AuditEventType::DataAccess).len(), 1);
+        assert_eq!(
+            logger
+                .entries_by_type(AuditEventType::DataModification)
+                .len(),
+            1
+        );
+        assert_eq!(
+            logger
+                .entries_by_type(AuditEventType::SecurityViolation)
+                .len(),
+            1
+        );
+        assert_eq!(
+            logger.entries_by_type(AuditEventType::CellFormation).len(),
+            1
+        );
+        assert_eq!(logger.entries_by_type(AuditEventType::KeyExchange).len(), 1);
+        assert_eq!(
+            logger
+                .entries_by_type(AuditEventType::SessionManagement)
+                .len(),
+            1
+        );
+        assert_eq!(logger.entries_by_type(AuditEventType::Encryption).len(), 1);
+    }
+
+    #[test]
+    fn test_file_audit_logger() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let log_path = temp_dir.path().join("audit.log");
+
+        let logger = FileAuditLogger::new(&log_path).unwrap();
+        logger.log_authentication("device:test", true, Some("test auth"));
+        logger.log_denial("device:test", "TestPerm", "target", "testing");
+        logger.flush().unwrap();
+
+        // Read and verify log file
+        let contents = std::fs::read_to_string(&log_path).unwrap();
+        let lines: Vec<&str> = contents.lines().collect();
+        assert_eq!(lines.len(), 2);
+
+        // Parse first line as JSON
+        let entry: AuditLogEntry = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(entry.entity_id, "device:test");
+        assert!(entry.success);
+    }
+
+    #[test]
+    fn test_null_audit_logger() {
+        let logger = NullAuditLogger::new();
+
+        // All operations should be no-ops
+        logger.log_authentication("test", true, None);
+        logger.log_denial("test", "perm", "target", "reason");
+
+        assert_eq!(logger.entry_count(), 0);
+        assert!(logger.flush().is_ok());
+    }
+
+    #[test]
+    fn test_security_violation_types() {
+        let violations = vec![
+            SecurityViolation::InvalidSignature,
+            SecurityViolation::ReplayAttack,
+            SecurityViolation::UnauthorizedAccess,
+            SecurityViolation::CertificateError,
+            SecurityViolation::TamperedMessage,
+            SecurityViolation::RateLimitExceeded,
+            SecurityViolation::UnknownDevice,
+            SecurityViolation::ExpiredCredentials,
+            SecurityViolation::ProtocolViolation,
+        ];
+
+        let logger = MemoryAuditLogger::new();
+        for violation in violations {
+            logger.log_violation("test", violation, "test details");
+        }
+
+        assert_eq!(logger.entry_count(), 9);
+    }
+
+    #[test]
+    fn test_audit_entry_sequence_ordering() {
+        let logger = MemoryAuditLogger::new();
+
+        for i in 0..10 {
+            logger.log_authentication(&format!("dev{}", i), true, None);
+        }
+
+        let entries = logger.entries();
+        for (i, entry) in entries.iter().enumerate() {
+            assert_eq!(entry.sequence, (i + 1) as u64);
+        }
+    }
+
+    #[test]
+    fn test_event_type_display() {
+        assert_eq!(
+            format!("{}", AuditEventType::Authentication),
+            "AUTHENTICATION"
+        );
+        assert_eq!(
+            format!("{}", AuditEventType::Authorization),
+            "AUTHORIZATION"
+        );
+        assert_eq!(
+            format!("{}", AuditEventType::SecurityViolation),
+            "SECURITY_VIOLATION"
+        );
+    }
+}

--- a/hive-protocol/src/security/encryption.rs
+++ b/hive-protocol/src/security/encryption.rs
@@ -1,0 +1,928 @@
+//! # Encryption Module - Data Encryption for HIVE Protocol
+//!
+//! Implements ADR-006 Layer 5: Data Encryption.
+//!
+//! ## Overview
+//!
+//! Provides encryption for all data in transit and at rest using:
+//! - **ChaCha20-Poly1305**: AEAD symmetric encryption
+//! - **X25519**: Diffie-Hellman key exchange
+//! - **HKDF-SHA256**: Key derivation
+//!
+//! ## Encryption Layers
+//!
+//! | Layer | Scope | Key Type |
+//! |-------|-------|----------|
+//! | Transport | Peer-to-peer connections | Session keys (DH) |
+//! | Storage | At-rest documents | Device key |
+//! | Cell Broadcast | Cell-wide messages | Group key |
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_protocol::security::{EncryptionManager, EncryptionKeypair};
+//!
+//! // Create encryption manager for this device
+//! let keypair = EncryptionKeypair::generate();
+//! let mut manager = EncryptionManager::new(keypair);
+//!
+//! // Establish secure channel with peer
+//! let channel = manager.establish_channel(&peer_id, &peer_public_key)?;
+//!
+//! // Encrypt message for peer
+//! let ciphertext = channel.encrypt(b"secret message")?;
+//!
+//! // Decrypt message from peer
+//! let plaintext = channel.decrypt(&ciphertext)?;
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use chacha20poly1305::{
+    aead::{Aead, AeadCore, KeyInit, OsRng},
+    ChaCha20Poly1305, Key, Nonce,
+};
+use hkdf::Hkdf;
+use sha2::Sha256;
+use tokio::sync::RwLock;
+use x25519_dalek::{PublicKey, SharedSecret, StaticSecret};
+
+use super::error::SecurityError;
+use super::DeviceId;
+
+/// Size of encryption nonce in bytes (96 bits for ChaCha20-Poly1305)
+pub const NONCE_SIZE: usize = 12;
+
+/// Size of symmetric key in bytes (256 bits)
+pub const SYMMETRIC_KEY_SIZE: usize = 32;
+
+/// Size of X25519 public key in bytes
+pub const X25519_PUBLIC_KEY_SIZE: usize = 32;
+
+/// HKDF info string for peer-to-peer key derivation
+const HKDF_INFO_PEER: &[u8] = b"hive-protocol-v1-peer";
+
+/// HKDF info string for group key derivation (reserved for future key distribution)
+#[allow(dead_code)]
+const HKDF_INFO_GROUP: &[u8] = b"hive-protocol-v1-group";
+
+/// X25519 keypair for key exchange
+#[derive(Clone)]
+pub struct EncryptionKeypair {
+    /// Secret key (kept private)
+    secret: Arc<StaticSecret>,
+    /// Public key (shared with peers)
+    public: PublicKey,
+}
+
+impl EncryptionKeypair {
+    /// Generate a new random keypair
+    pub fn generate() -> Self {
+        let secret = StaticSecret::random_from_rng(OsRng);
+        let public = PublicKey::from(&secret);
+        Self {
+            secret: Arc::new(secret),
+            public,
+        }
+    }
+
+    /// Create from existing secret key bytes
+    pub fn from_secret_bytes(bytes: &[u8; 32]) -> Self {
+        let secret = StaticSecret::from(*bytes);
+        let public = PublicKey::from(&secret);
+        Self {
+            secret: Arc::new(secret),
+            public,
+        }
+    }
+
+    /// Get the public key
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public
+    }
+
+    /// Get public key bytes
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.public.to_bytes()
+    }
+
+    /// Perform Diffie-Hellman key exchange
+    pub fn dh_exchange(&self, peer_public: &PublicKey) -> SharedSecret {
+        self.secret.diffie_hellman(peer_public)
+    }
+}
+
+impl std::fmt::Debug for EncryptionKeypair {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionKeypair")
+            .field("public", &hex::encode(self.public.as_bytes()))
+            .field("secret", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Symmetric key for encryption/decryption
+#[derive(Clone)]
+pub struct SymmetricKey {
+    key: Key,
+}
+
+impl SymmetricKey {
+    /// Create from raw bytes
+    pub fn from_bytes(bytes: &[u8; SYMMETRIC_KEY_SIZE]) -> Self {
+        Self {
+            key: *Key::from_slice(bytes),
+        }
+    }
+
+    /// Derive symmetric key from shared secret using HKDF
+    pub fn derive_from_shared_secret(shared_secret: &SharedSecret, info: &[u8]) -> Self {
+        let hk = Hkdf::<Sha256>::new(None, shared_secret.as_bytes());
+        let mut key_bytes = [0u8; SYMMETRIC_KEY_SIZE];
+        hk.expand(info, &mut key_bytes)
+            .expect("HKDF expand should never fail with correct output length");
+        Self::from_bytes(&key_bytes)
+    }
+
+    /// Derive key for peer-to-peer encryption
+    pub fn derive_for_peer(shared_secret: &SharedSecret) -> Self {
+        Self::derive_from_shared_secret(shared_secret, HKDF_INFO_PEER)
+    }
+
+    /// Get raw key bytes
+    pub fn as_bytes(&self) -> &[u8; SYMMETRIC_KEY_SIZE] {
+        // Key is guaranteed to be 32 bytes (256-bit)
+        self.key[..].try_into().unwrap()
+    }
+
+    /// Encrypt data with random nonce
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptedData, SecurityError> {
+        let cipher = ChaCha20Poly1305::new(&self.key);
+        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext)
+            .map_err(|e| SecurityError::EncryptionError(e.to_string()))?;
+
+        Ok(EncryptedData {
+            nonce: nonce.into(),
+            ciphertext,
+        })
+    }
+
+    /// Decrypt data
+    pub fn decrypt(&self, encrypted: &EncryptedData) -> Result<Vec<u8>, SecurityError> {
+        let cipher = ChaCha20Poly1305::new(&self.key);
+        let nonce = Nonce::from_slice(&encrypted.nonce);
+
+        cipher
+            .decrypt(nonce, encrypted.ciphertext.as_ref())
+            .map_err(|e| SecurityError::DecryptionError(e.to_string()))
+    }
+}
+
+impl std::fmt::Debug for SymmetricKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SymmetricKey")
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Encrypted data with nonce
+#[derive(Debug, Clone)]
+pub struct EncryptedData {
+    /// Nonce used for encryption
+    pub nonce: [u8; NONCE_SIZE],
+    /// Encrypted ciphertext (includes auth tag)
+    pub ciphertext: Vec<u8>,
+}
+
+impl EncryptedData {
+    /// Serialize to bytes (nonce || ciphertext)
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(NONCE_SIZE + self.ciphertext.len());
+        bytes.extend_from_slice(&self.nonce);
+        bytes.extend_from_slice(&self.ciphertext);
+        bytes
+    }
+
+    /// Deserialize from bytes
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SecurityError> {
+        if bytes.len() < NONCE_SIZE {
+            return Err(SecurityError::DecryptionError(
+                "ciphertext too short for nonce".to_string(),
+            ));
+        }
+
+        let mut nonce = [0u8; NONCE_SIZE];
+        nonce.copy_from_slice(&bytes[..NONCE_SIZE]);
+        let ciphertext = bytes[NONCE_SIZE..].to_vec();
+
+        Ok(Self { nonce, ciphertext })
+    }
+}
+
+/// Secure channel between two peers
+#[derive(Debug)]
+pub struct SecureChannel {
+    /// Peer identifier
+    pub peer_id: DeviceId,
+    /// Symmetric key for this channel
+    key: SymmetricKey,
+    /// When channel was established
+    pub established_at: SystemTime,
+}
+
+impl SecureChannel {
+    /// Create new secure channel
+    pub fn new(peer_id: DeviceId, key: SymmetricKey) -> Self {
+        Self {
+            peer_id,
+            key,
+            established_at: SystemTime::now(),
+        }
+    }
+
+    /// Encrypt message for peer
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptedData, SecurityError> {
+        self.key.encrypt(plaintext)
+    }
+
+    /// Decrypt message from peer
+    pub fn decrypt(&self, encrypted: &EncryptedData) -> Result<Vec<u8>, SecurityError> {
+        self.key.decrypt(encrypted)
+    }
+
+    /// Get channel age in seconds
+    pub fn age_secs(&self) -> u64 {
+        self.established_at
+            .elapsed()
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+}
+
+/// Group key for cell broadcast encryption
+#[derive(Clone)]
+pub struct GroupKey {
+    /// Cell ID this key is for
+    pub cell_id: String,
+    /// Symmetric key for the group
+    key: SymmetricKey,
+    /// Key generation/version number
+    pub generation: u64,
+    /// When key was created
+    pub created_at: SystemTime,
+}
+
+impl GroupKey {
+    /// Generate new random group key
+    pub fn generate(cell_id: String) -> Self {
+        let mut key_bytes = [0u8; SYMMETRIC_KEY_SIZE];
+        OsRng.fill_bytes(&mut key_bytes);
+        Self {
+            cell_id,
+            key: SymmetricKey::from_bytes(&key_bytes),
+            generation: 1,
+            created_at: SystemTime::now(),
+        }
+    }
+
+    /// Create from bytes with generation number
+    pub fn from_bytes(
+        cell_id: String,
+        key_bytes: &[u8; SYMMETRIC_KEY_SIZE],
+        generation: u64,
+    ) -> Self {
+        Self {
+            cell_id,
+            key: SymmetricKey::from_bytes(key_bytes),
+            generation,
+            created_at: SystemTime::now(),
+        }
+    }
+
+    /// Encrypt message for cell broadcast
+    pub fn encrypt(&self, plaintext: &[u8]) -> Result<EncryptedCellMessage, SecurityError> {
+        let encrypted = self.key.encrypt(plaintext)?;
+        Ok(EncryptedCellMessage {
+            cell_id: self.cell_id.clone(),
+            generation: self.generation,
+            encrypted,
+        })
+    }
+
+    /// Decrypt cell message
+    pub fn decrypt(&self, message: &EncryptedCellMessage) -> Result<Vec<u8>, SecurityError> {
+        if message.cell_id != self.cell_id {
+            return Err(SecurityError::DecryptionError(format!(
+                "cell ID mismatch: expected {}, got {}",
+                self.cell_id, message.cell_id
+            )));
+        }
+        if message.generation != self.generation {
+            return Err(SecurityError::DecryptionError(format!(
+                "key generation mismatch: expected {}, got {}",
+                self.generation, message.generation
+            )));
+        }
+        self.key.decrypt(&message.encrypted)
+    }
+
+    /// Rotate to new key generation
+    pub fn rotate(&self) -> Self {
+        let mut key_bytes = [0u8; SYMMETRIC_KEY_SIZE];
+        OsRng.fill_bytes(&mut key_bytes);
+        Self {
+            cell_id: self.cell_id.clone(),
+            key: SymmetricKey::from_bytes(&key_bytes),
+            generation: self.generation + 1,
+            created_at: SystemTime::now(),
+        }
+    }
+
+    /// Get key bytes for distribution
+    pub fn key_bytes(&self) -> [u8; SYMMETRIC_KEY_SIZE] {
+        *self.key.as_bytes()
+    }
+}
+
+impl std::fmt::Debug for GroupKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GroupKey")
+            .field("cell_id", &self.cell_id)
+            .field("generation", &self.generation)
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+/// Encrypted message for cell broadcast
+#[derive(Debug, Clone)]
+pub struct EncryptedCellMessage {
+    /// Cell this message is for
+    pub cell_id: String,
+    /// Key generation used
+    pub generation: u64,
+    /// Encrypted data
+    pub encrypted: EncryptedData,
+}
+
+impl EncryptedCellMessage {
+    /// Serialize to bytes
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let cell_id_bytes = self.cell_id.as_bytes();
+        let encrypted_bytes = self.encrypted.to_bytes();
+
+        let mut bytes = Vec::new();
+        // Format: cell_id_len (4 bytes) || cell_id || generation (8 bytes) || encrypted_data
+        bytes.extend_from_slice(&(cell_id_bytes.len() as u32).to_le_bytes());
+        bytes.extend_from_slice(cell_id_bytes);
+        bytes.extend_from_slice(&self.generation.to_le_bytes());
+        bytes.extend_from_slice(&encrypted_bytes);
+        bytes
+    }
+
+    /// Deserialize from bytes
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SecurityError> {
+        if bytes.len() < 12 {
+            return Err(SecurityError::DecryptionError(
+                "message too short".to_string(),
+            ));
+        }
+
+        let cell_id_len = u32::from_le_bytes(bytes[0..4].try_into().unwrap()) as usize;
+        if bytes.len() < 4 + cell_id_len + 8 {
+            return Err(SecurityError::DecryptionError(
+                "message truncated".to_string(),
+            ));
+        }
+
+        let cell_id = String::from_utf8(bytes[4..4 + cell_id_len].to_vec())
+            .map_err(|e| SecurityError::DecryptionError(e.to_string()))?;
+        let generation = u64::from_le_bytes(
+            bytes[4 + cell_id_len..4 + cell_id_len + 8]
+                .try_into()
+                .unwrap(),
+        );
+        let encrypted = EncryptedData::from_bytes(&bytes[4 + cell_id_len + 8..])?;
+
+        Ok(Self {
+            cell_id,
+            generation,
+            encrypted,
+        })
+    }
+}
+
+/// Encrypted document for at-rest storage
+#[derive(Debug, Clone)]
+pub struct EncryptedDocument {
+    /// Encrypted data
+    pub encrypted: EncryptedData,
+    /// Device ID that encrypted this document
+    pub encrypted_by: DeviceId,
+    /// Timestamp when encrypted
+    pub encrypted_at: u64,
+}
+
+impl EncryptedDocument {
+    /// Create from encrypted data
+    pub fn new(encrypted: EncryptedData, device_id: DeviceId) -> Self {
+        let encrypted_at = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Self {
+            encrypted,
+            encrypted_by: device_id,
+            encrypted_at,
+        }
+    }
+}
+
+/// Encryption manager for HIVE Protocol
+///
+/// Manages encryption keys and secure channels:
+/// - Peer-to-peer session keys via X25519 key exchange
+/// - Cell group keys for broadcast encryption
+/// - Device key for at-rest encryption
+pub struct EncryptionManager {
+    /// This device's keypair
+    keypair: EncryptionKeypair,
+    /// This device's ID (derived from signing keypair)
+    device_id: DeviceId,
+    /// Secure channels to peers
+    peer_channels: Arc<RwLock<HashMap<DeviceId, SecureChannel>>>,
+    /// Cell group keys
+    cell_keys: Arc<RwLock<HashMap<String, GroupKey>>>,
+    /// Device encryption key for at-rest
+    device_key: SymmetricKey,
+}
+
+impl EncryptionManager {
+    /// Create new encryption manager
+    pub fn new(keypair: EncryptionKeypair, device_id: DeviceId) -> Self {
+        // Derive device key from keypair public key
+        let hk = Hkdf::<Sha256>::new(None, keypair.public_key_bytes().as_ref());
+        let mut device_key_bytes = [0u8; SYMMETRIC_KEY_SIZE];
+        hk.expand(b"hive-protocol-v1-device", &mut device_key_bytes)
+            .expect("HKDF expand should never fail");
+
+        Self {
+            keypair,
+            device_id,
+            peer_channels: Arc::new(RwLock::new(HashMap::new())),
+            cell_keys: Arc::new(RwLock::new(HashMap::new())),
+            device_key: SymmetricKey::from_bytes(&device_key_bytes),
+        }
+    }
+
+    /// Get this device's public key
+    pub fn public_key(&self) -> &PublicKey {
+        self.keypair.public_key()
+    }
+
+    /// Get this device's public key bytes
+    pub fn public_key_bytes(&self) -> [u8; 32] {
+        self.keypair.public_key_bytes()
+    }
+
+    /// Establish secure channel with peer via X25519 key exchange
+    pub async fn establish_channel(
+        &self,
+        peer_id: DeviceId,
+        peer_public_key: &[u8; X25519_PUBLIC_KEY_SIZE],
+    ) -> Result<(), SecurityError> {
+        let peer_public = PublicKey::from(*peer_public_key);
+        let shared_secret = self.keypair.dh_exchange(&peer_public);
+        let symmetric_key = SymmetricKey::derive_for_peer(&shared_secret);
+
+        let channel = SecureChannel::new(peer_id, symmetric_key);
+        self.peer_channels.write().await.insert(peer_id, channel);
+
+        Ok(())
+    }
+
+    /// Get secure channel for peer
+    pub async fn get_channel(&self, peer_id: &DeviceId) -> Option<SecureChannel> {
+        let channels = self.peer_channels.read().await;
+        channels.get(peer_id).map(|c| SecureChannel {
+            peer_id: c.peer_id,
+            key: c.key.clone(),
+            established_at: c.established_at,
+        })
+    }
+
+    /// Check if channel exists for peer
+    pub async fn has_channel(&self, peer_id: &DeviceId) -> bool {
+        self.peer_channels.read().await.contains_key(peer_id)
+    }
+
+    /// Remove channel (peer disconnected)
+    pub async fn remove_channel(&self, peer_id: &DeviceId) {
+        self.peer_channels.write().await.remove(peer_id);
+    }
+
+    /// Encrypt message for specific peer
+    pub async fn encrypt_for_peer(
+        &self,
+        peer_id: &DeviceId,
+        plaintext: &[u8],
+    ) -> Result<EncryptedData, SecurityError> {
+        let channels = self.peer_channels.read().await;
+        let channel = channels.get(peer_id).ok_or_else(|| {
+            SecurityError::EncryptionError(format!("no channel for peer: {}", peer_id))
+        })?;
+        channel.encrypt(plaintext)
+    }
+
+    /// Decrypt message from peer
+    pub async fn decrypt_from_peer(
+        &self,
+        peer_id: &DeviceId,
+        encrypted: &EncryptedData,
+    ) -> Result<Vec<u8>, SecurityError> {
+        let channels = self.peer_channels.read().await;
+        let channel = channels.get(peer_id).ok_or_else(|| {
+            SecurityError::DecryptionError(format!("no channel for peer: {}", peer_id))
+        })?;
+        channel.decrypt(encrypted)
+    }
+
+    /// Create or get group key for cell
+    pub async fn get_or_create_cell_key(&self, cell_id: &str) -> GroupKey {
+        let mut keys = self.cell_keys.write().await;
+        if let Some(key) = keys.get(cell_id) {
+            key.clone()
+        } else {
+            let key = GroupKey::generate(cell_id.to_string());
+            keys.insert(cell_id.to_string(), key.clone());
+            key
+        }
+    }
+
+    /// Set cell key (received from leader)
+    pub async fn set_cell_key(&self, key: GroupKey) {
+        self.cell_keys
+            .write()
+            .await
+            .insert(key.cell_id.clone(), key);
+    }
+
+    /// Get cell key
+    pub async fn get_cell_key(&self, cell_id: &str) -> Option<GroupKey> {
+        self.cell_keys.read().await.get(cell_id).cloned()
+    }
+
+    /// Rotate cell key (when member leaves)
+    pub async fn rotate_cell_key(&self, cell_id: &str) -> Result<GroupKey, SecurityError> {
+        let mut keys = self.cell_keys.write().await;
+        let old_key = keys.get(cell_id).ok_or_else(|| {
+            SecurityError::EncryptionError(format!("no key for cell: {}", cell_id))
+        })?;
+        let new_key = old_key.rotate();
+        keys.insert(cell_id.to_string(), new_key.clone());
+        Ok(new_key)
+    }
+
+    /// Remove cell key (left cell)
+    pub async fn remove_cell_key(&self, cell_id: &str) {
+        self.cell_keys.write().await.remove(cell_id);
+    }
+
+    /// Encrypt message for cell broadcast
+    pub async fn encrypt_for_cell(
+        &self,
+        cell_id: &str,
+        plaintext: &[u8],
+    ) -> Result<EncryptedCellMessage, SecurityError> {
+        let keys = self.cell_keys.read().await;
+        let key = keys.get(cell_id).ok_or_else(|| {
+            SecurityError::EncryptionError(format!("no key for cell: {}", cell_id))
+        })?;
+        key.encrypt(plaintext)
+    }
+
+    /// Decrypt cell message
+    pub async fn decrypt_cell_message(
+        &self,
+        message: &EncryptedCellMessage,
+    ) -> Result<Vec<u8>, SecurityError> {
+        let keys = self.cell_keys.read().await;
+        let key = keys.get(&message.cell_id).ok_or_else(|| {
+            SecurityError::DecryptionError(format!("no key for cell: {}", message.cell_id))
+        })?;
+        key.decrypt(message)
+    }
+
+    /// Encrypt document for at-rest storage
+    pub fn encrypt_document(&self, plaintext: &[u8]) -> Result<EncryptedDocument, SecurityError> {
+        let encrypted = self.device_key.encrypt(plaintext)?;
+        Ok(EncryptedDocument::new(encrypted, self.device_id))
+    }
+
+    /// Decrypt document from storage
+    pub fn decrypt_document(&self, document: &EncryptedDocument) -> Result<Vec<u8>, SecurityError> {
+        if document.encrypted_by != self.device_id {
+            return Err(SecurityError::DecryptionError(
+                "document encrypted by different device".to_string(),
+            ));
+        }
+        self.device_key.decrypt(&document.encrypted)
+    }
+
+    /// Get number of active peer channels
+    pub async fn peer_channel_count(&self) -> usize {
+        self.peer_channels.read().await.len()
+    }
+
+    /// Get number of cell keys
+    pub async fn cell_key_count(&self) -> usize {
+        self.cell_keys.read().await.len()
+    }
+}
+
+impl std::fmt::Debug for EncryptionManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionManager")
+            .field("device_id", &self.device_id)
+            .field("public_key", &hex::encode(self.keypair.public_key_bytes()))
+            .finish()
+    }
+}
+
+use rand_core::RngCore;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keypair_generation() {
+        let kp1 = EncryptionKeypair::generate();
+        let kp2 = EncryptionKeypair::generate();
+
+        // Different keypairs should have different public keys
+        assert_ne!(kp1.public_key_bytes(), kp2.public_key_bytes());
+    }
+
+    #[test]
+    fn test_keypair_from_bytes() {
+        let kp1 = EncryptionKeypair::generate();
+        let secret_bytes = [42u8; 32]; // Fixed secret for testing
+        let kp2 = EncryptionKeypair::from_secret_bytes(&secret_bytes);
+        let kp3 = EncryptionKeypair::from_secret_bytes(&secret_bytes);
+
+        // Same secret should produce same public key
+        assert_eq!(kp2.public_key_bytes(), kp3.public_key_bytes());
+        // Different from random
+        assert_ne!(kp1.public_key_bytes(), kp2.public_key_bytes());
+    }
+
+    #[test]
+    fn test_dh_key_exchange() {
+        let alice = EncryptionKeypair::generate();
+        let bob = EncryptionKeypair::generate();
+
+        // Both parties derive the same shared secret
+        let alice_shared = alice.dh_exchange(bob.public_key());
+        let bob_shared = bob.dh_exchange(alice.public_key());
+
+        assert_eq!(alice_shared.as_bytes(), bob_shared.as_bytes());
+    }
+
+    #[test]
+    fn test_symmetric_key_encrypt_decrypt() {
+        let key = SymmetricKey::from_bytes(&[42u8; 32]);
+        let plaintext = b"Hello, World!";
+
+        let encrypted = key.encrypt(plaintext).unwrap();
+        let decrypted = key.decrypt(&encrypted).unwrap();
+
+        assert_eq!(plaintext.as_slice(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_symmetric_key_different_nonces() {
+        let key = SymmetricKey::from_bytes(&[42u8; 32]);
+        let plaintext = b"Hello, World!";
+
+        let encrypted1 = key.encrypt(plaintext).unwrap();
+        let encrypted2 = key.encrypt(plaintext).unwrap();
+
+        // Same plaintext, different nonces = different ciphertext
+        assert_ne!(encrypted1.nonce, encrypted2.nonce);
+        assert_ne!(encrypted1.ciphertext, encrypted2.ciphertext);
+
+        // Both decrypt correctly
+        assert_eq!(key.decrypt(&encrypted1).unwrap(), plaintext);
+        assert_eq!(key.decrypt(&encrypted2).unwrap(), plaintext);
+    }
+
+    #[test]
+    fn test_wrong_key_decryption_fails() {
+        let key1 = SymmetricKey::from_bytes(&[42u8; 32]);
+        let key2 = SymmetricKey::from_bytes(&[43u8; 32]);
+        let plaintext = b"Hello, World!";
+
+        let encrypted = key1.encrypt(plaintext).unwrap();
+        let result = key2.decrypt(&encrypted);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_encrypted_data_serialization() {
+        let key = SymmetricKey::from_bytes(&[42u8; 32]);
+        let plaintext = b"Hello, World!";
+
+        let encrypted = key.encrypt(plaintext).unwrap();
+        let bytes = encrypted.to_bytes();
+        let restored = EncryptedData::from_bytes(&bytes).unwrap();
+
+        assert_eq!(encrypted.nonce, restored.nonce);
+        assert_eq!(encrypted.ciphertext, restored.ciphertext);
+
+        let decrypted = key.decrypt(&restored).unwrap();
+        assert_eq!(plaintext.as_slice(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_secure_channel() {
+        let alice = EncryptionKeypair::generate();
+        let bob = EncryptionKeypair::generate();
+
+        // Derive shared keys
+        let alice_shared = alice.dh_exchange(bob.public_key());
+        let bob_shared = bob.dh_exchange(alice.public_key());
+
+        let alice_key = SymmetricKey::derive_for_peer(&alice_shared);
+        let bob_key = SymmetricKey::derive_for_peer(&bob_shared);
+
+        let alice_id = DeviceId::from_bytes([1u8; 16]);
+        let bob_id = DeviceId::from_bytes([2u8; 16]);
+
+        let alice_channel = SecureChannel::new(bob_id, alice_key);
+        let bob_channel = SecureChannel::new(alice_id, bob_key);
+
+        // Alice sends to Bob
+        let message = b"Secret message from Alice";
+        let encrypted = alice_channel.encrypt(message).unwrap();
+        let decrypted = bob_channel.decrypt(&encrypted).unwrap();
+
+        assert_eq!(message.as_slice(), decrypted.as_slice());
+
+        // Bob sends to Alice
+        let reply = b"Reply from Bob";
+        let encrypted_reply = bob_channel.encrypt(reply).unwrap();
+        let decrypted_reply = alice_channel.decrypt(&encrypted_reply).unwrap();
+
+        assert_eq!(reply.as_slice(), decrypted_reply.as_slice());
+    }
+
+    #[test]
+    fn test_group_key() {
+        let key = GroupKey::generate("cell-1".to_string());
+        let plaintext = b"Broadcast message";
+
+        let encrypted = key.encrypt(plaintext).unwrap();
+        let decrypted = key.decrypt(&encrypted).unwrap();
+
+        assert_eq!(plaintext.as_slice(), decrypted.as_slice());
+        assert_eq!(encrypted.cell_id, "cell-1");
+        assert_eq!(encrypted.generation, 1);
+    }
+
+    #[test]
+    fn test_group_key_rotation() {
+        let key1 = GroupKey::generate("cell-1".to_string());
+        let key2 = key1.rotate();
+
+        assert_eq!(key1.cell_id, key2.cell_id);
+        assert_eq!(key1.generation + 1, key2.generation);
+        assert_ne!(key1.key_bytes(), key2.key_bytes());
+
+        // Old key can't decrypt new messages
+        let message = b"New message";
+        let encrypted = key2.encrypt(message).unwrap();
+        assert!(key1.decrypt(&encrypted).is_err());
+
+        // New key can decrypt new messages
+        let decrypted = key2.decrypt(&encrypted).unwrap();
+        assert_eq!(message.as_slice(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_encrypted_cell_message_serialization() {
+        let key = GroupKey::generate("cell-1".to_string());
+        let plaintext = b"Cell broadcast";
+
+        let encrypted = key.encrypt(plaintext).unwrap();
+        let bytes = encrypted.to_bytes();
+        let restored = EncryptedCellMessage::from_bytes(&bytes).unwrap();
+
+        assert_eq!(encrypted.cell_id, restored.cell_id);
+        assert_eq!(encrypted.generation, restored.generation);
+
+        let decrypted = key.decrypt(&restored).unwrap();
+        assert_eq!(plaintext.as_slice(), decrypted.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_encryption_manager_peer_channels() {
+        let alice_kp = EncryptionKeypair::generate();
+        let bob_kp = EncryptionKeypair::generate();
+
+        let alice_id = DeviceId::from_bytes([1u8; 16]);
+        let bob_id = DeviceId::from_bytes([2u8; 16]);
+
+        let alice_mgr = EncryptionManager::new(alice_kp.clone(), alice_id);
+        let bob_mgr = EncryptionManager::new(bob_kp.clone(), bob_id);
+
+        // Establish channels
+        alice_mgr
+            .establish_channel(bob_id, &bob_mgr.public_key_bytes())
+            .await
+            .unwrap();
+        bob_mgr
+            .establish_channel(alice_id, &alice_mgr.public_key_bytes())
+            .await
+            .unwrap();
+
+        // Verify channels exist
+        assert!(alice_mgr.has_channel(&bob_id).await);
+        assert!(bob_mgr.has_channel(&alice_id).await);
+
+        // Alice sends to Bob
+        let message = b"Hello Bob!";
+        let encrypted = alice_mgr.encrypt_for_peer(&bob_id, message).await.unwrap();
+        let decrypted = bob_mgr
+            .decrypt_from_peer(&alice_id, &encrypted)
+            .await
+            .unwrap();
+
+        assert_eq!(message.as_slice(), decrypted.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_encryption_manager_cell_keys() {
+        let kp = EncryptionKeypair::generate();
+        let device_id = DeviceId::from_bytes([1u8; 16]);
+        let mgr = EncryptionManager::new(kp, device_id);
+
+        // Create cell key
+        let key = mgr.get_or_create_cell_key("cell-1").await;
+        assert_eq!(key.cell_id, "cell-1");
+        assert_eq!(key.generation, 1);
+
+        // Get same key
+        let key2 = mgr.get_or_create_cell_key("cell-1").await;
+        assert_eq!(key.generation, key2.generation);
+
+        // Encrypt for cell
+        let message = b"Cell message";
+        let encrypted = mgr.encrypt_for_cell("cell-1", message).await.unwrap();
+        let decrypted = mgr.decrypt_cell_message(&encrypted).await.unwrap();
+
+        assert_eq!(message.as_slice(), decrypted.as_slice());
+
+        // Rotate key
+        let new_key = mgr.rotate_cell_key("cell-1").await.unwrap();
+        assert_eq!(new_key.generation, 2);
+    }
+
+    #[test]
+    fn test_document_encryption() {
+        let kp = EncryptionKeypair::generate();
+        let device_id = DeviceId::from_bytes([1u8; 16]);
+        let mgr = EncryptionManager::new(kp, device_id);
+
+        let document = b"Sensitive document content";
+        let encrypted = mgr.encrypt_document(document).unwrap();
+        let decrypted = mgr.decrypt_document(&encrypted).unwrap();
+
+        assert_eq!(document.as_slice(), decrypted.as_slice());
+    }
+
+    #[test]
+    fn test_document_wrong_device_fails() {
+        let kp1 = EncryptionKeypair::generate();
+        let kp2 = EncryptionKeypair::generate();
+        let device_id1 = DeviceId::from_bytes([1u8; 16]);
+        let device_id2 = DeviceId::from_bytes([2u8; 16]);
+
+        let mgr1 = EncryptionManager::new(kp1, device_id1);
+        let mgr2 = EncryptionManager::new(kp2, device_id2);
+
+        let document = b"Sensitive document";
+        let encrypted = mgr1.encrypt_document(document).unwrap();
+
+        // Different device can't decrypt
+        let result = mgr2.decrypt_document(&encrypted);
+        assert!(result.is_err());
+    }
+}

--- a/hive-protocol/src/security/error.rs
+++ b/hive-protocol/src/security/error.rs
@@ -125,6 +125,27 @@ pub enum SecurityError {
     /// TOTP generation/verification error
     #[error("TOTP error: {message}")]
     TotpError { message: String },
+
+    // Encryption errors (Phase 4: Encryption & Audit)
+    /// Encryption operation failed
+    #[error("encryption error: {0}")]
+    EncryptionError(String),
+
+    /// Decryption operation failed
+    #[error("decryption error: {0}")]
+    DecryptionError(String),
+
+    /// Key exchange failed
+    #[error("key exchange error: {0}")]
+    KeyExchangeError(String),
+
+    /// No group key for cell
+    #[error("no group key for cell: {cell_id}")]
+    NoGroupKey { cell_id: String },
+
+    /// Key generation mismatch
+    #[error("key generation mismatch: expected {expected}, got {actual}")]
+    KeyGenerationMismatch { expected: u64, actual: u64 },
 }
 
 impl SecurityError {
@@ -161,6 +182,12 @@ impl SecurityError {
             SecurityError::UnsupportedAuthMethod { .. } => "UNSUPPORTED_AUTH",
             SecurityError::PasswordHashError { .. } => "PASSWORD_HASH_ERROR",
             SecurityError::TotpError { .. } => "TOTP_ERROR",
+            // Encryption errors
+            SecurityError::EncryptionError(_) => "ENCRYPTION_ERROR",
+            SecurityError::DecryptionError(_) => "DECRYPTION_ERROR",
+            SecurityError::KeyExchangeError(_) => "KEY_EXCHANGE_ERROR",
+            SecurityError::NoGroupKey { .. } => "NO_GROUP_KEY",
+            SecurityError::KeyGenerationMismatch { .. } => "KEY_GENERATION_MISMATCH",
         }
     }
 

--- a/hive-protocol/src/security/mod.rs
+++ b/hive-protocol/src/security/mod.rs
@@ -35,14 +35,20 @@
 //! let peer_id = authenticator.verify_response(&response)?;
 //! ```
 
+mod audit;
 mod authenticator;
 mod authorization;
 mod device_id;
+mod encryption;
 mod error;
 mod keypair;
 mod transport;
 mod user_auth;
 
+pub use audit::{
+    AuditEventType, AuditLogEntry, AuditLogger, FileAuditLogger, MemoryAuditLogger,
+    NullAuditLogger, SecurityViolation,
+};
 pub use authenticator::{DeviceAuthenticator, VerifiedPeer};
 pub use authorization::{
     AuthenticatedEntity, AuthorizationContext, AuthorizationController, AuthorizationPolicy,
@@ -50,6 +56,10 @@ pub use authorization::{
     UserIdentityInfo,
 };
 pub use device_id::DeviceId;
+pub use encryption::{
+    EncryptedCellMessage, EncryptedData, EncryptedDocument, EncryptionKeypair, EncryptionManager,
+    GroupKey, SecureChannel, SymmetricKey, NONCE_SIZE, SYMMETRIC_KEY_SIZE, X25519_PUBLIC_KEY_SIZE,
+};
 pub use error::SecurityError;
 pub use keypair::DeviceKeypair;
 pub use transport::{AuthenticatedConnection, AuthenticationChannel, SecureMeshTransport};


### PR DESCRIPTION
## Summary

Implements Layer 4 (Encryption & Audit) of the Security Framework (EPIC #106).

Note: Layers 1-3 were already merged via PRs #165, #166, #167.

### Encryption Module (`encryption.rs`)
- ChaCha20-Poly1305 authenticated encryption
- Diffie-Hellman key exchange
- Session key management

### Audit Module (`audit.rs`)
- Comprehensive security event logging
- Event types for all security operations
- Timestamped audit trail

## Test Results
- All unit tests pass
- All E2E tests pass

## Test plan
- [x] All unit tests pass
- [x] All E2E tests pass  
- [x] Pre-commit hooks pass
- [ ] CI passes

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)