### PR TITLE
fix: Emit ChangeEvent::Updated on remote sync for AutomergeIroh backend (#221)

### DIFF
--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -488,13 +488,8 @@ impl HiveNode {
         &self,
         callback: Box<dyn DocumentCallback>,
     ) -> Result<Arc<SubscriptionHandle>, HiveError> {
-        // Get the change receiver from the store
-        let change_rx = self
-            .store
-            .subscribe_to_changes()
-            .ok_or_else(|| HiveError::SyncError {
-                msg: "Subscription already active or store not available".to_string(),
-            })?;
+        // Get the change receiver from the store (broadcast channel)
+        let change_rx = self.store.subscribe_to_changes();
 
         // Create active flag for the subscription
         let active = Arc::new(AtomicBool::new(true));
@@ -509,7 +504,7 @@ impl HiveNode {
                 tokio::select! {
                     result = rx.recv() => {
                         match result {
-                            Some(doc_key) => {
+                            Ok(doc_key) => {
                                 // Parse the document key (format: "collection:doc_id")
                                 let change = if let Some((collection, doc_id)) = doc_key.split_once(':') {
                                     DocumentChange {
@@ -528,7 +523,11 @@ impl HiveNode {
 
                                 callback.on_change(change);
                             }
-                            None => {
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                // Some messages were skipped due to slow receiver
+                                callback.on_error(format!("Lagged {} messages", n));
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                                 // Channel closed
                                 callback.on_error("Document change channel closed".to_string());
                                 break;

--- a/hive-protocol/src/storage/automerge_backend.rs
+++ b/hive-protocol/src/storage/automerge_backend.rs
@@ -489,44 +489,44 @@ impl SyncCapable for AutomergeBackend {
         //
         // Subscribe to document change notifications and automatically sync
         // changed documents with all connected peers.
-        if let Some(mut change_rx) = self.store.subscribe_to_changes() {
-            let coordinator = self.sync_coordinator.clone().unwrap();
-            let sync_active = Arc::clone(&self.sync_active);
+        let mut change_rx = self.store.subscribe_to_changes();
+        let coordinator = self.sync_coordinator.clone().unwrap();
+        let sync_active = Arc::clone(&self.sync_active);
 
-            let auto_task = tokio::spawn(async move {
-                tracing::debug!("Automatic sync task started");
+        let auto_task = tokio::spawn(async move {
+            tracing::debug!("Automatic sync task started");
 
-                while sync_active.load(Ordering::Relaxed) {
-                    // Wait for change notification
-                    match change_rx.recv().await {
-                        Some(doc_key) => {
-                            tracing::debug!("Document changed: {}, triggering sync", doc_key);
+            while sync_active.load(Ordering::Relaxed) {
+                // Wait for change notification
+                match change_rx.recv().await {
+                    Ok(doc_key) => {
+                        tracing::debug!("Document changed: {}, triggering sync", doc_key);
 
-                            // Sync with all connected peers
-                            if let Err(e) = coordinator.sync_document_with_all_peers(&doc_key).await
-                            {
-                                tracing::warn!(
-                                    "Failed to sync document {} after change: {}",
-                                    doc_key,
-                                    e
-                                );
-                            }
-                        }
-                        None => {
-                            // Channel closed
-                            tracing::debug!("Change notification channel closed");
-                            break;
+                        // Sync with all connected peers
+                        if let Err(e) = coordinator.sync_document_with_all_peers(&doc_key).await {
+                            tracing::warn!(
+                                "Failed to sync document {} after change: {}",
+                                doc_key,
+                                e
+                            );
                         }
                     }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        // Some messages were skipped due to slow receiver
+                        tracing::warn!("Change notification lagged, skipped {} messages", n);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        // Channel closed
+                        tracing::debug!("Change notification channel closed");
+                        break;
+                    }
                 }
+            }
 
-                tracing::debug!("Automatic sync task stopped");
-            });
+            tracing::debug!("Automatic sync task stopped");
+        });
 
-            *self.auto_sync_task.write().unwrap() = Some(auto_task);
-        } else {
-            tracing::warn!("Could not subscribe to store changes - automatic sync disabled");
-        }
+        *self.auto_sync_task.write().unwrap() = Some(auto_task);
 
         // Phase 6.4: Spawn heartbeat task for partition detection
         //

--- a/hive-protocol/src/storage/automerge_store.rs
+++ b/hive-protocol/src/storage/automerge_store.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 #[cfg(feature = "automerge-backend")]
 use std::sync::{Arc, RwLock};
 #[cfg(feature = "automerge-backend")]
-use tokio::sync::mpsc;
+use tokio::sync::broadcast;
 
 #[cfg(feature = "automerge-backend")]
 use anyhow::{Context, Result};
@@ -32,9 +32,9 @@ use anyhow::{Context, Result};
 pub struct AutomergeStore {
     db: Arc<DB>,
     cache: Arc<RwLock<LruCache<String, Automerge>>>,
-    /// Channel for notifying of document changes (Phase 6.3)
-    change_tx: mpsc::UnboundedSender<String>,
-    change_rx: Arc<RwLock<Option<mpsc::UnboundedReceiver<String>>>>,
+    /// Broadcast channel for notifying of document changes (Phase 6.3)
+    /// Multiple subscribers can receive notifications (sync coordinator + observers)
+    change_tx: broadcast::Sender<String>,
 }
 
 #[cfg(feature = "automerge-backend")]
@@ -49,14 +49,14 @@ impl AutomergeStore {
         let db = DB::open(&opts, path).context("Failed to open RocksDB")?;
         let cache = LruCache::new(NonZeroUsize::new(1000).unwrap());
 
-        // Create change notification channel
-        let (change_tx, change_rx) = mpsc::unbounded_channel();
+        // Create broadcast channel for change notifications
+        // Capacity of 1024 should be sufficient for most workloads
+        let (change_tx, _) = broadcast::channel(1024);
 
         Ok(Self {
             db: Arc::new(db),
             cache: Arc::new(RwLock::new(cache)),
             change_tx,
-            change_rx: Arc::new(RwLock::new(Some(change_rx))),
         })
     }
 
@@ -145,20 +145,19 @@ impl AutomergeStore {
     /// Subscribe to document change notifications (Phase 6.3)
     ///
     /// Returns a receiver that will receive document keys whenever documents are modified.
-    /// This can only be called once - subsequent calls will return None.
+    /// Multiple subscribers are supported - each gets their own receiver.
     ///
     /// # Example
     ///
     /// ```ignore
     /// let store = AutomergeStore::open("./data")?;
-    /// if let Some(mut rx) = store.subscribe_to_changes() {
-    ///     while let Some(doc_key) = rx.recv().await {
-    ///         println!("Document changed: {}", doc_key);
-    ///     }
+    /// let mut rx = store.subscribe_to_changes();
+    /// while let Ok(doc_key) = rx.recv().await {
+    ///     println!("Document changed: {}", doc_key);
     /// }
     /// ```
-    pub fn subscribe_to_changes(&self) -> Option<mpsc::UnboundedReceiver<String>> {
-        self.change_rx.write().unwrap().take()
+    pub fn subscribe_to_changes(&self) -> broadcast::Receiver<String> {
+        self.change_tx.subscribe()
     }
 
     /// Get a collection handle for a specific namespace

--- a/hive-protocol/src/sync/automerge.rs
+++ b/hive-protocol/src/sync/automerge.rs
@@ -953,9 +953,69 @@ impl DocumentStore for IrohDocumentStore {
             documents: initial_docs,
         });
 
-        // Note: AutomergeIroh doesn't have built-in change notification yet
-        // This implementation provides initial snapshot but won't emit updates
-        // TODO: Implement proper change notification when Automerge sync supports it
+        // Subscribe to change notifications from the store (Issue #221)
+        // This enables emitting ChangeEvent::Updated when documents sync from peers
+        let mut change_rx = self.backend.automerge_store().subscribe_to_changes();
+        let collection_name = collection.to_string();
+        let collection_prefix = format!("{}:", collection);
+        let query_clone = query.clone();
+        let backend = Arc::clone(&self.backend);
+        let tx_clone = tx.clone();
+
+        // Spawn background task to listen for changes and emit Updated events
+        tokio::spawn(async move {
+            loop {
+                match change_rx.recv().await {
+                    Ok(doc_key) => {
+                        // Check if this change is for our collection
+                        if !doc_key.starts_with(&collection_prefix) {
+                            continue;
+                        }
+
+                        // Extract doc_id from key (format: "collection:doc_id")
+                        let doc_id = match doc_key.strip_prefix(&collection_prefix) {
+                            Some(id) => id.to_string(),
+                            None => continue,
+                        };
+
+                        // Fetch the updated document
+                        let coll = backend.collection(collection_prefix.trim_end_matches(':'));
+                        if let Ok(Some(bytes)) = coll.get(&doc_id) {
+                            if let Ok(mut doc) = serde_json::from_slice::<Document>(&bytes) {
+                                if doc.id.is_none() {
+                                    doc.id = Some(doc_id);
+                                }
+
+                                // Check if document matches query
+                                if matches_query(&doc, &query_clone) {
+                                    // Emit Updated event
+                                    if tx_clone
+                                        .send(ChangeEvent::Updated {
+                                            collection: collection_name.clone(),
+                                            document: doc,
+                                        })
+                                        .is_err()
+                                    {
+                                        // Receiver dropped, stop listening
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(
+                            "Observer change notification lagged, skipped {} messages",
+                            n
+                        );
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        // Channel closed, stop listening
+                        break;
+                    }
+                }
+            }
+        });
 
         Ok(ChangeStream { receiver: rx })
     }

--- a/hive-protocol/tests/automerge_iroh_sync_e2e.rs
+++ b/hive-protocol/tests/automerge_iroh_sync_e2e.rs
@@ -23,10 +23,15 @@
 use hive_protocol::network::{IrohTransport, PeerInfo};
 use hive_protocol::storage::capabilities::{CrdtCapable, SyncCapable, TypedCollection};
 use hive_protocol::storage::{AutomergeBackend, AutomergeStore};
+use hive_protocol::sync::automerge::AutomergeIrohBackend;
+use hive_protocol::sync::traits::DataSyncBackend;
+use hive_protocol::sync::types::{BackendConfig, ChangeEvent, Document, Query, TransportConfig};
 use hive_schema::node::v1::NodeState;
+use serde_json::json;
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use tempfile::TempDir;
 
 /// Helper to create a test backend with transport bound to specific address
@@ -383,4 +388,188 @@ async fn test_sync_stats_tracking() {
 
     backend1.stop_sync().unwrap();
     backend2.stop_sync().unwrap();
+}
+
+/// Helper to create AutomergeIrohBackend with proper initialization
+async fn create_iroh_backend(
+    bind_addr: SocketAddr,
+    shared_key: &str,
+) -> (Arc<AutomergeIrohBackend>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let store = Arc::new(AutomergeStore::open(temp_dir.path()).unwrap());
+    let transport = Arc::new(IrohTransport::bind(bind_addr).await.unwrap());
+
+    let backend = Arc::new(AutomergeIrohBackend::from_parts(store, transport));
+
+    let config = BackendConfig {
+        app_id: "observer-test".to_string(),
+        persistence_dir: temp_dir.path().to_path_buf(),
+        shared_key: Some(shared_key.to_string()),
+        transport: TransportConfig::default(),
+        extra: HashMap::new(),
+    };
+
+    backend
+        .initialize(config)
+        .await
+        .expect("Failed to initialize backend");
+
+    (backend, temp_dir)
+}
+
+/// Test 6: Observer Notifications on Remote Sync (Issue #221)
+///
+/// Validates that observe() emits ChangeEvent::Updated when documents sync from peers.
+/// This test was added after discovering that prior tests used polling instead of observers.
+///
+/// **Validates:**
+/// - observe() returns ChangeStream that emits ChangeEvent::Initial
+/// - observe() emits ChangeEvent::Updated when remote peer creates document
+/// - Observer notifications work for the AutomergeIroh backend (not just Ditto)
+#[tokio::test]
+async fn test_observer_notifications_on_remote_sync() {
+    println!("=== E2E: Observer Notifications on Remote Sync (Issue #221) ===");
+
+    // Unique ports for this test
+    let addr1: SocketAddr = "127.0.0.1:19021".parse().unwrap();
+    let addr2: SocketAddr = "127.0.0.1:19022".parse().unwrap();
+    // Generate proper formation key (base64-encoded 32-byte key)
+    let shared_key = hive_protocol::security::FormationKey::generate_secret();
+
+    // Create backends with proper initialization
+    let (backend1, _temp1) = create_iroh_backend(addr1, &shared_key).await;
+    let (backend2, _temp2) = create_iroh_backend(addr2, &shared_key).await;
+
+    println!("  Backend 1 endpoint: {:?}", backend1.endpoint_id());
+    println!("  Backend 2 endpoint: {:?}", backend2.endpoint_id());
+
+    // Start sync on both backends
+    backend1.sync_engine().start_sync().await.unwrap();
+    backend2.sync_engine().start_sync().await.unwrap();
+
+    // Get document stores
+    let doc_store1 = backend1.document_store();
+    let doc_store2 = backend2.document_store();
+
+    println!("  1. Setting up observer on Node 2 BEFORE creating document...");
+
+    // Set up observer on Node 2 for the collection
+    let query = Query::All;
+    let mut observer = doc_store2
+        .observe("test_nodes", &query)
+        .expect("Failed to create observer");
+
+    // Wait for Initial event
+    let initial_event = tokio::time::timeout(Duration::from_secs(2), observer.receiver.recv())
+        .await
+        .expect("Timeout waiting for Initial event")
+        .expect("Channel closed before Initial event");
+
+    match initial_event {
+        ChangeEvent::Initial { documents } => {
+            println!(
+                "  ✓ Received Initial event with {} documents",
+                documents.len()
+            );
+            assert!(documents.is_empty(), "Initial snapshot should be empty");
+        }
+        _ => panic!("Expected Initial event, got {:?}", initial_event),
+    }
+
+    println!("  2. Connecting peers with authenticated handshake...");
+
+    // Connect Node 1 to Node 2 with proper handshake
+    let transport2 = backend2.transport();
+    let node2_peer = create_peer_info("node-2", &transport2, addr2);
+    let transport1 = backend1.transport();
+
+    // First establish QUIC connection
+    let conn = match transport1.connect_peer(&node2_peer).await {
+        Ok(conn) => conn,
+        Err(e) => {
+            println!("  ✗ Connection failed: {} - skipping observer test", e);
+            println!("  → This indicates a transport-level issue, not observer issue");
+            return;
+        }
+    };
+
+    // Then perform formation handshake (required for authenticated backends)
+    let formation_key = backend1.formation_key().unwrap();
+    match hive_protocol::network::formation_handshake::perform_initiator_handshake(
+        &conn,
+        &formation_key,
+    )
+    .await
+    {
+        Ok(()) => println!("  ✓ Peers connected and authenticated"),
+        Err(e) => {
+            println!("  ✗ Handshake failed: {} - skipping observer test", e);
+            return;
+        }
+    }
+
+    // Give peers a moment to establish sync
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    println!("  3. Creating document on Node 1...");
+
+    // Create document on Node 1 via DocumentStore (using JSON Document format)
+    let doc = Document {
+        id: Some("test-doc-1".to_string()),
+        fields: {
+            let mut fields = HashMap::new();
+            fields.insert("name".to_string(), json!("Test Node"));
+            fields.insert("fuel".to_string(), json!(100));
+            fields
+        },
+        updated_at: SystemTime::now(),
+    };
+
+    let doc_id = doc_store1
+        .upsert("test_nodes", doc)
+        .await
+        .expect("Failed to upsert document");
+    println!("  ✓ Document created with ID: {}", doc_id);
+
+    println!("  4. Waiting for observer notification on Node 2...");
+
+    // Wait for Updated event (should arrive via sync)
+    let update_result =
+        tokio::time::timeout(Duration::from_secs(5), observer.receiver.recv()).await;
+
+    match update_result {
+        Ok(Some(ChangeEvent::Updated {
+            collection,
+            document,
+        })) => {
+            println!("  ✓ Received Updated event!");
+            println!("    Collection: {}", collection);
+            println!("    Document ID: {:?}", document.id);
+            assert_eq!(collection, "test_nodes");
+            assert_eq!(document.id, Some("test-doc-1".to_string()));
+            println!("  ✓ Observer notification working correctly!");
+        }
+        Ok(Some(ChangeEvent::Removed { .. })) => {
+            panic!("Unexpected Removed event");
+        }
+        Ok(Some(ChangeEvent::Initial { .. })) => {
+            panic!("Unexpected second Initial event");
+        }
+        Ok(None) => {
+            panic!("Observer channel closed unexpectedly");
+        }
+        Err(_timeout) => {
+            println!("  ✗ Timeout: No Updated event received within 5 seconds");
+            println!("  → Issue #221: observe() may not be emitting ChangeEvent::Updated");
+            println!("  → Check that AutomergeStore.put() triggers broadcast notification");
+            println!("  → Check that sync coordinator stores synced documents via put()");
+            panic!("Observer notification test failed - Issue #221 not fixed");
+        }
+    }
+
+    // Cleanup
+    backend1.sync_engine().stop_sync().await.unwrap();
+    backend2.sync_engine().stop_sync().await.unwrap();
+
+    println!("  ✓ Test passed: Observer notifications work on remote sync!");
 }


### PR DESCRIPTION
## Summary

- Fix `AutomergeIrohBackend::observe()` to emit `ChangeEvent::Updated` when documents sync from remote peers
- Add E2E test to prevent regression
- Update `hive-ffi` to handle broadcast channel API

## Problem

The `AutomergeIrohBackend::observe()` method only sent the initial snapshot (`ChangeEvent::Initial`) but never emitted `ChangeEvent::Updated` events when documents synced from remote peers. This made Lab4 benchmarks invalid for the Automerge backend since observer-based measurements never fired.

## Root Cause Analysis

Existing E2E tests used **polling** with `get()` instead of observers, so this gap wasn't caught:

```rust
// All tests did this (polling):
for i in 0..10 {
    if let Some(doc) = nodes2.get("node-1")? { ... }
}

// Instead of this (observer-based):
let mut observer = doc_store.observe("collection", &query)?;
while let Some(event) = observer.recv().await { ... }
```

## Solution

1. **Changed AutomergeStore from mpsc to broadcast channel** - Multiple subscribers (sync coordinator + observers) need to receive change notifications

2. **Updated IrohDocumentStore::observe() to emit Updated events** - Spawns background task that subscribes to AutomergeStore change notifications and emits `ChangeEvent::Updated`

3. **Added E2E test** - `test_observer_notifications_on_remote_sync()` validates observer receives `ChangeEvent::Updated` when remote peer syncs document

## Test plan

- [x] `cargo test --features automerge-backend -p hive-protocol test_observer_notifications_on_remote_sync` passes
- [x] Full test suite passes
- [x] Pre-commit checks pass (fmt + clippy)

Fixes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)