### PR TITLE
feat: Require FormationKey authentication for AutomergeIroh peer connections

### DIFF
--- a/docs/adr/030-multi-interface-transport.md
+++ b/docs/adr/030-multi-interface-transport.md
@@ -1,0 +1,380 @@
+# ADR-030: Multi-Interface Transport for Network Bridging
+
+**Status**: Accepted
+**Date**: 2025-12-02
+**Authors**: Kit Plummer, Claude
+**Relates To**: ADR-011 (Automerge + Iroh), ADR-017 (P2P Mesh Management)
+
+---
+
+## Investigation Results (2025-12-02)
+
+**Critical Finding: Iroh already handles multi-interface automatically!**
+
+When calling `Endpoint::builder().bind().await`, Iroh:
+1. Discovers ALL local network interfaces
+2. Binds to all of them simultaneously
+3. Advertises all addresses in `EndpointAddr`
+
+Test output showing automatic multi-interface discovery:
+```
+EndpointAddr {
+    id: PublicKey(...),
+    addrs: {
+        Ip(100.85.90.54:56575),   // External/Tailscale IP
+        Ip(192.168.1.95:56575),    // LAN IPv4
+        Ip([2600:1700:...]:56576), // IPv6 (multiple)
+    },
+}
+```
+
+**Implication**: Our current `IrohTransport::bind(bind_addr)` that forces a single address is actually **limiting** Iroh's native capabilities. The default `IrohTransport::new()` (which binds to all interfaces) is the correct approach for multi-network scenarios.
+
+---
+
+## Context and Problem Statement
+
+### The Multi-Network Reality
+
+Tactical platforms operate across multiple disparate networks simultaneously:
+
+- **Tactical Radio (MANET)**: Low bandwidth (300bps-2Mbps), high latency, mesh topology
+- **WiFi/Ethernet**: Medium bandwidth, low latency, infrastructure-based
+- **Starlink (Satellite)**: High bandwidth, high latency, requires gateway
+- **5G (Private Cellular)**: Variable bandwidth, medium latency, coverage-dependent
+
+**Critical Use Case: Network Bridging**
+
+A platform with access to multiple networks must act as a **bridge** to sync data across network boundaries:
+
+```
+┌─────────────────┐         ┌─────────────────┐         ┌─────────────────┐
+│  Radio Network  │◄───────►│  Bridge Node    │◄───────►│  WiFi Network   │
+│  (MANET peers)  │         │  (Multi-NIC)    │         │  (Base station) │
+└─────────────────┘         └─────────────────┘         └─────────────────┘
+      eth0                        eth0 + eth1                  eth1
+   192.168.1.x                                              10.0.0.x
+```
+
+### Current Implementation Gap
+
+**ADR-011 claims Iroh provides**:
+> Multi-path support: Simultaneous use of multiple network interfaces (Starlink + MANET + 5G)
+
+**Current implementation reality** (`iroh_transport.rs`):
+```rust
+pub async fn bind(bind_addr: SocketAddr) -> Result<Self> {
+    // Only binds to ONE address
+    let endpoint = Endpoint::builder()
+        .bind_addr_v4(bind_addr_v4)  // Single interface
+        .bind()
+        .await?;
+}
+```
+
+The current `IrohTransport` only supports binding to a **single socket address**, making network bridging impossible.
+
+---
+
+## Decision Drivers
+
+### Requirements
+
+1. **Multi-Interface Binding**: Bind to multiple network interfaces simultaneously
+2. **Cross-Network Sync**: Sync CRDT data between nodes on different physical networks
+3. **Interface-Aware Routing**: Route messages based on destination network
+4. **Graceful Degradation**: Continue operating if one interface fails
+5. **Let Iroh Manage**: Prefer Iroh's native capabilities over custom implementation
+
+### Constraints
+
+1. **Iroh API Limitations**: Current Iroh API may not expose multi-interface directly
+2. **IPv4 Only**: Current implementation only supports IPv4 (`bind_addr_v4`)
+3. **Single Endpoint Model**: Each `IrohTransport` wraps one `Endpoint`
+
+---
+
+## Considered Options
+
+### Option 1: Multiple Transport Instances (Application-Level)
+
+Create separate `IrohTransport` instances per interface, route at application layer.
+
+```rust
+pub struct MultiBridgeTransport {
+    transports: HashMap<NetworkInterface, Arc<IrohTransport>>,
+    router: MessageRouter,
+}
+
+impl MultiBridgeTransport {
+    pub async fn new(interfaces: Vec<NetworkInterface>) -> Result<Self> {
+        let mut transports = HashMap::new();
+        for iface in interfaces {
+            let transport = IrohTransport::bind(iface.bind_addr).await?;
+            transports.insert(iface, Arc::new(transport));
+        }
+        Ok(Self { transports, router: MessageRouter::new() })
+    }
+
+    pub async fn broadcast(&self, message: &[u8]) -> Result<()> {
+        for transport in self.transports.values() {
+            transport.broadcast(message).await?;
+        }
+        Ok(())
+    }
+}
+```
+
+**Pros**:
+- Works with current Iroh API
+- Simple to implement
+- Clear separation of concerns
+
+**Cons**:
+- Multiple QUIC endpoints (higher resource usage)
+- Application must handle cross-transport routing
+- No unified connection migration between interfaces
+- Doesn't leverage Iroh's multipath capabilities
+
+### Option 2: Iroh Multipath QUIC (Let Iroh Manage)
+
+Use Iroh's native multipath QUIC support (if available).
+
+Per [QUIC Multipath Extension (RFC draft)](https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/), QUIC supports:
+- Multiple paths within single connection
+- Path-aware packet scheduling
+- Connection migration between paths
+
+**Iroh's approach** (from iroh.computer docs):
+- Endpoint discovers all local addresses automatically
+- Peers exchange address info via relay or direct connection
+- Path probing selects best path dynamically
+
+```rust
+// Iroh may already bind to all interfaces by default
+let endpoint = Endpoint::builder()
+    .bind()  // Binds to 0.0.0.0 - all interfaces
+    .await?;
+
+// Iroh should advertise all addresses
+let addr = endpoint.addr();  // Contains all interface addresses
+```
+
+**Pros**:
+- Leverages Iroh's production-tested multipath
+- Single endpoint, multiple paths
+- Automatic path selection and failover
+- Connection migration built-in
+
+**Cons**:
+- Requires Iroh to support this (need to verify)
+- Less control over interface selection
+- May not work for network bridging (different subnets)
+
+### Option 3: Hybrid Approach (RECOMMENDED)
+
+1. **Use Iroh's multipath** for same-subnet multi-interface
+2. **Use multiple endpoints** for cross-subnet bridging
+
+```rust
+pub struct BridgeTransport {
+    /// Primary endpoint (Iroh manages multi-interface on same subnet)
+    primary: Arc<IrohTransport>,
+
+    /// Bridge endpoints for isolated networks
+    bridges: HashMap<NetworkId, Arc<IrohTransport>>,
+
+    /// Cross-network message relay
+    relay: BridgeRelay,
+}
+
+impl BridgeTransport {
+    pub async fn new(config: BridgeConfig) -> Result<Self> {
+        // Primary endpoint for main network (Iroh multi-interface)
+        let primary = IrohTransport::new().await?;  // Binds to all interfaces
+
+        // Additional endpoints for isolated networks (if needed)
+        let mut bridges = HashMap::new();
+        for isolated_net in config.isolated_networks {
+            let bridge = IrohTransport::bind(isolated_net.bind_addr).await?;
+            bridges.insert(isolated_net.id, Arc::new(bridge));
+        }
+
+        Ok(Self {
+            primary: Arc::new(primary),
+            bridges,
+            relay: BridgeRelay::new(),
+        })
+    }
+}
+```
+
+**Pros**:
+- Best of both worlds
+- Iroh manages multi-interface within networks
+- Custom logic for cross-network bridging
+- Flexible for different deployment scenarios
+
+**Cons**:
+- More complex implementation
+- Need to understand when to use which approach
+
+---
+
+## Decision
+
+**Adopt Option 2: Let Iroh Manage (Simplified)**
+
+Based on investigation results, Iroh natively handles multi-interface. The decision is:
+
+1. **Default**: Use `IrohTransport::new()` (not `bind(addr)`) for all standard deployments
+   - Iroh automatically discovers and binds to ALL interfaces
+   - Peers receive all addresses and can connect via any one
+
+2. **Restrict Only When Needed**: Use `IrohTransport::bind(addr)` only when explicitly limiting to one interface (e.g., security isolation)
+
+3. **Bridge Mode (Future)**: Only needed for truly air-gapped networks where Iroh's automatic discovery cannot work. Defer implementation until required.
+
+**Implementation is simpler than anticipated** - we primarily need to ensure our code uses the default `new()` constructor rather than forcing single-interface binding.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Verify Iroh Multipath (Investigation) - COMPLETE ✅
+
+**Test**: `hive-protocol/tests/iroh_multipath_investigation.rs`
+
+**Result**: Iroh automatically advertises all interfaces:
+- IPv4 LAN addresses
+- IPv6 addresses
+- External/VPN addresses (e.g., Tailscale)
+
+```rust
+// This already works - Iroh discovers all interfaces
+let endpoint = Endpoint::builder()
+    .alpns(vec![b"hive/1".to_vec()])
+    .bind()  // Binds to ALL interfaces automatically
+    .await?;
+
+let addr = endpoint.addr();
+// addr.addrs contains ALL interface addresses
+```
+
+### Phase 2: Audit IrohTransport Usage - TODO
+
+Review codebase to ensure we're using the multi-interface-friendly constructor:
+
+**Current code** (`iroh_transport.rs`):
+```rust
+// GOOD - uses all interfaces
+pub async fn new() -> Result<Self> {
+    let endpoint = Endpoint::builder()
+        .alpns(...)
+        .bind()  // Binds to all interfaces
+        .await?;
+}
+
+// LIMITING - forces single interface (use only when explicitly needed)
+pub async fn bind(bind_addr: SocketAddr) -> Result<Self> {
+    let endpoint = Endpoint::builder()
+        .bind_addr_v4(bind_addr_v4)  // Single interface only
+        .bind()
+        .await?;
+}
+```
+
+**Action**: Ensure production code paths use `new()` by default. The `bind()` method should be reserved for:
+- Testing (deterministic ports)
+- Security isolation (restrict to specific interface)
+- Legacy compatibility
+
+### Phase 3: Bridge Transport (DEFERRED - Future)
+
+**Not needed for most deployments** since Iroh handles multi-interface natively.
+
+Only implement if a specific requirement arises for truly air-gapped/isolated networks where:
+- Network A has no IP route to Network B
+- A node physically connected to both must relay traffic
+
+```rust
+// Future: Only if needed
+pub struct BridgeTransport {
+    main: Arc<IrohMeshTransport>,
+    bridges: HashMap<String, Arc<IrohMeshTransport>>,
+}
+```
+
+### Phase 4: Documentation Update - TODO
+
+Update documentation to clarify multi-interface support:
+
+1. **README**: Note that Iroh automatically uses all available interfaces
+2. **PeerConfig docs**: Clarify when to use `bind_address` vs letting Iroh choose
+3. **Deployment guide**: Explain that bridge nodes just need multiple NICs - Iroh handles the rest
+
+---
+
+## Success Criteria
+
+### Functional Requirements
+
+- [ ] Single node can bind to multiple network interfaces
+- [ ] Peers on different networks can sync via bridge node
+- [ ] Interface failure doesn't break sync on other interfaces
+- [ ] Configuration supports per-interface peer assignment
+
+### Performance Requirements
+
+- [ ] Message relay latency < 50ms additional overhead
+- [ ] No message loss during interface transitions
+- [ ] Memory overhead < 10MB per additional interface
+
+### Testing
+
+- [ ] Unit tests for multi-transport routing
+- [ ] Integration tests with simulated multi-network topology
+- [ ] Containerlab test with isolated network namespaces
+
+---
+
+## Open Questions
+
+1. **Iroh Multipath Status**: Does current Iroh version (0.35+) support multi-interface out of box?
+   - Need to test with actual multi-NIC setup
+
+2. **Same Endpoint ID?**: Should bridge transports share same EndpointId or have separate identities?
+   - Separate: Cleaner isolation, but more complex peer management
+   - Shared: Unified identity, but may confuse Iroh's path selection
+
+3. **Relay Protocol**: How should cross-network messages be relayed?
+   - Option A: Re-wrap in new QUIC stream on destination network
+   - Option B: Use Automerge sync protocol (document-level bridging)
+   - Option C: Use Iroh Gossip for multi-network broadcast
+
+---
+
+## References
+
+1. [Iroh Documentation](https://iroh.computer/docs)
+2. [QUIC Multipath RFC Draft](https://datatracker.ietf.org/doc/draft-ietf-quic-multipath/)
+3. ADR-011: CRDT + Networking Stack Selection
+4. ADR-017: P2P Mesh Management and Discovery
+
+---
+
+**Last Updated**: 2025-12-02
+**Investigation Complete**: Iroh natively supports multi-interface
+**Decision Status**: ✅ **ACCEPTED** - Let Iroh manage interfaces; defer BridgeTransport until needed
+
+## Summary
+
+**Question**: Does AutomergeIroh backend support multiple network interfaces?
+
+**Answer**: **Yes** - Iroh automatically discovers and binds to all available interfaces when using the default `bind()` method. Peers receive all addresses and can connect via any one.
+
+**Action Items**:
+1. ✅ Investigation complete - Iroh handles multi-interface natively
+2. 🔲 Audit codebase to ensure `IrohTransport::new()` is used in production paths
+3. 🔲 Update documentation
+4. 🔲 (Future) Implement BridgeTransport only if air-gapped network support is required

--- a/hive-protocol/src/network/iroh_transport.rs
+++ b/hive-protocol/src/network/iroh_transport.rs
@@ -56,12 +56,27 @@ pub struct IrohTransport {
 
 #[cfg(feature = "automerge-backend")]
 impl IrohTransport {
-    /// Create a new Iroh transport (binds to any available port)
+    /// Create a new Iroh transport (binds to ALL available interfaces)
+    ///
+    /// This is the recommended constructor for production use. Iroh automatically
+    /// discovers all local network interfaces and advertises them to peers,
+    /// enabling multi-network connectivity without additional configuration.
+    ///
+    /// # Multi-Interface Support (ADR-030)
+    ///
+    /// When using this constructor, peers will receive addresses for all interfaces:
+    /// - LAN IPv4 addresses (e.g., 192.168.1.x)
+    /// - External/VPN addresses (e.g., Tailscale)
+    /// - IPv6 addresses
+    ///
+    /// Peers can connect via any advertised address, enabling seamless
+    /// operation across multiple networks.
     ///
     /// # Example
     ///
     /// ```ignore
     /// let transport = IrohTransport::new().await?;
+    /// // transport.endpoint_addr() now contains ALL interface addresses
     /// ```
     pub async fn new() -> Result<Self> {
         let endpoint = Endpoint::builder()
@@ -78,15 +93,25 @@ impl IrohTransport {
         })
     }
 
-    /// Create a new Iroh transport bound to a specific address
+    /// Create a new Iroh transport bound to a SINGLE specific address
+    ///
+    /// **Warning**: This limits the transport to one interface only!
+    ///
+    /// Use this method only when you need to:
+    /// - Run tests with deterministic ports
+    /// - Restrict connectivity to a specific network interface (security isolation)
+    /// - Debug with a known address
+    ///
+    /// For production multi-network deployments, use [`IrohTransport::new()`] instead.
     ///
     /// # Arguments
     ///
-    /// * `bind_addr` - Socket address to bind to (e.g., "127.0.0.1:9000")
+    /// * `bind_addr` - Socket address to bind to (IPv4 only, e.g., "127.0.0.1:9000")
     ///
     /// # Example
     ///
     /// ```ignore
+    /// // For testing only - limits to single interface
     /// let addr = "127.0.0.1:9000".parse()?;
     /// let transport = IrohTransport::bind(addr).await?;
     /// ```

--- a/hive-protocol/src/sync/automerge.rs
+++ b/hive-protocol/src/sync/automerge.rs
@@ -722,6 +722,10 @@ pub struct AutomergeIrohBackend {
     /// Initialization state
     initialized: Arc<Mutex<bool>>,
 
+    /// Formation key for peer authentication (ADR-030)
+    /// Peers must share the same app_id and secret_key to connect
+    formation_key: Arc<std::sync::RwLock<Option<crate::security::FormationKey>>>,
+
     /// Peer discovery manager (ADR-011 Phase 3)
     #[cfg(feature = "automerge-backend")]
     discovery_manager: Arc<tokio::sync::RwLock<crate::discovery::peer::DiscoveryManager>>,
@@ -738,11 +742,26 @@ impl AutomergeIrohBackend {
             transport,
             peer_callbacks: Arc::new(Mutex::new(Vec::new())),
             initialized: Arc::new(Mutex::new(false)),
+            formation_key: Arc::new(std::sync::RwLock::new(None)),
             #[cfg(feature = "automerge-backend")]
             discovery_manager: Arc::new(tokio::sync::RwLock::new(
                 crate::discovery::peer::DiscoveryManager::default(),
             )),
         }
+    }
+
+    /// Get the formation key (if initialized with credentials)
+    pub fn formation_key(&self) -> Option<crate::security::FormationKey> {
+        self.formation_key.read().unwrap().clone()
+    }
+
+    /// Get the formation ID (app_id used as formation identifier)
+    pub fn formation_id(&self) -> Option<String> {
+        self.formation_key
+            .read()
+            .unwrap()
+            .as_ref()
+            .map(|k| k.formation_id().to_string())
     }
 
     /// Create from store and transport (convenience method)
@@ -947,19 +966,67 @@ struct IrohPeerDiscovery {
     peer_callbacks: PeerCallbacks,
     #[cfg(feature = "automerge-backend")]
     discovery_manager: Arc<tokio::sync::RwLock<crate::discovery::peer::DiscoveryManager>>,
+    /// Formation key for peer authentication (required for secure connections)
+    #[cfg(feature = "automerge-backend")]
+    formation_key: Arc<std::sync::RwLock<Option<crate::security::FormationKey>>>,
 }
 
 #[async_trait]
 impl PeerDiscovery for IrohPeerDiscovery {
     async fn start(&self) -> Result<()> {
-        // Start Iroh transport accept loop
-        self.transport
-            .start_accept_loop()
-            .map_err(|e| Error::Network {
-                message: format!("Failed to start accept loop: {}", e),
-                peer_id: None,
-                source: None,
-            })?;
+        // Get formation key for authentication (required)
+        let formation_key = self
+            .formation_key
+            .read()
+            .unwrap()
+            .clone()
+            .ok_or_else(|| Error::Internal("Formation key not initialized".to_string()))?;
+
+        // Start authenticated accept loop (replaces simple start_accept_loop)
+        // This spawns a background task that accepts connections and performs handshake
+        #[cfg(feature = "automerge-backend")]
+        {
+            let transport = Arc::clone(&self.transport);
+            let formation_key_accept = formation_key.clone();
+
+            tokio::spawn(async move {
+                use crate::network::formation_handshake::perform_responder_handshake;
+
+                loop {
+                    // Accept incoming connection
+                    match transport.accept().await {
+                        Ok(conn) => {
+                            let peer_id = conn.remote_id();
+                            tracing::debug!("Accepted connection from: {:?}", peer_id);
+
+                            // Perform formation handshake to authenticate peer
+                            match perform_responder_handshake(&conn, &formation_key_accept).await {
+                                Ok(()) => {
+                                    tracing::info!("Peer {:?} authenticated successfully", peer_id);
+                                    // Connection is already stored by transport.accept()
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "Peer {:?} failed authentication: {}. Closing connection.",
+                                        peer_id,
+                                        e
+                                    );
+                                    // Close the unauthenticated connection
+                                    conn.close(1u32.into(), b"authentication failed");
+                                    transport.disconnect(&peer_id).ok();
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            // Accept loop stopped or endpoint closed
+                            tracing::debug!("Accept loop ended: {}", e);
+                            break;
+                        }
+                    }
+                }
+                tracing::debug!("Authenticated accept loop stopped");
+            });
+        }
 
         // Start discovery manager
         #[cfg(feature = "automerge-backend")]
@@ -970,13 +1037,15 @@ impl PeerDiscovery for IrohPeerDiscovery {
             })?;
         }
 
-        // Spawn background task to connect to discovered peers
+        // Spawn background task to connect to discovered peers (with authentication)
         #[cfg(feature = "automerge-backend")]
         {
             let discovery_manager = Arc::clone(&self.discovery_manager);
             let transport = Arc::clone(&self.transport);
+            let formation_key_connect = formation_key;
 
             tokio::spawn(async move {
+                use crate::network::formation_handshake::perform_initiator_handshake;
                 use crate::network::PeerInfo as NetworkPeerInfo;
 
                 loop {
@@ -1000,14 +1069,40 @@ impl PeerDiscovery for IrohPeerDiscovery {
                         // Only attempt connection if not already connected
                         if let Ok(endpoint_id) = peer.endpoint_id() {
                             if transport.get_connection(&endpoint_id).is_none() {
-                                if let Err(e) = transport.connect_peer(&network_peer_info).await {
-                                    tracing::debug!(
-                                        "Failed to connect to discovered peer {}: {}",
-                                        peer.name,
-                                        e
-                                    );
-                                } else {
-                                    tracing::info!("Connected to discovered peer: {}", peer.name);
+                                match transport.connect_peer(&network_peer_info).await {
+                                    Ok(conn) => {
+                                        // Perform formation handshake to authenticate
+                                        match perform_initiator_handshake(
+                                            &conn,
+                                            &formation_key_connect,
+                                        )
+                                        .await
+                                        {
+                                            Ok(()) => {
+                                                tracing::info!(
+                                                    "Connected and authenticated with peer: {}",
+                                                    peer.name
+                                                );
+                                            }
+                                            Err(e) => {
+                                                tracing::warn!(
+                                                    "Peer {} failed authentication: {}. Disconnecting.",
+                                                    peer.name,
+                                                    e
+                                                );
+                                                // Disconnect unauthenticated peer
+                                                conn.close(1u32.into(), b"authentication failed");
+                                                transport.disconnect(&endpoint_id).ok();
+                                            }
+                                        }
+                                    }
+                                    Err(e) => {
+                                        tracing::debug!(
+                                            "Failed to connect to discovered peer {}: {}",
+                                            peer.name,
+                                            e
+                                        );
+                                    }
                                 }
                             }
                         }
@@ -1066,6 +1161,14 @@ impl PeerDiscovery for IrohPeerDiscovery {
     async fn add_peer(&self, address: &str, _transport: TransportType) -> Result<()> {
         use crate::network::PeerInfo as NetworkPeerInfo;
 
+        // Get formation key for authentication
+        let formation_key = self
+            .formation_key
+            .read()
+            .unwrap()
+            .clone()
+            .ok_or_else(|| Error::Internal("Formation key not initialized".to_string()))?;
+
         let peer_info = NetworkPeerInfo {
             name: "manual-peer".to_string(),
             node_id: address.to_string(),
@@ -1073,7 +1176,9 @@ impl PeerDiscovery for IrohPeerDiscovery {
             relay_url: None,
         };
 
-        self.transport
+        // Connect to peer
+        let conn = self
+            .transport
             .connect_peer(&peer_info)
             .await
             .map_err(|e| Error::Network {
@@ -1081,6 +1186,26 @@ impl PeerDiscovery for IrohPeerDiscovery {
                 peer_id: None,
                 source: None,
             })?;
+
+        // Perform formation handshake to authenticate
+        #[cfg(feature = "automerge-backend")]
+        {
+            use crate::network::formation_handshake::perform_initiator_handshake;
+
+            if let Err(e) = perform_initiator_handshake(&conn, &formation_key).await {
+                // Authentication failed - disconnect
+                let endpoint_id = conn.remote_id();
+                conn.close(1u32.into(), b"authentication failed");
+                self.transport.disconnect(&endpoint_id).ok();
+
+                return Err(Error::Network {
+                    message: format!("Peer authentication failed: {}", e),
+                    peer_id: Some(address.to_string()),
+                    source: None,
+                });
+            }
+        }
+
         Ok(())
     }
 
@@ -1163,7 +1288,31 @@ impl SyncEngine for IrohSyncEngine {
 // DataSyncBackend implementation
 #[async_trait]
 impl DataSyncBackend for AutomergeIrohBackend {
-    async fn initialize(&self, _config: BackendConfig) -> Result<()> {
+    async fn initialize(&self, config: BackendConfig) -> Result<()> {
+        // Require shared_key for peer authentication
+        let shared_key = config.shared_key.as_ref().ok_or_else(|| {
+            Error::config_error(
+                "AutomergeIroh backend requires HIVE_SECRET_KEY (or DITTO_SHARED_KEY) for peer authentication",
+                Some("shared_key".to_string()),
+            )
+        })?;
+
+        // Create FormationKey from app_id (formation_id) and shared_key
+        // This ensures only peers with matching credentials can sync
+        let formation_key = crate::security::FormationKey::from_base64(&config.app_id, shared_key)
+            .map_err(|e| {
+                Error::config_error(
+                    format!(
+                        "Invalid shared_key format: {}. Expected base64-encoded 32-byte key.",
+                        e
+                    ),
+                    Some("shared_key".to_string()),
+                )
+            })?;
+
+        // Store the formation key for peer authentication
+        *self.formation_key.write().unwrap() = Some(formation_key);
+
         *self.initialized.lock().unwrap() = true;
         self.peer_discovery().start().await?;
         Ok(())
@@ -1190,6 +1339,8 @@ impl DataSyncBackend for AutomergeIrohBackend {
             peer_callbacks: Arc::clone(&self.peer_callbacks),
             #[cfg(feature = "automerge-backend")]
             discovery_manager: Arc::clone(&self.discovery_manager),
+            #[cfg(feature = "automerge-backend")]
+            formation_key: Arc::clone(&self.formation_key),
         })
     }
 
@@ -1279,12 +1430,14 @@ mod tests {
     use std::collections::HashMap;
     use std::path::PathBuf;
 
-    /// Helper: Create test BackendConfig
+    /// Helper: Create test BackendConfig with valid credentials
     fn test_config() -> BackendConfig {
+        // Generate a valid test secret key (base64-encoded 32 bytes)
+        let test_secret = crate::security::FormationKey::generate_secret();
         BackendConfig {
             app_id: "test_app".to_string(),
             persistence_dir: PathBuf::from("/tmp/automerge_test"),
-            shared_key: None,
+            shared_key: Some(test_secret),
             transport: TransportConfig::default(),
             extra: HashMap::new(),
         }
@@ -1405,5 +1558,111 @@ mod tests {
             .unwrap();
 
         assert!(retrieved.is_none());
+    }
+}
+
+/// Tests for AutomergeIrohBackend credential requirements
+#[cfg(all(test, feature = "automerge-backend"))]
+mod iroh_credential_tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    /// Test that AutomergeIrohBackend initialization fails without shared_key
+    #[tokio::test]
+    async fn test_automerge_iroh_requires_credentials() {
+        // Create backend components
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(crate::storage::AutomergeStore::open(temp_dir.path()).unwrap());
+        let transport = Arc::new(crate::network::IrohTransport::new().await.unwrap());
+
+        let backend = AutomergeIrohBackend::from_parts(store, transport);
+
+        // Config without shared_key should fail
+        let config = BackendConfig {
+            app_id: "test_app".to_string(),
+            persistence_dir: PathBuf::from("/tmp/test"),
+            shared_key: None, // Missing!
+            transport: TransportConfig::default(),
+            extra: HashMap::new(),
+        };
+
+        let result = backend.initialize(config).await;
+        assert!(result.is_err());
+
+        let error = result.unwrap_err();
+        let error_msg = error.to_string();
+        assert!(
+            error_msg.contains("HIVE_SECRET_KEY") || error_msg.contains("shared_key"),
+            "Error should mention missing credentials: {}",
+            error_msg
+        );
+    }
+
+    /// Test that AutomergeIrohBackend initializes successfully with valid credentials
+    #[tokio::test]
+    async fn test_automerge_iroh_with_valid_credentials() {
+        // Create backend components
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(crate::storage::AutomergeStore::open(temp_dir.path()).unwrap());
+        let transport = Arc::new(crate::network::IrohTransport::new().await.unwrap());
+
+        let backend = AutomergeIrohBackend::from_parts(store, transport);
+
+        // Generate valid test credentials
+        let test_secret = crate::security::FormationKey::generate_secret();
+
+        let config = BackendConfig {
+            app_id: "test_formation".to_string(),
+            persistence_dir: temp_dir.path().to_path_buf(),
+            shared_key: Some(test_secret),
+            transport: TransportConfig::default(),
+            extra: HashMap::new(),
+        };
+
+        let result = backend.initialize(config).await;
+        assert!(result.is_ok(), "Should initialize with valid credentials");
+
+        // Verify formation key was stored
+        let formation_key = backend.formation_key();
+        assert!(
+            formation_key.is_some(),
+            "Formation key should be set after initialization"
+        );
+        assert_eq!(
+            formation_key.unwrap().formation_id(),
+            "test_formation",
+            "Formation ID should match app_id"
+        );
+    }
+
+    /// Test that invalid shared_key format is rejected
+    #[tokio::test]
+    async fn test_automerge_iroh_rejects_invalid_key_format() {
+        // Create backend components
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = Arc::new(crate::storage::AutomergeStore::open(temp_dir.path()).unwrap());
+        let transport = Arc::new(crate::network::IrohTransport::new().await.unwrap());
+
+        let backend = AutomergeIrohBackend::from_parts(store, transport);
+
+        // Invalid base64 key
+        let config = BackendConfig {
+            app_id: "test_app".to_string(),
+            persistence_dir: PathBuf::from("/tmp/test"),
+            shared_key: Some("not-valid-base64!!!".to_string()),
+            transport: TransportConfig::default(),
+            extra: HashMap::new(),
+        };
+
+        let result = backend.initialize(config).await;
+        assert!(result.is_err(), "Should reject invalid base64 key");
+
+        let error_msg = result.unwrap_err().to_string();
+        assert!(
+            error_msg.contains("Invalid shared_key format"),
+            "Error should mention invalid format: {}",
+            error_msg
+        );
     }
 }

--- a/hive-protocol/src/testing/e2e_harness.rs
+++ b/hive-protocol/src/testing/e2e_harness.rs
@@ -47,6 +47,10 @@ pub struct E2EHarness {
     pub name: String,
     /// Temporary directories for test isolation (kept alive for test duration)
     temp_dirs: Vec<tempfile::TempDir>,
+    /// Shared test secret for AutomergeIroh peer authentication
+    /// All backends created by this harness will share this secret
+    #[cfg(feature = "automerge-backend")]
+    test_secret: String,
 }
 
 impl E2EHarness {
@@ -55,6 +59,8 @@ impl E2EHarness {
         Self {
             name: name.into(),
             temp_dirs: Vec::new(),
+            #[cfg(feature = "automerge-backend")]
+            test_secret: crate::security::FormationKey::generate_secret(),
         }
     }
 
@@ -257,10 +263,11 @@ impl E2EHarness {
         let backend = Arc::new(AutomergeIrohBackend::from_parts(store, transport));
 
         // Initialize the backend with config (this also starts the accept loop via peer_discovery().start())
+        // All backends in this harness share the same test_secret for peer authentication
         let config = BackendConfig {
             app_id: "automerge-test".to_string(),
             persistence_dir: temp_dir.path().to_path_buf(),
-            shared_key: None,
+            shared_key: Some(self.test_secret.clone()),
             transport: TransportConfig::default(),
             extra: HashMap::new(),
         };

--- a/hive-protocol/tests/backend_agnostic_e2e.rs
+++ b/hive-protocol/tests/backend_agnostic_e2e.rs
@@ -718,3 +718,191 @@ async fn run_concurrent_updates_test<B: DataSyncBackend>(
         .await
         .expect("Should stop sync on backend2");
 }
+
+// ============================================================================
+// Security Tests - Credential-Based Access Control
+// ============================================================================
+
+/// Test that AutomergeIroh backends with DIFFERENT credentials cannot connect
+///
+/// This validates the FormationKey authentication:
+/// - Peers with different secret keys should be rejected
+/// - Connection should fail or be closed after handshake failure
+#[cfg(feature = "automerge-backend")]
+#[tokio::test]
+async fn test_automerge_different_credentials_rejected() {
+    use hive_protocol::network::IrohTransport;
+    use hive_protocol::security::FormationKey;
+    use hive_protocol::storage::AutomergeStore;
+    use hive_protocol::sync::automerge::AutomergeIrohBackend;
+    use hive_protocol::sync::types::{BackendConfig, TransportConfig};
+    use std::collections::HashMap;
+
+    println!("=== Security Test: Different Credentials Rejected ===\n");
+
+    // Create two separate temp directories
+    let temp_dir1 = tempfile::tempdir().unwrap();
+    let temp_dir2 = tempfile::tempdir().unwrap();
+
+    // Create two backends with DIFFERENT credentials
+    let secret1 = FormationKey::generate_secret();
+    let secret2 = FormationKey::generate_secret(); // Different secret!
+
+    println!("  Creating backend1 with secret1...");
+    let store1 = Arc::new(AutomergeStore::open(temp_dir1.path()).unwrap());
+    let transport1 = Arc::new(IrohTransport::new().await.unwrap());
+    let backend1 = Arc::new(AutomergeIrohBackend::from_parts(store1, transport1));
+
+    let config1 = BackendConfig {
+        app_id: "test-formation".to_string(),
+        persistence_dir: temp_dir1.path().to_path_buf(),
+        shared_key: Some(secret1),
+        transport: TransportConfig::default(),
+        extra: HashMap::new(),
+    };
+    backend1.initialize(config1).await.unwrap();
+
+    println!("  Creating backend2 with secret2 (DIFFERENT)...");
+    let store2 = Arc::new(AutomergeStore::open(temp_dir2.path()).unwrap());
+    let transport2 = Arc::new(IrohTransport::new().await.unwrap());
+    let backend2 = Arc::new(AutomergeIrohBackend::from_parts(store2, transport2));
+
+    let config2 = BackendConfig {
+        app_id: "test-formation".to_string(), // Same app_id
+        persistence_dir: temp_dir2.path().to_path_buf(),
+        shared_key: Some(secret2), // Different secret!
+        transport: TransportConfig::default(),
+        extra: HashMap::new(),
+    };
+    backend2.initialize(config2).await.unwrap();
+
+    // Try to connect backend1 -> backend2
+    println!("\n  Attempting connection with mismatched credentials...");
+
+    let addr2 = backend2.transport().endpoint_addr();
+    let transport1 = backend1.transport();
+
+    // The connection itself may succeed (QUIC level), but the handshake should fail
+    match transport1.connect(addr2).await {
+        Ok(conn) => {
+            // Connection established, now try handshake
+            use hive_protocol::network::formation_handshake::perform_initiator_handshake;
+
+            let formation_key1 = backend1.formation_key().expect("Should have formation key");
+
+            match perform_initiator_handshake(&conn, &formation_key1).await {
+                Ok(()) => {
+                    panic!("❌ SECURITY FAILURE: Handshake should have been rejected with different credentials!");
+                }
+                Err(e) => {
+                    println!("  ✓ Handshake correctly rejected: {}", e);
+                    // Close and remove the connection after failed handshake
+                    conn.close(1u32.into(), b"authentication failed");
+                    transport1.disconnect(&conn.remote_id()).ok();
+                }
+            }
+        }
+        Err(e) => {
+            // Connection failed - this is also acceptable
+            println!("  ✓ Connection rejected: {}", e);
+        }
+    }
+
+    // Verify no peers are connected
+    let connected_peers = backend1.transport().connected_peers();
+    assert!(
+        connected_peers.is_empty(),
+        "Backend1 should have no connected peers after rejected handshake"
+    );
+
+    println!("\n  ✅ Security test passed: Different credentials correctly rejected!\n");
+
+    // Cleanup
+    let _ = backend1.shutdown().await;
+    let _ = backend2.shutdown().await;
+}
+
+/// Test that AutomergeIroh backends with SAME credentials CAN connect
+///
+/// This is the positive case - confirming authentication works when credentials match
+#[cfg(feature = "automerge-backend")]
+#[tokio::test]
+async fn test_automerge_same_credentials_accepted() {
+    use hive_protocol::network::IrohTransport;
+    use hive_protocol::security::FormationKey;
+    use hive_protocol::storage::AutomergeStore;
+    use hive_protocol::sync::automerge::AutomergeIrohBackend;
+    use hive_protocol::sync::types::{BackendConfig, TransportConfig};
+    use std::collections::HashMap;
+
+    println!("=== Security Test: Same Credentials Accepted ===\n");
+
+    // Create two separate temp directories
+    let temp_dir1 = tempfile::tempdir().unwrap();
+    let temp_dir2 = tempfile::tempdir().unwrap();
+
+    // Create two backends with SAME credentials
+    let shared_secret = FormationKey::generate_secret();
+
+    println!("  Creating backend1 with shared_secret...");
+    let store1 = Arc::new(AutomergeStore::open(temp_dir1.path()).unwrap());
+    let transport1 = Arc::new(IrohTransport::new().await.unwrap());
+    let backend1 = Arc::new(AutomergeIrohBackend::from_parts(store1, transport1));
+
+    let config1 = BackendConfig {
+        app_id: "test-formation".to_string(),
+        persistence_dir: temp_dir1.path().to_path_buf(),
+        shared_key: Some(shared_secret.clone()),
+        transport: TransportConfig::default(),
+        extra: HashMap::new(),
+    };
+    backend1.initialize(config1).await.unwrap();
+
+    println!("  Creating backend2 with shared_secret (SAME)...");
+    let store2 = Arc::new(AutomergeStore::open(temp_dir2.path()).unwrap());
+    let transport2 = Arc::new(IrohTransport::new().await.unwrap());
+    let backend2 = Arc::new(AutomergeIrohBackend::from_parts(store2, transport2));
+
+    let config2 = BackendConfig {
+        app_id: "test-formation".to_string(),
+        persistence_dir: temp_dir2.path().to_path_buf(),
+        shared_key: Some(shared_secret), // Same secret!
+        transport: TransportConfig::default(),
+        extra: HashMap::new(),
+    };
+    backend2.initialize(config2).await.unwrap();
+
+    // Connect backend1 -> backend2
+    println!("\n  Attempting connection with matching credentials...");
+
+    let addr2 = backend2.transport().endpoint_addr();
+    let transport1_ref = backend1.transport();
+
+    let conn = transport1_ref
+        .connect(addr2)
+        .await
+        .expect("Should connect at QUIC level");
+
+    // Perform handshake
+    use hive_protocol::network::formation_handshake::perform_initiator_handshake;
+    let formation_key1 = backend1.formation_key().expect("Should have formation key");
+
+    perform_initiator_handshake(&conn, &formation_key1)
+        .await
+        .expect("Handshake should succeed with matching credentials");
+
+    println!("  ✓ Handshake succeeded with matching credentials");
+
+    // Verify peer is connected
+    let connected_peers = backend1.transport().connected_peers();
+    assert!(
+        !connected_peers.is_empty(),
+        "Backend1 should have connected peer after successful handshake"
+    );
+
+    println!("\n  ✅ Security test passed: Same credentials correctly accepted!\n");
+
+    // Cleanup
+    let _ = backend1.shutdown().await;
+    let _ = backend2.shutdown().await;
+}

--- a/hive-protocol/tests/multi_node_mesh_e2e.rs
+++ b/hive-protocol/tests/multi_node_mesh_e2e.rs
@@ -92,12 +92,36 @@ async fn test_automerge_three_node_mesh() {
 
     println!("  ✓ 3 backends created");
 
-    // Explicitly connect peers for Automerge (full mesh topology)
-    println!("  Connecting Automerge peers in full mesh...");
+    // Start peer discovery first (starts authenticated accept loops)
+    println!("  Starting peer discovery on all nodes...");
+    backend1
+        .peer_discovery()
+        .start()
+        .await
+        .expect("Should start discovery on backend1");
+    backend2
+        .peer_discovery()
+        .start()
+        .await
+        .expect("Should start discovery on backend2");
+    backend3
+        .peer_discovery()
+        .start()
+        .await
+        .expect("Should start discovery on backend3");
+    println!("  ✓ Peer discovery started");
 
-    // Get transports and endpoint IDs
+    // Give accept loops time to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    // Explicitly connect peers for Automerge (full mesh topology)
+    println!("  Connecting Automerge peers in full mesh with authentication...");
+
+    // Get transports, formation keys, and endpoint IDs
     let transport1 = backend1.transport();
     let transport2 = backend2.transport();
+    let formation_key1 = backend1.formation_key().expect("Should have formation key");
+    let formation_key2 = backend2.formation_key().expect("Should have formation key");
 
     let endpoint2_id = backend2.endpoint_id();
     let endpoint3_id = backend3.endpoint_id();
@@ -117,24 +141,37 @@ async fn test_automerge_three_node_mesh() {
         relay_url: None,
     };
 
-    // Full mesh: Connect each node to the other two
-    // Node 1 → Node 2, Node 3
-    transport1
+    // Full mesh: Connect each node to the other two with authenticated handshakes
+    use hive_protocol::network::formation_handshake::perform_initiator_handshake;
+
+    // Node 1 → Node 2
+    let conn1_2 = transport1
         .connect_peer(&peer2_info)
         .await
         .expect("Should connect node1 to node2");
-    transport1
+    perform_initiator_handshake(&conn1_2, &formation_key1)
+        .await
+        .expect("Should authenticate node1 to node2");
+
+    // Node 1 → Node 3
+    let conn1_3 = transport1
         .connect_peer(&peer3_info)
         .await
         .expect("Should connect node1 to node3");
+    perform_initiator_handshake(&conn1_3, &formation_key1)
+        .await
+        .expect("Should authenticate node1 to node3");
 
     // Node 2 → Node 3 (already connected to Node 1 from above)
-    transport2
+    let conn2_3 = transport2
         .connect_peer(&peer3_info)
         .await
         .expect("Should connect node2 to node3");
+    perform_initiator_handshake(&conn2_3, &formation_key2)
+        .await
+        .expect("Should authenticate node2 to node3");
 
-    println!("  ✓ Full mesh connected (3 connections)");
+    println!("  ✓ Full mesh connected with authentication (3 connections)");
 
     run_three_node_mesh_test(backend1, backend2, backend3, "Automerge+Iroh").await;
 }

--- a/hive-protocol/tests/peer_discovery_e2e.rs
+++ b/hive-protocol/tests/peer_discovery_e2e.rs
@@ -279,9 +279,13 @@ async fn test_e2e_discovery_and_connection() {
     let temp_a = TempDir::new().expect("Failed to create temp dir");
     let temp_b = TempDir::new().expect("Failed to create temp dir");
 
+    // Use specific bind addresses for deterministic connection
+    let addr_a: std::net::SocketAddr = "127.0.0.1:19501".parse().unwrap();
+    let addr_b: std::net::SocketAddr = "127.0.0.1:19502".parse().unwrap();
+
     // Create Node A
     let transport_a = Arc::new(
-        IrohTransport::new()
+        IrohTransport::bind(addr_a)
             .await
             .expect("Failed to create transport A"),
     );
@@ -293,7 +297,7 @@ async fn test_e2e_discovery_and_connection() {
 
     // Create Node B
     let transport_b = Arc::new(
-        IrohTransport::new()
+        IrohTransport::bind(addr_b)
             .await
             .expect("Failed to create transport B"),
     );
@@ -307,9 +311,9 @@ async fn test_e2e_discovery_and_connection() {
     let endpoint_a = transport_a.endpoint_id();
     let endpoint_b = transport_b.endpoint_id();
 
-    // Use dummy addresses since we're using Iroh's built-in relay/QUIC
-    let addrs_a: Vec<String> = vec![];
-    let addrs_b: Vec<String> = vec![];
+    // Use actual bind addresses for peer discovery
+    let addrs_a: Vec<String> = vec![addr_a.to_string()];
+    let addrs_b: Vec<String> = vec![addr_b.to_string()];
 
     // Configure Node A to discover Node B
     let peer_b_info = PeerInfo {
@@ -340,10 +344,13 @@ async fn test_e2e_discovery_and_connection() {
     use hive_protocol::sync::types::{BackendConfig, TransportConfig};
     use std::collections::HashMap;
 
+    // Generate shared test credentials - both nodes must share the same secret
+    let test_secret = hive_protocol::security::FormationKey::generate_secret();
+
     let config_a = BackendConfig {
         app_id: "test-app".to_string(),
         persistence_dir: temp_a.path().to_path_buf(),
-        shared_key: None,
+        shared_key: Some(test_secret.clone()),
         transport: TransportConfig::default(),
         extra: HashMap::new(),
     };
@@ -351,7 +358,7 @@ async fn test_e2e_discovery_and_connection() {
     let config_b = BackendConfig {
         app_id: "test-app".to_string(),
         persistence_dir: temp_b.path().to_path_buf(),
-        shared_key: None,
+        shared_key: Some(test_secret),
         transport: TransportConfig::default(),
         extra: HashMap::new(),
     };
@@ -493,10 +500,13 @@ async fn test_mdns_zero_config_discovery() {
     use hive_protocol::sync::types::{BackendConfig, TransportConfig};
     use std::collections::HashMap;
 
+    // Generate shared test credentials - both nodes must share the same secret
+    let test_secret = hive_protocol::security::FormationKey::generate_secret();
+
     let config_a = BackendConfig {
         app_id: "test-app-mdns".to_string(),
         persistence_dir: temp_a.path().to_path_buf(),
-        shared_key: None,
+        shared_key: Some(test_secret.clone()),
         transport: TransportConfig::default(),
         extra: HashMap::new(),
     };
@@ -504,7 +514,7 @@ async fn test_mdns_zero_config_discovery() {
     let config_b = BackendConfig {
         app_id: "test-app-mdns".to_string(),
         persistence_dir: temp_b.path().to_path_buf(),
-        shared_key: None,
+        shared_key: Some(test_secret),
         transport: TransportConfig::default(),
         extra: HashMap::new(),
     };


### PR DESCRIPTION
## Summary

- Implements credential-based access control for AutomergeIroh backend
- Peers can only connect if they share the same `HIVE_APP_ID` and `HIVE_SECRET_KEY`
- Adds FormationKey handshake to both accept and connect flows
- Includes E2E tests verifying credential enforcement

## Changes

### Core Authentication (sync/automerge.rs)
- Add `formation_key` field to `AutomergeIrohBackend` and `IrohPeerDiscovery`
- Require `shared_key` in `initialize()` - creates `FormationKey` for peer authentication
- Replace simple accept loop with authenticated version using `perform_responder_handshake()`
- Update discovery connect loop to perform `perform_initiator_handshake()`

### E2E Security Tests (backend_agnostic_e2e.rs)
- `test_automerge_different_credentials_rejected` - verifies handshake fails with mismatched secrets
- `test_automerge_same_credentials_accepted` - verifies handshake succeeds with matching secrets

### Test Harness (e2e_harness.rs)
- Add `test_secret` field to share credentials across test backends

### Documentation
- ADR-030: Multi-interface transport (documents Iroh's automatic interface handling)

## Test plan

- [x] `test_automerge_different_credentials_rejected` passes
- [x] `test_automerge_same_credentials_accepted` passes
- [x] `test_automerge_three_node_mesh` passes with authentication
- [x] `test_e2e_discovery_and_connection` passes
- [x] Full automerge-backend test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)