### PR TITLE
feat: Add document subscription callbacks to Kotlin FFI

### DIFF
--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -26,6 +26,8 @@ use std::net::SocketAddr;
 #[cfg(feature = "sync")]
 use std::path::PathBuf;
 #[cfg(feature = "sync")]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(feature = "sync")]
 use tokio::sync::RwLock;
 
 // Setup UniFFI scaffolding
@@ -196,6 +198,79 @@ pub struct SyncStats {
     pub bytes_received: u64,
 }
 
+/// Type of document change event
+#[cfg(feature = "sync")]
+#[derive(Debug, Clone, uniffi::Enum)]
+pub enum ChangeType {
+    /// Document was created or updated
+    Upsert,
+    /// Document was deleted
+    Delete,
+}
+
+/// Document change event for subscriptions
+#[cfg(feature = "sync")]
+#[derive(Debug, Clone, uniffi::Record)]
+pub struct DocumentChange {
+    /// Collection name
+    pub collection: String,
+    /// Document ID
+    pub doc_id: String,
+    /// Type of change
+    pub change_type: ChangeType,
+}
+
+/// Callback interface for document change notifications
+///
+/// Implement this interface in Kotlin/Swift to receive document updates.
+#[cfg(feature = "sync")]
+#[uniffi::export(callback_interface)]
+pub trait DocumentCallback: Send + Sync {
+    /// Called when a document changes
+    fn on_change(&self, change: DocumentChange);
+
+    /// Called when an error occurs in the subscription
+    fn on_error(&self, message: String);
+}
+
+/// Handle for an active document subscription
+///
+/// Drop this handle to unsubscribe from document changes.
+#[cfg(feature = "sync")]
+#[derive(uniffi::Object)]
+pub struct SubscriptionHandle {
+    /// Flag to signal the subscription should stop
+    active: Arc<AtomicBool>,
+}
+
+#[cfg(feature = "sync")]
+impl SubscriptionHandle {
+    fn new(active: Arc<AtomicBool>) -> Self {
+        Self { active }
+    }
+}
+
+#[cfg(feature = "sync")]
+#[uniffi::export]
+impl SubscriptionHandle {
+    /// Check if the subscription is still active
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::SeqCst)
+    }
+
+    /// Cancel the subscription
+    pub fn cancel(&self) {
+        self.active.store(false, Ordering::SeqCst);
+    }
+}
+
+#[cfg(feature = "sync")]
+impl Drop for SubscriptionHandle {
+    fn drop(&mut self) {
+        self.active.store(false, Ordering::SeqCst);
+    }
+}
+
 /// A HIVE network node with P2P sync capabilities
 ///
 /// Wraps AutomergeBackend + IrohTransport for document sync.
@@ -204,6 +279,8 @@ pub struct SyncStats {
 pub struct HiveNode {
     backend: Arc<RwLock<AutomergeBackend>>,
     transport: Arc<IrohTransport>,
+    /// Store reference for subscriptions
+    store: Arc<AutomergeStore>,
     #[allow(dead_code)] // Kept for potential future use (e.g., storage cleanup)
     storage_path: PathBuf,
     /// Tokio runtime for async operations
@@ -396,6 +473,80 @@ impl HiveNode {
                 .map_err(|e| HiveError::SyncError { msg: e.to_string() })
         })
     }
