### PR TITLE
feat: Add Android NDK linker configuration to cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,18 @@
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+# Android NDK toolchain configuration
+# Requires: ANDROID_HOME and NDK_HOME environment variables
+# Default NDK path: $ANDROID_HOME/ndk/<version>/toolchains/llvm/prebuilt/linux-x86_64/bin
+[target.aarch64-linux-android]
+linker = "aarch64-linux-android24-clang"
+
+[target.armv7-linux-androideabi]
+linker = "armv7a-linux-androideabi24-clang"
+
+[target.x86_64-linux-android]
+linker = "x86_64-linux-android24-clang"
+
+[target.i686-linux-android]
+linker = "i686-linux-android24-clang"


### PR DESCRIPTION
## Summary
- Add Android target linker settings to `.cargo/config.toml` for local development builds
- Supports all four Android architectures: aarch64, armv7, x86_64, i686
- Uses API level 24 (Android 7.0) for broad compatibility

## Setup Required
Add NDK toolchain to PATH in your shell config:
```bash
export ANDROID_HOME="$HOME/Android/Sdk"
export NDK_HOME="$ANDROID_HOME/ndk/<version>"
export PATH="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH"
```

## Test plan
- [x] Verified `cargo build -p hive-ffi --release --target aarch64-linux-android` succeeds
- [x] Generated Kotlin bindings with UniFFI

🤖 Generated with [Claude Code](https://claude.com/claude-code)