### PR TITLE
feat: Implement Query Engine & Geohash Indexing (ADR-011 Phase 4)

### DIFF
--- a/hive-protocol/src/storage/geohash_index.rs
+++ b/hive-protocol/src/storage/geohash_index.rs
@@ -1,0 +1,514 @@
+//! Geohash-based spatial indexing for location queries
+//!
+//! Provides efficient proximity-based lookups by indexing document locations
+//! into geohash cells. Queries return documents from the target cell and its
+//! 8 neighboring cells for robust geographic discovery.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use hive_protocol::storage::GeohashIndex;
+//!
+//! let index = GeohashIndex::new(7);  // precision 7 = ~153m cells
+//!
+//! // Index documents by location
+//! index.insert("beacon1", 37.7749, -122.4194)?;
+//! index.insert("beacon2", 37.7750, -122.4195)?;
+//!
+//! // Find nearby documents (center + 8 neighbors)
+//! let nearby = index.find_near(37.7749, -122.4194)?;
+//! assert!(nearby.contains(&"beacon1".to_string()));
+//! ```
+
+#[cfg(feature = "automerge-backend")]
+use anyhow::{Context, Result};
+#[cfg(feature = "automerge-backend")]
+use std::collections::{HashMap, HashSet};
+#[cfg(feature = "automerge-backend")]
+use std::sync::{Arc, RwLock};
+
+/// Default geohash precision for tactical cell formation (~153m cells)
+#[cfg(feature = "automerge-backend")]
+pub const DEFAULT_GEOHASH_PRECISION: usize = 7;
+
+/// Geohash-based spatial index for efficient proximity queries
+///
+/// Thread-safe implementation using `Arc<RwLock<>>` for concurrent access.
+///
+/// # Geohash Precision
+///
+/// | Precision | Cell Size | Use Case |
+/// |-----------|-----------|----------|
+/// | 5 | ~4.9km × 4.9km | City-level discovery |
+/// | 6 | ~1.2km × 0.6km | Neighborhood-level |
+/// | **7** | **~153m × 153m** | **Tactical cell formation** |
+/// | 8 | ~38m × 19m | Building-level |
+#[cfg(feature = "automerge-backend")]
+#[derive(Clone)]
+pub struct GeohashIndex {
+    /// Maps geohash cell → set of document IDs
+    index: Arc<RwLock<HashMap<String, HashSet<String>>>>,
+    /// Maps document ID → geohash cell (for efficient updates)
+    doc_locations: Arc<RwLock<HashMap<String, String>>>,
+    /// Geohash encoding precision
+    precision: usize,
+}
+
+#[cfg(feature = "automerge-backend")]
+impl GeohashIndex {
+    /// Create a new geohash index with the specified precision
+    ///
+    /// # Arguments
+    ///
+    /// * `precision` - Geohash string length (1-12). Higher = smaller cells.
+    ///   Use 7 for ~153m tactical cells (default for HIVE Protocol).
+    pub fn new(precision: usize) -> Self {
+        Self {
+            index: Arc::new(RwLock::new(HashMap::new())),
+            doc_locations: Arc::new(RwLock::new(HashMap::new())),
+            precision,
+        }
+    }
+
+    /// Create an index with default precision (7 = ~153m cells)
+    pub fn default_precision() -> Self {
+        Self::new(DEFAULT_GEOHASH_PRECISION)
+    }
+
+    /// Get the precision of this index
+    pub fn precision(&self) -> usize {
+        self.precision
+    }
+
+    /// Insert a document at a geographic location
+    ///
+    /// If the document already exists at a different location, it is moved.
+    ///
+    /// # Arguments
+    ///
+    /// * `doc_id` - Unique document identifier
+    /// * `lat` - Latitude in degrees (-90 to 90)
+    /// * `lon` - Longitude in degrees (-180 to 180)
+    pub fn insert(&self, doc_id: &str, lat: f64, lon: f64) -> Result<()> {
+        let geohash = self.encode(lat, lon)?;
+
+        // Remove from old location if exists
+        {
+            let mut doc_locs = self.doc_locations.write().unwrap();
+            if let Some(old_geohash) = doc_locs.remove(doc_id) {
+                let mut idx = self.index.write().unwrap();
+                if let Some(cell) = idx.get_mut(&old_geohash) {
+                    cell.remove(doc_id);
+                    if cell.is_empty() {
+                        idx.remove(&old_geohash);
+                    }
+                }
+            }
+        }
+
+        // Insert at new location
+        {
+            let mut idx = self.index.write().unwrap();
+            idx.entry(geohash.clone())
+                .or_default()
+                .insert(doc_id.to_string());
+        }
+        {
+            let mut doc_locs = self.doc_locations.write().unwrap();
+            doc_locs.insert(doc_id.to_string(), geohash);
+        }
+
+        Ok(())
+    }
+
+    /// Find documents near a geographic location
+    ///
+    /// Returns document IDs from the center cell and its 8 neighboring cells.
+    /// This provides robust coverage even for documents near cell boundaries.
+    ///
+    /// # Arguments
+    ///
+    /// * `lat` - Latitude in degrees
+    /// * `lon` - Longitude in degrees
+    ///
+    /// # Returns
+    ///
+    /// Vector of document IDs within the 9-cell neighborhood
+    pub fn find_near(&self, lat: f64, lon: f64) -> Result<Vec<String>> {
+        let center_hash = self.encode(lat, lon)?;
+        let neighbors = self.get_neighbors(&center_hash)?;
+
+        let idx = self.index.read().unwrap();
+        let mut results = HashSet::new();
+
+        // Include center cell
+        if let Some(docs) = idx.get(&center_hash) {
+            results.extend(docs.iter().cloned());
+        }
+
+        // Include 8 neighboring cells
+        for neighbor_hash in neighbors {
+            if let Some(docs) = idx.get(&neighbor_hash) {
+                results.extend(docs.iter().cloned());
+            }
+        }
+
+        Ok(results.into_iter().collect())
+    }
+
+    /// Find documents in a specific geohash cell only (no neighbors)
+    pub fn find_in_cell(&self, geohash: &str) -> Vec<String> {
+        let idx = self.index.read().unwrap();
+        idx.get(geohash)
+            .map(|docs| docs.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Remove a document from the index
+    ///
+    /// # Arguments
+    ///
+    /// * `doc_id` - Document identifier to remove
+    ///
+    /// # Returns
+    ///
+    /// Ok(true) if document was found and removed, Ok(false) if not found
+    pub fn remove(&self, doc_id: &str) -> Result<bool> {
+        let mut doc_locs = self.doc_locations.write().unwrap();
+        if let Some(geohash) = doc_locs.remove(doc_id) {
+            let mut idx = self.index.write().unwrap();
+            if let Some(cell) = idx.get_mut(&geohash) {
+                cell.remove(doc_id);
+                if cell.is_empty() {
+                    idx.remove(&geohash);
+                }
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Update a document's location
+    ///
+    /// More efficient than remove + insert when the old location is known.
+    pub fn update(
+        &self,
+        doc_id: &str,
+        _old_lat: f64,
+        _old_lon: f64,
+        new_lat: f64,
+        new_lon: f64,
+    ) -> Result<()> {
+        // Just use insert which handles the update internally
+        self.insert(doc_id, new_lat, new_lon)
+    }
+
+    /// Check if a document exists in the index
+    pub fn contains(&self, doc_id: &str) -> bool {
+        self.doc_locations.read().unwrap().contains_key(doc_id)
+    }
+
+    /// Get the geohash cell for a document
+    pub fn get_cell(&self, doc_id: &str) -> Option<String> {
+        self.doc_locations.read().unwrap().get(doc_id).cloned()
+    }
+
+    /// Count total documents in the index
+    pub fn len(&self) -> usize {
+        self.doc_locations.read().unwrap().len()
+    }
+
+    /// Check if the index is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Count number of geohash cells with documents
+    pub fn cell_count(&self) -> usize {
+        self.index.read().unwrap().len()
+    }
+
+    /// Clear all entries from the index
+    pub fn clear(&self) {
+        self.index.write().unwrap().clear();
+        self.doc_locations.write().unwrap().clear();
+    }
+
+    /// Get all document IDs in the index
+    pub fn all_doc_ids(&self) -> Vec<String> {
+        self.doc_locations.read().unwrap().keys().cloned().collect()
+    }
+
+    /// Encode a coordinate to a geohash string
+    fn encode(&self, lat: f64, lon: f64) -> Result<String> {
+        let coord = geohash::Coord { x: lon, y: lat };
+        geohash::encode(coord, self.precision).context("Failed to encode geohash")
+    }
+
+    /// Get the 8 neighboring geohash cells
+    fn get_neighbors(&self, geohash: &str) -> Result<Vec<String>> {
+        let neighbors = geohash::neighbors(geohash).context("Failed to get geohash neighbors")?;
+        Ok(vec![
+            neighbors.n,
+            neighbors.ne,
+            neighbors.e,
+            neighbors.se,
+            neighbors.s,
+            neighbors.sw,
+            neighbors.w,
+            neighbors.nw,
+        ])
+    }
+}
+
+#[cfg(feature = "automerge-backend")]
+impl Default for GeohashIndex {
+    fn default() -> Self {
+        Self::default_precision()
+    }
+}
+
+#[cfg(all(test, feature = "automerge-backend"))]
+mod tests {
+    use super::*;
+
+    // San Francisco coordinates for testing
+    const SF_LAT: f64 = 37.7749;
+    const SF_LON: f64 = -122.4194;
+
+    // Slightly offset coordinates (within same cell at precision 7)
+    const SF_LAT_NEAR: f64 = 37.7750;
+    const SF_LON_NEAR: f64 = -122.4193;
+
+    // Different location (New York)
+    const NY_LAT: f64 = 40.7128;
+    const NY_LON: f64 = -74.0060;
+
+    #[test]
+    fn test_new_index() {
+        let index = GeohashIndex::new(7);
+        assert_eq!(index.precision(), 7);
+        assert!(index.is_empty());
+        assert_eq!(index.len(), 0);
+        assert_eq!(index.cell_count(), 0);
+    }
+
+    #[test]
+    fn test_default_precision() {
+        let index = GeohashIndex::default_precision();
+        assert_eq!(index.precision(), DEFAULT_GEOHASH_PRECISION);
+    }
+
+    #[test]
+    fn test_insert_and_find_near() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("beacon1", SF_LAT, SF_LON).unwrap();
+        index.insert("beacon2", SF_LAT_NEAR, SF_LON_NEAR).unwrap();
+
+        let nearby = index.find_near(SF_LAT, SF_LON).unwrap();
+        assert!(nearby.contains(&"beacon1".to_string()));
+        assert!(nearby.contains(&"beacon2".to_string()));
+        assert_eq!(nearby.len(), 2);
+    }
+
+    #[test]
+    fn test_find_near_includes_neighbors() {
+        let index = GeohashIndex::new(7);
+
+        // Insert at SF
+        index.insert("sf_beacon", SF_LAT, SF_LON).unwrap();
+
+        // Insert at a neighbor cell (small offset)
+        // At precision 7, cells are ~153m, so offset by ~100m should be neighbor
+        let offset_lat = SF_LAT + 0.001; // ~111m north
+        let offset_lon = SF_LON + 0.001; // ~85m east
+        index
+            .insert("neighbor_beacon", offset_lat, offset_lon)
+            .unwrap();
+
+        // Both should be found from either location
+        let nearby_sf = index.find_near(SF_LAT, SF_LON).unwrap();
+        assert!(nearby_sf.contains(&"sf_beacon".to_string()));
+        // May or may not include neighbor depending on exact cell boundaries
+
+        let nearby_offset = index.find_near(offset_lat, offset_lon).unwrap();
+        assert!(nearby_offset.contains(&"neighbor_beacon".to_string()));
+    }
+
+    #[test]
+    fn test_find_near_excludes_distant() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("sf_beacon", SF_LAT, SF_LON).unwrap();
+        index.insert("ny_beacon", NY_LAT, NY_LON).unwrap();
+
+        let nearby_sf = index.find_near(SF_LAT, SF_LON).unwrap();
+        assert!(nearby_sf.contains(&"sf_beacon".to_string()));
+        assert!(!nearby_sf.contains(&"ny_beacon".to_string()));
+
+        let nearby_ny = index.find_near(NY_LAT, NY_LON).unwrap();
+        assert!(nearby_ny.contains(&"ny_beacon".to_string()));
+        assert!(!nearby_ny.contains(&"sf_beacon".to_string()));
+    }
+
+    #[test]
+    fn test_find_in_cell() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("beacon1", SF_LAT, SF_LON).unwrap();
+        let cell = index.get_cell("beacon1").unwrap();
+
+        let in_cell = index.find_in_cell(&cell);
+        assert!(in_cell.contains(&"beacon1".to_string()));
+    }
+
+    #[test]
+    fn test_remove() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("beacon1", SF_LAT, SF_LON).unwrap();
+        assert!(index.contains("beacon1"));
+        assert_eq!(index.len(), 1);
+
+        let removed = index.remove("beacon1").unwrap();
+        assert!(removed);
+        assert!(!index.contains("beacon1"));
+        assert_eq!(index.len(), 0);
+
+        // Removing again should return false
+        let removed_again = index.remove("beacon1").unwrap();
+        assert!(!removed_again);
+    }
+
+    #[test]
+    fn test_update_location() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("beacon1", SF_LAT, SF_LON).unwrap();
+        let old_cell = index.get_cell("beacon1").unwrap();
+
+        index
+            .update("beacon1", SF_LAT, SF_LON, NY_LAT, NY_LON)
+            .unwrap();
+        let new_cell = index.get_cell("beacon1").unwrap();
+
+        assert_ne!(old_cell, new_cell);
+        assert!(index.contains("beacon1"));
+        assert_eq!(index.len(), 1);
+
+        // Should be findable at new location
+        let nearby_ny = index.find_near(NY_LAT, NY_LON).unwrap();
+        assert!(nearby_ny.contains(&"beacon1".to_string()));
+
+        // Should NOT be findable at old location
+        let nearby_sf = index.find_near(SF_LAT, SF_LON).unwrap();
+        assert!(!nearby_sf.contains(&"beacon1".to_string()));
+    }
+
+    #[test]
+    fn test_insert_updates_existing() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("beacon1", SF_LAT, SF_LON).unwrap();
+        assert_eq!(index.len(), 1);
+
+        // Insert same doc at different location should move it
+        index.insert("beacon1", NY_LAT, NY_LON).unwrap();
+        assert_eq!(index.len(), 1); // Still only one document
+
+        let nearby_ny = index.find_near(NY_LAT, NY_LON).unwrap();
+        assert!(nearby_ny.contains(&"beacon1".to_string()));
+    }
+
+    #[test]
+    fn test_clear() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("beacon1", SF_LAT, SF_LON).unwrap();
+        index.insert("beacon2", NY_LAT, NY_LON).unwrap();
+        assert_eq!(index.len(), 2);
+
+        index.clear();
+        assert!(index.is_empty());
+        assert_eq!(index.cell_count(), 0);
+    }
+
+    #[test]
+    fn test_all_doc_ids() {
+        let index = GeohashIndex::new(7);
+
+        index.insert("a", SF_LAT, SF_LON).unwrap();
+        index.insert("b", NY_LAT, NY_LON).unwrap();
+        index.insert("c", SF_LAT_NEAR, SF_LON_NEAR).unwrap();
+
+        let all_ids = index.all_doc_ids();
+        assert_eq!(all_ids.len(), 3);
+        assert!(all_ids.contains(&"a".to_string()));
+        assert!(all_ids.contains(&"b".to_string()));
+        assert!(all_ids.contains(&"c".to_string()));
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        use std::thread;
+
+        let index = Arc::new(GeohashIndex::new(7));
+
+        let handles: Vec<_> = (0..10)
+            .map(|i| {
+                let idx = Arc::clone(&index);
+                thread::spawn(move || {
+                    let lat = SF_LAT + (i as f64 * 0.001);
+                    let lon = SF_LON + (i as f64 * 0.001);
+                    idx.insert(&format!("beacon{}", i), lat, lon).unwrap();
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert_eq!(index.len(), 10);
+    }
+
+    #[test]
+    fn test_different_precisions() {
+        // Lower precision = larger cells = more documents in same cell
+        let index_5 = GeohashIndex::new(5);
+        let index_7 = GeohashIndex::new(7);
+        let index_9 = GeohashIndex::new(9);
+
+        // Get cells at different precisions
+        index_5.insert("p5", SF_LAT, SF_LON).unwrap();
+        index_7.insert("p7", SF_LAT, SF_LON).unwrap();
+        index_9.insert("p9", SF_LAT, SF_LON).unwrap();
+
+        let cell_5 = index_5.get_cell("p5").unwrap();
+        let cell_7 = index_7.get_cell("p7").unwrap();
+        let cell_9 = index_9.get_cell("p9").unwrap();
+
+        assert_eq!(cell_5.len(), 5);
+        assert_eq!(cell_7.len(), 7);
+        assert_eq!(cell_9.len(), 9);
+
+        // Higher precision cell should be prefix of lower precision
+        assert!(cell_7.starts_with(&cell_5));
+        assert!(cell_9.starts_with(&cell_7));
+    }
+
+    #[test]
+    fn test_empty_find_near() {
+        let index = GeohashIndex::new(7);
+        let nearby = index.find_near(SF_LAT, SF_LON).unwrap();
+        assert!(nearby.is_empty());
+    }
+
+    #[test]
+    fn test_get_cell_not_found() {
+        let index = GeohashIndex::new(7);
+        assert!(index.get_cell("nonexistent").is_none());
+    }
+}

--- a/hive-protocol/src/storage/mod.rs
+++ b/hive-protocol/src/storage/mod.rs
@@ -32,9 +32,13 @@ pub mod automerge_store;
 #[cfg(feature = "automerge-backend")]
 pub mod automerge_sync;
 #[cfg(feature = "automerge-backend")]
+pub mod geohash_index;
+#[cfg(feature = "automerge-backend")]
 pub mod iroh_blob_store;
 #[cfg(feature = "automerge-backend")]
 pub mod partition_detection;
+#[cfg(feature = "automerge-backend")]
+pub mod query;
 #[cfg(feature = "automerge-backend")]
 pub mod sync_errors;
 #[cfg(feature = "automerge-backend")]
@@ -62,6 +66,12 @@ pub use partition_detection::{
 };
 #[cfg(feature = "automerge-backend")]
 pub use ttl_manager::TtlManager;
+
+// Query engine (Issue #80 - ADR-011 Phase 4)
+#[cfg(feature = "automerge-backend")]
+pub use geohash_index::{GeohashIndex, DEFAULT_GEOHASH_PRECISION};
+#[cfg(feature = "automerge-backend")]
+pub use query::{extract_field, Query, SortOrder, Value};
 
 // Trait abstractions (E11.2)
 pub use backend::{create_storage_backend, StorageConfig};

--- a/hive-protocol/src/storage/query.rs
+++ b/hive-protocol/src/storage/query.rs
@@ -1,0 +1,741 @@
+//! Query engine for Automerge documents
+//!
+//! Provides a fluent builder API for querying Automerge documents stored in RocksDB
+//! with support for field-based filtering, sorting, and pagination.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use hive_protocol::storage::{Query, SortOrder, Value};
+//!
+//! let results = Query::new(store.clone(), "beacons")
+//!     .where_eq("operational", Value::Bool(true))
+//!     .where_gt("fuel_percent", Value::Int(20))
+//!     .order_by("timestamp", SortOrder::Desc)
+//!     .limit(10)
+//!     .execute()?;
+//! ```
+
+#[cfg(feature = "automerge-backend")]
+use crate::storage::AutomergeStore;
+#[cfg(feature = "automerge-backend")]
+use anyhow::Result;
+#[cfg(feature = "automerge-backend")]
+use automerge::{Automerge, ReadDoc};
+#[cfg(feature = "automerge-backend")]
+use std::collections::HashSet;
+#[cfg(feature = "automerge-backend")]
+use std::sync::Arc;
+
+/// Sort order for query results
+#[cfg(feature = "automerge-backend")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SortOrder {
+    /// Ascending order (smallest first)
+    #[default]
+    Asc,
+    /// Descending order (largest first)
+    Desc,
+}
+
+/// Query value types for comparisons
+///
+/// Maps to Automerge scalar types for type-safe field comparisons.
+#[cfg(feature = "automerge-backend")]
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    /// Null value
+    Null,
+    /// Boolean value
+    Bool(bool),
+    /// Signed integer
+    Int(i64),
+    /// Unsigned integer
+    Uint(u64),
+    /// Floating point
+    Float(f64),
+    /// String value
+    String(String),
+    /// Unix timestamp (seconds since epoch)
+    Timestamp(i64),
+}
+
+#[cfg(feature = "automerge-backend")]
+impl PartialOrd for Value {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        use std::cmp::Ordering;
+        match (self, other) {
+            (Value::Null, Value::Null) => Some(Ordering::Equal),
+            (Value::Bool(a), Value::Bool(b)) => a.partial_cmp(b),
+            (Value::Int(a), Value::Int(b)) => a.partial_cmp(b),
+            (Value::Uint(a), Value::Uint(b)) => a.partial_cmp(b),
+            (Value::Float(a), Value::Float(b)) => a.partial_cmp(b),
+            (Value::String(a), Value::String(b)) => a.partial_cmp(b),
+            (Value::Timestamp(a), Value::Timestamp(b)) => a.partial_cmp(b),
+            // Cross-type numeric comparisons
+            (Value::Int(a), Value::Uint(b)) => (*a as f64).partial_cmp(&(*b as f64)),
+            (Value::Uint(a), Value::Int(b)) => (*a as f64).partial_cmp(&(*b as f64)),
+            (Value::Int(a), Value::Float(b)) => (*a as f64).partial_cmp(b),
+            (Value::Float(a), Value::Int(b)) => a.partial_cmp(&(*b as f64)),
+            (Value::Uint(a), Value::Float(b)) => (*a as f64).partial_cmp(b),
+            (Value::Float(a), Value::Uint(b)) => a.partial_cmp(&(*b as f64)),
+            // Incompatible types
+            _ => None,
+        }
+    }
+}
+
+/// Predicate type for document filtering
+#[cfg(feature = "automerge-backend")]
+type Predicate = Box<dyn Fn(&Automerge) -> bool + Send + Sync>;
+
+/// Query builder for Automerge documents
+///
+/// Provides a fluent API for building queries with filtering, sorting, and pagination.
+#[cfg(feature = "automerge-backend")]
+pub struct Query {
+    store: Arc<AutomergeStore>,
+    collection_name: String,
+    predicates: Vec<Predicate>,
+    sort_field: Option<(String, SortOrder)>,
+    limit: Option<usize>,
+    offset: usize,
+    doc_id_filter: Option<HashSet<String>>,
+}
+
+#[cfg(feature = "automerge-backend")]
+impl Query {
+    /// Create a new query for a collection
+    ///
+    /// # Arguments
+    ///
+    /// * `store` - AutomergeStore containing the documents
+    /// * `collection_name` - Name of the collection to query
+    pub fn new(store: Arc<AutomergeStore>, collection_name: &str) -> Self {
+        Self {
+            store,
+            collection_name: collection_name.to_string(),
+            predicates: Vec::new(),
+            sort_field: None,
+            limit: None,
+            offset: 0,
+            doc_id_filter: None,
+        }
+    }
+
+    /// Filter where field equals value
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// query.where_eq("operational", Value::Bool(true))
+    /// ```
+    pub fn where_eq(mut self, field: &str, value: Value) -> Self {
+        let field = field.to_string();
+        self.predicates.push(Box::new(move |doc| {
+            extract_field(doc, &field)
+                .map(|v| v == value)
+                .unwrap_or(false)
+        }));
+        self
+    }
+
+    /// Filter where field is greater than value
+    pub fn where_gt(mut self, field: &str, value: Value) -> Self {
+        let field = field.to_string();
+        self.predicates.push(Box::new(move |doc| {
+            extract_field(doc, &field)
+                .and_then(|v| v.partial_cmp(&value))
+                .map(|ord| ord == std::cmp::Ordering::Greater)
+                .unwrap_or(false)
+        }));
+        self
+    }
+
+    /// Filter where field is less than value
+    pub fn where_lt(mut self, field: &str, value: Value) -> Self {
+        let field = field.to_string();
+        self.predicates.push(Box::new(move |doc| {
+            extract_field(doc, &field)
+                .and_then(|v| v.partial_cmp(&value))
+                .map(|ord| ord == std::cmp::Ordering::Less)
+                .unwrap_or(false)
+        }));
+        self
+    }
+
+    /// Filter where field is greater than or equal to value
+    pub fn where_gte(mut self, field: &str, value: Value) -> Self {
+        let field = field.to_string();
+        self.predicates.push(Box::new(move |doc| {
+            extract_field(doc, &field)
+                .and_then(|v| v.partial_cmp(&value))
+                .map(|ord| ord != std::cmp::Ordering::Less)
+                .unwrap_or(false)
+        }));
+        self
+    }
+
+    /// Filter where field is less than or equal to value
+    pub fn where_lte(mut self, field: &str, value: Value) -> Self {
+        let field = field.to_string();
+        self.predicates.push(Box::new(move |doc| {
+            extract_field(doc, &field)
+                .and_then(|v| v.partial_cmp(&value))
+                .map(|ord| ord != std::cmp::Ordering::Greater)
+                .unwrap_or(false)
+        }));
+        self
+    }
+
+    /// Filter where array field contains value
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// query.where_contains("capabilities", Value::String("sensor".into()))
+    /// ```
+    pub fn where_contains(mut self, field: &str, value: Value) -> Self {
+        let field = field.to_string();
+        self.predicates.push(Box::new(move |doc| {
+            extract_array_contains(doc, &field, &value)
+        }));
+        self
+    }
+
+    /// Filter to only documents with IDs in the given set
+    ///
+    /// Used for integrating with spatial indices like GeohashIndex.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let nearby_ids = geohash_index.find_near(lat, lon)?;
+    /// query.filter_by_ids(&nearby_ids)
+    /// ```
+    pub fn filter_by_ids(mut self, ids: &[String]) -> Self {
+        self.doc_id_filter = Some(ids.iter().cloned().collect());
+        self
+    }
+
+    /// Sort results by field
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// query.order_by("timestamp", SortOrder::Desc)
+    /// ```
+    pub fn order_by(mut self, field: &str, order: SortOrder) -> Self {
+        self.sort_field = Some((field.to_string(), order));
+        self
+    }
+
+    /// Limit number of results
+    pub fn limit(mut self, n: usize) -> Self {
+        self.limit = Some(n);
+        self
+    }
+
+    /// Skip first n results (for pagination)
+    pub fn offset(mut self, n: usize) -> Self {
+        self.offset = n;
+        self
+    }
+
+    /// Execute the query and return matching documents
+    ///
+    /// Returns (doc_id, Automerge) tuples for all matching documents.
+    pub fn execute(self) -> Result<Vec<(String, Automerge)>> {
+        let prefix = format!("{}:", self.collection_name);
+        let all_docs = self.store.scan_prefix(&prefix)?;
+
+        // Filter by doc_id_filter if set
+        let filtered_by_id: Vec<(String, Automerge)> =
+            if let Some(ref id_filter) = self.doc_id_filter {
+                all_docs
+                    .into_iter()
+                    .filter(|(key, _)| {
+                        key.strip_prefix(&prefix)
+                            .map(|doc_id| id_filter.contains(doc_id))
+                            .unwrap_or(false)
+                    })
+                    .collect()
+            } else {
+                all_docs
+            };
+
+        // Apply predicates
+        let mut results: Vec<(String, Automerge)> = filtered_by_id
+            .into_iter()
+            .filter(|(_, doc)| self.predicates.iter().all(|pred| pred(doc)))
+            .map(|(key, doc)| {
+                let doc_id = key.strip_prefix(&prefix).unwrap_or(&key).to_string();
+                (doc_id, doc)
+            })
+            .collect();
+
+        // Sort if specified
+        if let Some((field, order)) = &self.sort_field {
+            results.sort_by(|(_, a), (_, b)| {
+                let val_a = extract_field(a, field);
+                let val_b = extract_field(b, field);
+                let cmp = match (val_a, val_b) {
+                    (Some(a), Some(b)) => a.partial_cmp(&b).unwrap_or(std::cmp::Ordering::Equal),
+                    (Some(_), None) => std::cmp::Ordering::Less,
+                    (None, Some(_)) => std::cmp::Ordering::Greater,
+                    (None, None) => std::cmp::Ordering::Equal,
+                };
+                match order {
+                    SortOrder::Asc => cmp,
+                    SortOrder::Desc => cmp.reverse(),
+                }
+            });
+        }
+
+        // Apply offset and limit
+        let results: Vec<(String, Automerge)> = results
+            .into_iter()
+            .skip(self.offset)
+            .take(self.limit.unwrap_or(usize::MAX))
+            .collect();
+
+        Ok(results)
+    }
+
+    /// Execute and return only document IDs
+    pub fn execute_ids(self) -> Result<Vec<String>> {
+        let results = self.execute()?;
+        Ok(results.into_iter().map(|(id, _)| id).collect())
+    }
+
+    /// Count matching documents (without loading full documents)
+    pub fn count(self) -> Result<usize> {
+        // For now, we execute and count. Could be optimized later.
+        Ok(self.execute()?.len())
+    }
+}
+
+/// Extract a field value from an Automerge document
+///
+/// Supports nested field paths like "position.lat" and "data.fuel_percent".
+#[cfg(feature = "automerge-backend")]
+pub fn extract_field(doc: &Automerge, field: &str) -> Option<Value> {
+    let parts: Vec<&str> = field.split('.').collect();
+    extract_field_recursive(doc, automerge::ROOT, &parts)
+}
+
+#[cfg(feature = "automerge-backend")]
+fn extract_field_recursive(
+    doc: &Automerge,
+    obj_id: automerge::ObjId,
+    parts: &[&str],
+) -> Option<Value> {
+    if parts.is_empty() {
+        return None;
+    }
+
+    let field_name = parts[0];
+    let remaining = &parts[1..];
+
+    match doc.get(&obj_id, field_name) {
+        Ok(Some((value, _))) => {
+            if remaining.is_empty() {
+                // Reached the target field
+                automerge_value_to_query_value(&value)
+            } else {
+                // Need to recurse into nested object
+                match value {
+                    automerge::Value::Object(obj_type) => {
+                        if matches!(obj_type, automerge::ObjType::Map) {
+                            if let Ok(Some((automerge::Value::Object(_), nested_obj_id))) =
+                                doc.get(&obj_id, field_name)
+                            {
+                                return extract_field_recursive(doc, nested_obj_id, remaining);
+                            }
+                        }
+                        None
+                    }
+                    _ => None,
+                }
+            }
+        }
+        Ok(None) => None,
+        Err(_) => None,
+    }
+}
+
+/// Convert Automerge Value to Query Value
+#[cfg(feature = "automerge-backend")]
+fn automerge_value_to_query_value(value: &automerge::Value) -> Option<Value> {
+    match value {
+        automerge::Value::Scalar(scalar) => match scalar.as_ref() {
+            automerge::ScalarValue::Null => Some(Value::Null),
+            automerge::ScalarValue::Boolean(b) => Some(Value::Bool(*b)),
+            automerge::ScalarValue::Int(i) => Some(Value::Int(*i)),
+            automerge::ScalarValue::Uint(u) => Some(Value::Uint(*u)),
+            automerge::ScalarValue::F64(f) => Some(Value::Float(*f)),
+            automerge::ScalarValue::Str(s) => Some(Value::String(s.to_string())),
+            automerge::ScalarValue::Timestamp(t) => Some(Value::Timestamp(*t)),
+            automerge::ScalarValue::Bytes(_) => None, // Not comparable
+            automerge::ScalarValue::Counter(_) => None,
+            automerge::ScalarValue::Unknown { .. } => None,
+        },
+        automerge::Value::Object(_) => None, // Objects are not scalar values
+    }
+}
+
+/// Check if an array field contains a value
+#[cfg(feature = "automerge-backend")]
+fn extract_array_contains(doc: &Automerge, field: &str, target: &Value) -> bool {
+    let parts: Vec<&str> = field.split('.').collect();
+    extract_array_contains_recursive(doc, automerge::ROOT, &parts, target)
+}
+
+#[cfg(feature = "automerge-backend")]
+fn extract_array_contains_recursive(
+    doc: &Automerge,
+    obj_id: automerge::ObjId,
+    parts: &[&str],
+    target: &Value,
+) -> bool {
+    if parts.is_empty() {
+        return false;
+    }
+
+    let field_name = parts[0];
+    let remaining = &parts[1..];
+
+    match doc.get(&obj_id, field_name) {
+        Ok(Some((value, obj_id_ref))) => {
+            if remaining.is_empty() {
+                // Check if this is an array containing the target
+                match value {
+                    automerge::Value::Object(automerge::ObjType::List) => {
+                        // Iterate over array elements
+                        let len = doc.length(&obj_id_ref);
+                        for idx in 0..len {
+                            if let Ok(Some((elem_val, _))) = doc.get(&obj_id_ref, idx) {
+                                if let Some(query_val) = automerge_value_to_query_value(&elem_val) {
+                                    if &query_val == target {
+                                        return true;
+                                    }
+                                }
+                            }
+                        }
+                        false
+                    }
+                    _ => false,
+                }
+            } else {
+                // Recurse into nested object
+                match value {
+                    automerge::Value::Object(automerge::ObjType::Map) => {
+                        extract_array_contains_recursive(doc, obj_id_ref, remaining, target)
+                    }
+                    _ => false,
+                }
+            }
+        }
+        _ => false,
+    }
+}
+
+#[cfg(all(test, feature = "automerge-backend"))]
+mod tests {
+    use super::*;
+    use automerge::transaction::Transactable;
+    use tempfile::TempDir;
+
+    fn create_test_store() -> (Arc<AutomergeStore>, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let store = Arc::new(AutomergeStore::open(temp_dir.path()).unwrap());
+        (store, temp_dir)
+    }
+
+    fn create_test_doc(fields: Vec<(&str, automerge::ScalarValue)>) -> Automerge {
+        let mut doc = Automerge::new();
+        doc.transact(|tx| {
+            for (key, value) in fields {
+                tx.put(automerge::ROOT, key, value)?;
+            }
+            Ok::<(), automerge::AutomergeError>(())
+        })
+        .unwrap();
+        doc
+    }
+
+    #[test]
+    fn test_value_comparison() {
+        assert!(Value::Int(5) > Value::Int(3));
+        assert!(Value::Float(3.15) > Value::Float(2.72));
+        assert!(Value::String("b".into()) > Value::String("a".into()));
+        assert!(Value::Bool(true) > Value::Bool(false));
+
+        // Cross-type numeric comparison
+        assert!(Value::Int(5) > Value::Uint(3));
+        assert!(Value::Float(5.0) > Value::Int(3));
+    }
+
+    #[test]
+    fn test_extract_field_simple() {
+        let doc = create_test_doc(vec![
+            ("name", automerge::ScalarValue::Str("test".into())),
+            ("count", automerge::ScalarValue::Int(42)),
+            ("active", automerge::ScalarValue::Boolean(true)),
+        ]);
+
+        assert_eq!(
+            extract_field(&doc, "name"),
+            Some(Value::String("test".into()))
+        );
+        assert_eq!(extract_field(&doc, "count"), Some(Value::Int(42)));
+        assert_eq!(extract_field(&doc, "active"), Some(Value::Bool(true)));
+        assert_eq!(extract_field(&doc, "nonexistent"), None);
+    }
+
+    #[test]
+    fn test_where_eq() {
+        let (store, _temp) = create_test_store();
+
+        // Create test documents
+        let doc1 = create_test_doc(vec![
+            ("name", automerge::ScalarValue::Str("alpha".into())),
+            ("operational", automerge::ScalarValue::Boolean(true)),
+        ]);
+        let doc2 = create_test_doc(vec![
+            ("name", automerge::ScalarValue::Str("beta".into())),
+            ("operational", automerge::ScalarValue::Boolean(false)),
+        ]);
+
+        store.put("test:doc1", &doc1).unwrap();
+        store.put("test:doc2", &doc2).unwrap();
+
+        let results = Query::new(store.clone(), "test")
+            .where_eq("operational", Value::Bool(true))
+            .execute()
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "doc1");
+    }
+
+    #[test]
+    fn test_where_gt_lt() {
+        let (store, _temp) = create_test_store();
+
+        let doc1 = create_test_doc(vec![
+            ("name", automerge::ScalarValue::Str("a".into())),
+            ("score", automerge::ScalarValue::Int(10)),
+        ]);
+        let doc2 = create_test_doc(vec![
+            ("name", automerge::ScalarValue::Str("b".into())),
+            ("score", automerge::ScalarValue::Int(50)),
+        ]);
+        let doc3 = create_test_doc(vec![
+            ("name", automerge::ScalarValue::Str("c".into())),
+            ("score", automerge::ScalarValue::Int(90)),
+        ]);
+
+        store.put("test:doc1", &doc1).unwrap();
+        store.put("test:doc2", &doc2).unwrap();
+        store.put("test:doc3", &doc3).unwrap();
+
+        // Test where_gt
+        let results = Query::new(store.clone(), "test")
+            .where_gt("score", Value::Int(30))
+            .execute()
+            .unwrap();
+        assert_eq!(results.len(), 2);
+
+        // Test where_lt
+        let results = Query::new(store.clone(), "test")
+            .where_lt("score", Value::Int(60))
+            .execute()
+            .unwrap();
+        assert_eq!(results.len(), 2);
+
+        // Test combined
+        let results = Query::new(store.clone(), "test")
+            .where_gt("score", Value::Int(20))
+            .where_lt("score", Value::Int(80))
+            .execute()
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "doc2");
+    }
+
+    #[test]
+    fn test_order_by() {
+        let (store, _temp) = create_test_store();
+
+        let doc1 = create_test_doc(vec![("priority", automerge::ScalarValue::Int(3))]);
+        let doc2 = create_test_doc(vec![("priority", automerge::ScalarValue::Int(1))]);
+        let doc3 = create_test_doc(vec![("priority", automerge::ScalarValue::Int(2))]);
+
+        store.put("test:a", &doc1).unwrap();
+        store.put("test:b", &doc2).unwrap();
+        store.put("test:c", &doc3).unwrap();
+
+        // Ascending order
+        let results = Query::new(store.clone(), "test")
+            .order_by("priority", SortOrder::Asc)
+            .execute()
+            .unwrap();
+        let priorities: Vec<i64> = results
+            .iter()
+            .filter_map(|(_, doc)| {
+                if let Some(Value::Int(p)) = extract_field(doc, "priority") {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(priorities, vec![1, 2, 3]);
+
+        // Descending order
+        let results = Query::new(store.clone(), "test")
+            .order_by("priority", SortOrder::Desc)
+            .execute()
+            .unwrap();
+        let priorities: Vec<i64> = results
+            .iter()
+            .filter_map(|(_, doc)| {
+                if let Some(Value::Int(p)) = extract_field(doc, "priority") {
+                    Some(p)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert_eq!(priorities, vec![3, 2, 1]);
+    }
+
+    #[test]
+    fn test_limit_offset() {
+        let (store, _temp) = create_test_store();
+
+        for i in 0..10 {
+            let doc = create_test_doc(vec![("index", automerge::ScalarValue::Int(i))]);
+            store.put(&format!("test:doc{}", i), &doc).unwrap();
+        }
+
+        // Test limit
+        let results = Query::new(store.clone(), "test")
+            .order_by("index", SortOrder::Asc)
+            .limit(3)
+            .execute()
+            .unwrap();
+        assert_eq!(results.len(), 3);
+
+        // Test offset
+        let results = Query::new(store.clone(), "test")
+            .order_by("index", SortOrder::Asc)
+            .offset(7)
+            .execute()
+            .unwrap();
+        assert_eq!(results.len(), 3);
+
+        // Test offset + limit (pagination)
+        let results = Query::new(store.clone(), "test")
+            .order_by("index", SortOrder::Asc)
+            .offset(3)
+            .limit(2)
+            .execute()
+            .unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn test_filter_by_ids() {
+        let (store, _temp) = create_test_store();
+
+        for i in 0..5 {
+            let doc = create_test_doc(vec![("value", automerge::ScalarValue::Int(i))]);
+            store.put(&format!("test:doc{}", i), &doc).unwrap();
+        }
+
+        let results = Query::new(store.clone(), "test")
+            .filter_by_ids(&["doc1".to_string(), "doc3".to_string()])
+            .execute()
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        let ids: Vec<&str> = results.iter().map(|(id, _)| id.as_str()).collect();
+        assert!(ids.contains(&"doc1"));
+        assert!(ids.contains(&"doc3"));
+    }
+
+    #[test]
+    fn test_where_contains() {
+        let (store, _temp) = create_test_store();
+
+        // Create document with array
+        let mut doc1 = Automerge::new();
+        doc1.transact(|tx| {
+            tx.put(automerge::ROOT, "name", "node1")?;
+            let caps_id =
+                tx.put_object(automerge::ROOT, "capabilities", automerge::ObjType::List)?;
+            tx.insert(&caps_id, 0, "sensor")?;
+            tx.insert(&caps_id, 1, "comms")?;
+            Ok::<(), automerge::AutomergeError>(())
+        })
+        .unwrap();
+
+        let mut doc2 = Automerge::new();
+        doc2.transact(|tx| {
+            tx.put(automerge::ROOT, "name", "node2")?;
+            let caps_id =
+                tx.put_object(automerge::ROOT, "capabilities", automerge::ObjType::List)?;
+            tx.insert(&caps_id, 0, "weapon")?;
+            Ok::<(), automerge::AutomergeError>(())
+        })
+        .unwrap();
+
+        store.put("test:node1", &doc1).unwrap();
+        store.put("test:node2", &doc2).unwrap();
+
+        let results = Query::new(store.clone(), "test")
+            .where_contains("capabilities", Value::String("sensor".into()))
+            .execute()
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, "node1");
+    }
+
+    #[test]
+    fn test_execute_ids() {
+        let (store, _temp) = create_test_store();
+
+        let doc1 = create_test_doc(vec![("active", automerge::ScalarValue::Boolean(true))]);
+        let doc2 = create_test_doc(vec![("active", automerge::ScalarValue::Boolean(true))]);
+
+        store.put("test:a", &doc1).unwrap();
+        store.put("test:b", &doc2).unwrap();
+
+        let ids = Query::new(store.clone(), "test")
+            .where_eq("active", Value::Bool(true))
+            .execute_ids()
+            .unwrap();
+
+        assert_eq!(ids.len(), 2);
+    }
+
+    #[test]
+    fn test_count() {
+        let (store, _temp) = create_test_store();
+
+        for i in 0..5 {
+            let doc = create_test_doc(vec![("value", automerge::ScalarValue::Int(i))]);
+            store.put(&format!("test:doc{}", i), &doc).unwrap();
+        }
+
+        let count = Query::new(store.clone(), "test")
+            .where_gt("value", Value::Int(2))
+            .count()
+            .unwrap();
+
+        assert_eq!(count, 2);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements query capabilities for Automerge documents enabling location-based and field-based searches
- Adds geohash spatial indexing with configurable precision (~153m cells at default)
- 25 unit tests covering queries, predicates, sorting, pagination, and concurrent access

## Changes
- `query.rs`: Query builder with `where_eq/gt/lt/gte/lte`, `where_contains`, `order_by`, `limit/offset`
- `geohash_index.rs`: Spatial index with `insert`, `find_near` (9-cell), `find_in_cell`, `update`, `remove`
- `mod.rs`: Module exports gated by `automerge-backend` feature

## Test plan
- [x] All 25 unit tests pass (10 query + 15 geohash)
- [x] Pre-commit hooks pass (fmt, clippy, workspace tests)
- [x] Feature-gated behind `automerge-backend`

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)