+
+    /// Subscribe to document changes
+    ///
+    /// Returns a SubscriptionHandle that must be kept alive to receive callbacks.
+    /// When the handle is dropped or cancel() is called, the subscription stops.
+    ///
+    /// The callback will receive DocumentChange events for all documents.
+    /// Filter by collection in your callback implementation if needed.
+    ///
+    /// Note: Only one subscription per node is supported. Calling subscribe again
+    /// will fail if a subscription is already active.
+    pub fn subscribe(
+        &self,
+        callback: Box<dyn DocumentCallback>,
+    ) -> Result<Arc<SubscriptionHandle>, HiveError> {
+        // Get the change receiver from the store
+        let change_rx = self
+            .store
+            .subscribe_to_changes()
+            .ok_or_else(|| HiveError::SyncError {
+                msg: "Subscription already active or store not available".to_string(),
+            })?;
+
+        // Create active flag for the subscription
+        let active = Arc::new(AtomicBool::new(true));
+        let active_clone = Arc::clone(&active);
+
+        // Spawn a task to listen for changes and call the callback
+        let callback = Arc::new(callback);
+        self.runtime.spawn(async move {
+            let mut rx = change_rx;
+
+            while active_clone.load(Ordering::SeqCst) {
+                tokio::select! {
+                    result = rx.recv() => {
+                        match result {
+                            Some(doc_key) => {
+                                // Parse the document key (format: "collection:doc_id")
+                                let change = if let Some((collection, doc_id)) = doc_key.split_once(':') {
+                                    DocumentChange {
+                                        collection: collection.to_string(),
+                                        doc_id: doc_id.to_string(),
+                                        change_type: ChangeType::Upsert, // We only get notifications on upsert currently
+                                    }
+                                } else {
+                                    // Key without colon - treat as collection with doc_id
+                                    DocumentChange {
+                                        collection: "default".to_string(),
+                                        doc_id: doc_key,
+                                        change_type: ChangeType::Upsert,
+                                    }
+                                };
+
+                                callback.on_change(change);
+                            }
+                            None => {
+                                // Channel closed
+                                callback.on_error("Document change channel closed".to_string());
+                                break;
+                            }
+                        }
+                    }
+                    _ = tokio::time::sleep(tokio::time::Duration::from_millis(100)) => {
+                        // Periodic check if we should stop
+                        if !active_clone.load(Ordering::SeqCst) {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(Arc::new(SubscriptionHandle::new(active)))
+    }
 }
 
 /// Create a new HiveNode
@@ -448,12 +599,13 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<HiveNode>, HiveError> {
     })?;
     let transport = Arc::new(transport);
 
-    // Create backend with transport
-    let backend = AutomergeBackend::with_transport(store, Arc::clone(&transport));
+    // Create backend with transport (clone store Arc so we can keep a reference)
+    let backend = AutomergeBackend::with_transport(Arc::clone(&store), Arc::clone(&transport));
 
     Ok(Arc::new(HiveNode {
         backend: Arc::new(RwLock::new(backend)),
         transport,
+        store,
         storage_path,
         runtime: Arc::new(runtime),
     }))

--- a/kotlin-test/src/main/kotlin/Main.kt
+++ b/kotlin-test/src/main/kotlin/Main.kt
@@ -165,8 +165,73 @@ fun main() {
         tempDir.deleteRecursively()
     }
 
-    // Test 10: Two-node sync test
-    println("10. Testing two-node sync...")
+    // Test 10: Subscription callbacks
+    println("10. Testing subscription callbacks...")
+    val tempDirSub = createTempDir("hive-sub-test-${UUID.randomUUID()}")
+    try {
+        val subNodeConfig = NodeConfig(
+            bindAddress = "127.0.0.1:0",
+            storagePath = tempDirSub.absolutePath
+        )
+        val subNode = createNode(subNodeConfig)
+
+        // Track received changes
+        val receivedChanges = mutableListOf<DocumentChange>()
+        var errorMessage: String? = null
+
+        // Create callback implementation
+        val callback = object : DocumentCallback {
+            override fun onChange(change: DocumentChange) {
+                println("   Callback received: ${change.collection}/${change.docId} (${change.changeType})")
+                synchronized(receivedChanges) {
+                    receivedChanges.add(change)
+                }
+            }
+
+            override fun onError(message: String) {
+                println("   Callback error: $message")
+                errorMessage = message
+            }
+        }
+
+        // Subscribe to changes
+        val subscription = subNode.subscribe(callback)
+        println("   Subscribed to document changes (active: ${subscription.isActive()})")
+
+        // Write some documents - these should trigger callbacks
+        println("   Writing test documents...")
+        subNode.putDocument("callbacks", "doc-1", """{"test": 1}""")
+        subNode.putDocument("callbacks", "doc-2", """{"test": 2}""")
+        subNode.putDocument("other", "doc-3", """{"test": 3}""")
+
+        // Give callbacks time to be delivered
+        Thread.sleep(500)
+
+        // Check results
+        synchronized(receivedChanges) {
+            println("   Received ${receivedChanges.size} change notifications")
+            if (receivedChanges.size >= 3) {
+                println("   ✓ Subscription callbacks passed!\n")
+            } else {
+                println("   ⚠ Expected 3 callbacks, got ${receivedChanges.size}")
+                println("   ⚠ Subscription callbacks incomplete\n")
+            }
+        }
+
+        // Cancel subscription
+        subscription.cancel()
+        check(!subscription.isActive()) { "Subscription should be inactive after cancel" }
+        println("   Subscription cancelled")
+
+        // Cleanup
+        subNode.destroy()
+
+    } finally {
+        tempDirSub.deleteRecursively()
+    }
+
+    // Test 11: Two-node sync test
+    println("11. Testing two-node sync...")
     val tempDir1 = createTempDir("hive-node1-${UUID.randomUUID()}")
     val tempDir2 = createTempDir("hive-node2-${UUID.randomUUID()}")
 
@@ -244,7 +309,7 @@ fun main() {
         }
 
         // Test 11: Bidirectional sync test
-        println("11. Testing bidirectional sync...")
+        println("12. Testing bidirectional sync...")
 
         // Write different documents on each node
         val doc1 = """{"source": "node1", "data": "alpha", "seq": 1}"""
@@ -287,7 +352,7 @@ fun main() {
         }
 
         // Test 12: CRDT conflict resolution (concurrent writes to same document)
-        println("12. Testing CRDT conflict resolution...")
+        println("13. Testing CRDT conflict resolution...")
 
         // Both nodes write to the same document simultaneously
         val conflictDoc1 = """{"value": "from-node1", "counter": 100}"""

--- a/kotlin-test/src/main/kotlin/uniffi/hive_ffi/hive_ffi.kt
+++ b/kotlin-test/src/main/kotlin/uniffi/hive_ffi/hive_ffi.kt
@@ -654,6 +654,42 @@ internal open class UniffiForeignFutureStructVoid(
 internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
     fun callback(`callbackData`: Long,`result`: UniffiForeignFutureStructVoid.UniffiByValue,)
 }
+internal interface UniffiCallbackInterfaceDocumentCallbackMethod0 : com.sun.jna.Callback {
+    fun callback(`uniffiHandle`: Long,`change`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
+}
+internal interface UniffiCallbackInterfaceDocumentCallbackMethod1 : com.sun.jna.Callback {
+    fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,)
+}
+@Structure.FieldOrder("onChange", "onError", "uniffiFree")
+internal open class UniffiVTableCallbackInterfaceDocumentCallback(
+    @JvmField internal var `onChange`: UniffiCallbackInterfaceDocumentCallbackMethod0? = null,
+    @JvmField internal var `onError`: UniffiCallbackInterfaceDocumentCallbackMethod1? = null,
+    @JvmField internal var `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+) : Structure() {
+    class UniffiByValue(
+        `onChange`: UniffiCallbackInterfaceDocumentCallbackMethod0? = null,
+        `onError`: UniffiCallbackInterfaceDocumentCallbackMethod1? = null,
+        `uniffiFree`: UniffiCallbackInterfaceFree? = null,
+    ): UniffiVTableCallbackInterfaceDocumentCallback(`onChange`,`onError`,`uniffiFree`,), Structure.ByValue
+
+   internal fun uniffiSetValue(other: UniffiVTableCallbackInterfaceDocumentCallback) {
+        `onChange` = other.`onChange`
+        `onError` = other.`onError`
+        `uniffiFree` = other.`uniffiFree`
+    }
+
+}
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -762,6 +798,7 @@ internal interface UniffiLib : Library {
             .also { lib: UniffiLib ->
                 uniffiCheckContractApiVersion(lib)
                 uniffiCheckApiChecksums(lib)
+                uniffiCallbackInterfaceDocumentCallback.register(lib)
                 }
         }
         
@@ -799,10 +836,22 @@ internal interface UniffiLib : Library {
     ): Unit
     fun uniffi_hive_ffi_fn_method_hivenode_stop_sync(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
+    fun uniffi_hive_ffi_fn_method_hivenode_subscribe(`ptr`: Pointer,`callback`: Long,uniffi_out_err: UniffiRustCallStatus, 
+    ): Pointer
     fun uniffi_hive_ffi_fn_method_hivenode_sync_document(`ptr`: Pointer,`collection`: RustBuffer.ByValue,`docId`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Unit
     fun uniffi_hive_ffi_fn_method_hivenode_sync_stats(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
     ): RustBuffer.ByValue
+    fun uniffi_hive_ffi_fn_clone_subscriptionhandle(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Pointer
+    fun uniffi_hive_ffi_fn_free_subscriptionhandle(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    fun uniffi_hive_ffi_fn_method_subscriptionhandle_cancel(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Unit
+    fun uniffi_hive_ffi_fn_method_subscriptionhandle_is_active(`ptr`: Pointer,uniffi_out_err: UniffiRustCallStatus, 
+    ): Byte
+    fun uniffi_hive_ffi_fn_init_callback_vtable_documentcallback(`vtable`: UniffiVTableCallbackInterfaceDocumentCallback,
+    ): Unit
     fun uniffi_hive_ffi_fn_func_create_node(`config`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
     ): Pointer
     fun uniffi_hive_ffi_fn_func_create_position(`lat`: Double,`lon`: Double,`hae`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
@@ -959,9 +1008,19 @@ internal interface UniffiLib : Library {
     ): Short
     fun uniffi_hive_ffi_checksum_method_hivenode_stop_sync(
     ): Short
+    fun uniffi_hive_ffi_checksum_method_hivenode_subscribe(
+    ): Short
     fun uniffi_hive_ffi_checksum_method_hivenode_sync_document(
     ): Short
     fun uniffi_hive_ffi_checksum_method_hivenode_sync_stats(
+    ): Short
+    fun uniffi_hive_ffi_checksum_method_subscriptionhandle_cancel(
+    ): Short
+    fun uniffi_hive_ffi_checksum_method_subscriptionhandle_is_active(
+    ): Short
+    fun uniffi_hive_ffi_checksum_method_documentcallback_on_change(
+    ): Short
+    fun uniffi_hive_ffi_checksum_method_documentcallback_on_error(
     ): Short
     fun ffi_hive_ffi_uniffi_contract_version(
     ): Int
@@ -1031,10 +1090,25 @@ private fun uniffiCheckApiChecksums(lib: UniffiLib) {
     if (lib.uniffi_hive_ffi_checksum_method_hivenode_stop_sync() != 33902.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
+    if (lib.uniffi_hive_ffi_checksum_method_hivenode_subscribe() != 42943.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
     if (lib.uniffi_hive_ffi_checksum_method_hivenode_sync_document() != 29736.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_hive_ffi_checksum_method_hivenode_sync_stats() != 23036.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_hive_ffi_checksum_method_subscriptionhandle_cancel() != 5113.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_hive_ffi_checksum_method_subscriptionhandle_is_active() != 54900.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_hive_ffi_checksum_method_documentcallback_on_change() != 23908.toShort()) {
+        throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
+    }
+    if (lib.uniffi_hive_ffi_checksum_method_documentcallback_on_error() != 34233.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
 }
@@ -1465,6 +1539,20 @@ public interface HiveNodeInterface {
     fun `stopSync`()
     
     /**
+     * Subscribe to document changes
+     *
+     * Returns a SubscriptionHandle that must be kept alive to receive callbacks.
+     * When the handle is dropped or cancel() is called, the subscription stops.
+     *
+     * The callback will receive DocumentChange events for all documents.
+     * Filter by collection in your callback implementation if needed.
+     *
+     * Note: Only one subscription per node is supported. Calling subscribe again
+     * will fail if a subscription is already active.
+     */
+    fun `subscribe`(`callback`: DocumentCallback): SubscriptionHandle
+    
+    /**
      * Manually trigger sync for a specific document
      */
     fun `syncDocument`(`collection`: kotlin.String, `docId`: kotlin.String)
@@ -1749,6 +1837,31 @@ open class HiveNode: Disposable, AutoCloseable, HiveNodeInterface {
 
     
     /**
+     * Subscribe to document changes
+     *
+     * Returns a SubscriptionHandle that must be kept alive to receive callbacks.
+     * When the handle is dropped or cancel() is called, the subscription stops.
+     *
+     * The callback will receive DocumentChange events for all documents.
+     * Filter by collection in your callback implementation if needed.
+     *
+     * Note: Only one subscription per node is supported. Calling subscribe again
+     * will fail if a subscription is already active.
+     */
+    @Throws(HiveException::class)override fun `subscribe`(`callback`: DocumentCallback): SubscriptionHandle {
+            return FfiConverterTypeSubscriptionHandle.lift(
+    callWithPointer {
+    uniffiRustCallWithError(HiveException) { _status ->
+    UniffiLib.INSTANCE.uniffi_hive_ffi_fn_method_hivenode_subscribe(
+        it, FfiConverterTypeDocumentCallback.lower(`callback`),_status)
+}
+    }
+    )
+    }
+    
+
+    
+    /**
      * Manually trigger sync for a specific document
      */
     @Throws(HiveException::class)override fun `syncDocument`(`collection`: kotlin.String, `docId`: kotlin.String)
@@ -1811,6 +1924,324 @@ public object FfiConverterTypeHiveNode: FfiConverter<HiveNode, Pointer> {
         // The Rust code always expects pointers written as 8 bytes,
         // and will fail to compile if they don't fit.
         buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+
+// This template implements a class for working with a Rust struct via a Pointer/Arc<T>
+// to the live Rust struct on the other side of the FFI.
+//
+// Each instance implements core operations for working with the Rust `Arc<T>` and the
+// Kotlin Pointer to work with the live Rust struct on the other side of the FFI.
+//
+// There's some subtlety here, because we have to be careful not to operate on a Rust
+// struct after it has been dropped, and because we must expose a public API for freeing
+// theq Kotlin wrapper object in lieu of reliable finalizers. The core requirements are:
+//
+//   * Each instance holds an opaque pointer to the underlying Rust struct.
+//     Method calls need to read this pointer from the object's state and pass it in to
+//     the Rust FFI.
+//
+//   * When an instance is no longer needed, its pointer should be passed to a
+//     special destructor function provided by the Rust FFI, which will drop the
+//     underlying Rust struct.
+//
+//   * Given an instance, calling code is expected to call the special
+//     `destroy` method in order to free it after use, either by calling it explicitly
+//     or by using a higher-level helper like the `use` method. Failing to do so risks
+//     leaking the underlying Rust struct.
+//
+//   * We can't assume that calling code will do the right thing, and must be prepared
+//     to handle Kotlin method calls executing concurrently with or even after a call to
+//     `destroy`, and to handle multiple (possibly concurrent!) calls to `destroy`.
+//
+//   * We must never allow Rust code to operate on the underlying Rust struct after
+//     the destructor has been called, and must never call the destructor more than once.
+//     Doing so may trigger memory unsafety.
+//
+//   * To mitigate many of the risks of leaking memory and use-after-free unsafety, a `Cleaner`
+//     is implemented to call the destructor when the Kotlin object becomes unreachable.
+//     This is done in a background thread. This is not a panacea, and client code should be aware that
+//      1. the thread may starve if some there are objects that have poorly performing
+//     `drop` methods or do significant work in their `drop` methods.
+//      2. the thread is shared across the whole library. This can be tuned by using `android_cleaner = true`,
+//         or `android = true` in the [`kotlin` section of the `uniffi.toml` file](https://mozilla.github.io/uniffi-rs/kotlin/configuration.html).
+//
+// If we try to implement this with mutual exclusion on access to the pointer, there is the
+// possibility of a race between a method call and a concurrent call to `destroy`:
+//
+//    * Thread A starts a method call, reads the value of the pointer, but is interrupted
+//      before it can pass the pointer over the FFI to Rust.
+//    * Thread B calls `destroy` and frees the underlying Rust struct.
+//    * Thread A resumes, passing the already-read pointer value to Rust and triggering
+//      a use-after-free.
+//
+// One possible solution would be to use a `ReadWriteLock`, with each method call taking
+// a read lock (and thus allowed to run concurrently) and the special `destroy` method
+// taking a write lock (and thus blocking on live method calls). However, we aim not to
+// generate methods with any hidden blocking semantics, and a `destroy` method that might
+// block if called incorrectly seems to meet that bar.
+//
+// So, we achieve our goals by giving each instance an associated `AtomicLong` counter to track
+// the number of in-flight method calls, and an `AtomicBoolean` flag to indicate whether `destroy`
+// has been called. These are updated according to the following rules:
+//
+//    * The initial value of the counter is 1, indicating a live object with no in-flight calls.
+//      The initial value for the flag is false.
+//
+//    * At the start of each method call, we atomically check the counter.
+//      If it is 0 then the underlying Rust struct has already been destroyed and the call is aborted.
+//      If it is nonzero them we atomically increment it by 1 and proceed with the method call.
+//
+//    * At the end of each method call, we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+//    * When `destroy` is called, we atomically flip the flag from false to true.
+//      If the flag was already true we silently fail.
+//      Otherwise we atomically decrement and check the counter.
+//      If it has reached zero then we destroy the underlying Rust struct.
+//
+// Astute readers may observe that this all sounds very similar to the way that Rust's `Arc<T>` works,
+// and indeed it is, with the addition of a flag to guard against multiple calls to `destroy`.
+//
+// The overall effect is that the underlying Rust struct is destroyed only when `destroy` has been
+// called *and* all in-flight method calls have completed, avoiding violating any of the expectations
+// of the underlying Rust code.
+//
+// This makes a cleaner a better alternative to _not_ calling `destroy()` as
+// and when the object is finished with, but the abstraction is not perfect: if the Rust object's `drop`
+// method is slow, and/or there are many objects to cleanup, and it's on a low end Android device, then the cleaner
+// thread may be starved, and the app will leak memory.
+//
+// In this case, `destroy`ing manually may be a better solution.
+//
+// The cleaner can live side by side with the manual calling of `destroy`. In the order of responsiveness, uniffi objects
+// with Rust peers are reclaimed:
+//
+// 1. By calling the `destroy` method of the object, which calls `rustObject.free()`. If that doesn't happen:
+// 2. When the object becomes unreachable, AND the Cleaner thread gets to call `rustObject.free()`. If the thread is starved then:
+// 3. The memory is reclaimed when the process terminates.
+//
+// [1] https://stackoverflow.com/questions/24376768/can-java-finalize-an-object-when-it-is-still-in-scope/24380219
+//
+
+
+/**
+ * Handle for an active document subscription
+ *
+ * Drop this handle to unsubscribe from document changes.
+ */
+public interface SubscriptionHandleInterface {
+    
+    /**
+     * Cancel the subscription
+     */
+    fun `cancel`()
+    
+    /**
+     * Check if the subscription is still active
+     */
+    fun `isActive`(): kotlin.Boolean
+    
+    companion object
+}
+
+/**
+ * Handle for an active document subscription
+ *
+ * Drop this handle to unsubscribe from document changes.
+ */
+open class SubscriptionHandle: Disposable, AutoCloseable, SubscriptionHandleInterface {
+
+    constructor(pointer: Pointer) {
+        this.pointer = pointer
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    /**
+     * This constructor can be used to instantiate a fake object. Only used for tests. Any
+     * attempt to actually use an object constructed this way will fail as there is no
+     * connected Rust object.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    constructor(noPointer: NoPointer) {
+        this.pointer = null
+        this.cleanable = UniffiLib.CLEANER.register(this, UniffiCleanAction(pointer))
+    }
+
+    protected val pointer: Pointer?
+    protected val cleanable: UniffiCleaner.Cleanable
+
+    private val wasDestroyed = AtomicBoolean(false)
+    private val callCounter = AtomicLong(1)
+
+    override fun destroy() {
+        // Only allow a single call to this method.
+        // TODO: maybe we should log a warning if called more than once?
+        if (this.wasDestroyed.compareAndSet(false, true)) {
+            // This decrement always matches the initial count of 1 given at creation time.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    @Synchronized
+    override fun close() {
+        this.destroy()
+    }
+
+    internal inline fun <R> callWithPointer(block: (ptr: Pointer) -> R): R {
+        // Check and increment the call counter, to keep the object alive.
+        // This needs a compare-and-set retry loop in case of concurrent updates.
+        do {
+            val c = this.callCounter.get()
+            if (c == 0L) {
+                throw IllegalStateException("${this.javaClass.simpleName} object has already been destroyed")
+            }
+            if (c == Long.MAX_VALUE) {
+                throw IllegalStateException("${this.javaClass.simpleName} call counter would overflow")
+            }
+        } while (! this.callCounter.compareAndSet(c, c + 1L))
+        // Now we can safely do the method call without the pointer being freed concurrently.
+        try {
+            return block(this.uniffiClonePointer())
+        } finally {
+            // This decrement always matches the increment we performed above.
+            if (this.callCounter.decrementAndGet() == 0L) {
+                cleanable.clean()
+            }
+        }
+    }
+
+    // Use a static inner class instead of a closure so as not to accidentally
+    // capture `this` as part of the cleanable's action.
+    private class UniffiCleanAction(private val pointer: Pointer?) : Runnable {
+        override fun run() {
+            pointer?.let { ptr ->
+                uniffiRustCall { status ->
+                    UniffiLib.INSTANCE.uniffi_hive_ffi_fn_free_subscriptionhandle(ptr, status)
+                }
+            }
+        }
+    }
+
+    fun uniffiClonePointer(): Pointer {
+        return uniffiRustCall() { status ->
+            UniffiLib.INSTANCE.uniffi_hive_ffi_fn_clone_subscriptionhandle(pointer!!, status)
+        }
+    }
+
+    
+    /**
+     * Cancel the subscription
+     */override fun `cancel`()
+        = 
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_hive_ffi_fn_method_subscriptionhandle_cancel(
+        it, _status)
+}
+    }
+    
+    
+
+    
+    /**
+     * Check if the subscription is still active
+     */override fun `isActive`(): kotlin.Boolean {
+            return FfiConverterBoolean.lift(
+    callWithPointer {
+    uniffiRustCall() { _status ->
+    UniffiLib.INSTANCE.uniffi_hive_ffi_fn_method_subscriptionhandle_is_active(
+        it, _status)
+}
+    }
+    )
+    }
+    
+
+    
+
+    
+    
+    companion object
+    
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeSubscriptionHandle: FfiConverter<SubscriptionHandle, Pointer> {
+
+    override fun lower(value: SubscriptionHandle): Pointer {
+        return value.uniffiClonePointer()
+    }
+
+    override fun lift(value: Pointer): SubscriptionHandle {
+        return SubscriptionHandle(value)
+    }
+
+    override fun read(buf: ByteBuffer): SubscriptionHandle {
+        // The Rust code always writes pointers as 8 bytes, and will
+        // fail to compile if they don't fit.
+        return lift(Pointer(buf.getLong()))
+    }
+
+    override fun allocationSize(value: SubscriptionHandle) = 8UL
+
+    override fun write(value: SubscriptionHandle, buf: ByteBuffer) {
+        // The Rust code always expects pointers written as 8 bytes,
+        // and will fail to compile if they don't fit.
+        buf.putLong(Pointer.nativeValue(lower(value)))
+    }
+}
+
+
+
+/**
+ * Document change event for subscriptions
+ */
+data class DocumentChange (
+    /**
+     * Collection name
+     */
+    var `collection`: kotlin.String, 
+    /**
+     * Document ID
+     */
+    var `docId`: kotlin.String, 
+    /**
+     * Type of change
+     */
+    var `changeType`: ChangeType
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeDocumentChange: FfiConverterRustBuffer<DocumentChange> {
+    override fun read(buf: ByteBuffer): DocumentChange {
+        return DocumentChange(
+            FfiConverterString.read(buf),
+            FfiConverterString.read(buf),
+            FfiConverterTypeChangeType.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: DocumentChange) = (
+            FfiConverterString.allocationSize(value.`collection`) +
+            FfiConverterString.allocationSize(value.`docId`) +
+            FfiConverterTypeChangeType.allocationSize(value.`changeType`)
+    )
+
+    override fun write(value: DocumentChange, buf: ByteBuffer) {
+            FfiConverterString.write(value.`collection`, buf)
+            FfiConverterString.write(value.`docId`, buf)
+            FfiConverterTypeChangeType.write(value.`changeType`, buf)
     }
 }
 
@@ -2139,6 +2570,45 @@ public object FfiConverterTypeVelocity: FfiConverterRustBuffer<Velocity> {
 
 
 
+/**
+ * Type of document change event
+ */
+
+enum class ChangeType {
+    
+    /**
+     * Document was created or updated
+     */
+    UPSERT,
+    /**
+     * Document was deleted
+     */
+    DELETE;
+    companion object
+}
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeChangeType: FfiConverterRustBuffer<ChangeType> {
+    override fun read(buf: ByteBuffer) = try {
+        ChangeType.values()[buf.getInt() - 1]
+    } catch (e: IndexOutOfBoundsException) {
+        throw RuntimeException("invalid enum value, something is very wrong!!", e)
+    }
+
+    override fun allocationSize(value: ChangeType) = 4UL
+
+    override fun write(value: ChangeType, buf: ByteBuffer) {
+        buf.putInt(value.ordinal + 1)
+    }
+}
+
+
+
+
+
 
 
 /**
@@ -2282,6 +2752,116 @@ public object FfiConverterTypeHiveError : FfiConverterRustBuffer<HiveException> 
     }
 
 }
+
+
+
+
+
+/**
+ * Callback interface for document change notifications
+ *
+ * Implement this interface in Kotlin/Swift to receive document updates.
+ */
+public interface DocumentCallback {
+    
+    /**
+     * Called when a document changes
+     */
+    fun `onChange`(`change`: DocumentChange)
+    
+    /**
+     * Called when an error occurs in the subscription
+     */
+    fun `onError`(`message`: kotlin.String)
+    
+    companion object
+}
+
+// Magic number for the Rust proxy to call using the same mechanism as every other method,
+// to free the callback once it's dropped by Rust.
+internal const val IDX_CALLBACK_FREE = 0
+// Callback return codes
+internal const val UNIFFI_CALLBACK_SUCCESS = 0
+internal const val UNIFFI_CALLBACK_ERROR = 1
+internal const val UNIFFI_CALLBACK_UNEXPECTED_ERROR = 2
+
+/**
+ * @suppress
+ */
+public abstract class FfiConverterCallbackInterface<CallbackInterface: Any>: FfiConverter<CallbackInterface, Long> {
+    internal val handleMap = UniffiHandleMap<CallbackInterface>()
+
+    internal fun drop(handle: Long) {
+        handleMap.remove(handle)
+    }
+
+    override fun lift(value: Long): CallbackInterface {
+        return handleMap.get(value)
+    }
+
+    override fun read(buf: ByteBuffer) = lift(buf.getLong())
+
+    override fun lower(value: CallbackInterface) = handleMap.insert(value)
+
+    override fun allocationSize(value: CallbackInterface) = 8UL
+
+    override fun write(value: CallbackInterface, buf: ByteBuffer) {
+        buf.putLong(lower(value))
+    }
+}
+
+// Put the implementation in an object so we don't pollute the top-level namespace
+internal object uniffiCallbackInterfaceDocumentCallback {
+    internal object `onChange`: UniffiCallbackInterfaceDocumentCallbackMethod0 {
+        override fun callback(`uniffiHandle`: Long,`change`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,) {
+            val uniffiObj = FfiConverterTypeDocumentCallback.handleMap.get(uniffiHandle)
+            val makeCall = { ->
+                uniffiObj.`onChange`(
+                    FfiConverterTypeDocumentChange.lift(`change`),
+                )
+            }
+            val writeReturn = { _: Unit -> Unit }
+            uniffiTraitInterfaceCall(uniffiCallStatus, makeCall, writeReturn)
+        }
+    }
+    internal object `onError`: UniffiCallbackInterfaceDocumentCallbackMethod1 {
+        override fun callback(`uniffiHandle`: Long,`message`: RustBuffer.ByValue,`uniffiOutReturn`: Pointer,uniffiCallStatus: UniffiRustCallStatus,) {
+            val uniffiObj = FfiConverterTypeDocumentCallback.handleMap.get(uniffiHandle)
+            val makeCall = { ->
+                uniffiObj.`onError`(
+                    FfiConverterString.lift(`message`),
+                )
+            }
+            val writeReturn = { _: Unit -> Unit }
+            uniffiTraitInterfaceCall(uniffiCallStatus, makeCall, writeReturn)
+        }
+    }
+
+    internal object uniffiFree: UniffiCallbackInterfaceFree {
+        override fun callback(handle: Long) {
+            FfiConverterTypeDocumentCallback.handleMap.remove(handle)
+        }
+    }
+
+    internal var vtable = UniffiVTableCallbackInterfaceDocumentCallback.UniffiByValue(
+        `onChange`,
+        `onError`,
+        uniffiFree,
+    )
+
+    // Registers the foreign callback with the Rust side.
+    // This method is generated for each callback interface.
+    internal fun register(lib: UniffiLib) {
+        lib.uniffi_hive_ffi_fn_init_callback_vtable_documentcallback(vtable)
+    }
+}
+
+/**
+ * The ffiConverter which transforms the Callbacks in to handles to pass to Rust.
+ *
+ * @suppress
+ */
+public object FfiConverterTypeDocumentCallback: FfiConverterCallbackInterface<DocumentCallback>()
 
 
 


### PR DESCRIPTION
## Summary

- Adds reactive document change notifications for ATAK plugin development
- Implements `DocumentCallback` interface that Kotlin can implement to receive change events
- Provides `SubscriptionHandle` for lifecycle management

## New API

```kotlin
val callback = object : DocumentCallback {
    override fun onChange(change: DocumentChange) {
        println("${change.collection}/${change.docId} changed (${change.changeType})")
    }
    override fun onError(message: String) {
        println("Error: $message")
    }
}

val subscription = node.subscribe(callback)
// ... callbacks fire automatically when documents change
subscription.cancel()  // Stop receiving callbacks
```

## Test Results (13/13 passing)

| Test | Status |
|------|--------|
| 1-9. Existing tests | ✅ |
| **10. Subscription callbacks** | ✅ NEW |
| 11. Two-node sync | ✅ |
| 12. Bidirectional sync | ✅ |
| 13. CRDT conflict resolution | ✅ |

## Test plan

- [x] Run `cargo build -p hive-ffi`
- [x] Run Kotlin tests: `cd kotlin-test && ./gradlew run`
- [x] Verify subscription callback test passes
- [x] Verify callback receives all 3 document change notifications

Related: #196 (ATAK Plugin - other team can now start development)

🤖 Generated with [Claude Code](https://claude.com/claude-code)