### PR TITLE
feat: Add standards-ready spec/ and governance/ structure

### DIFF
--- a/governance/CHARTER.md
+++ b/governance/CHARTER.md
@@ -1,0 +1,197 @@
+# HIVE Protocol Project Charter
+
+## 1. Mission
+
+The HIVE Protocol project exists to develop and maintain an open standard for hierarchical coordination of autonomous systems, enabling scalable, partition-tolerant coordination across defense, commercial, and research applications.
+
+## 2. Vision
+
+A world where autonomous systems from any vendor, nation, or organization can coordinate effectively using a common, open protocol—reducing integration costs, enabling interoperability, and accelerating innovation.
+
+## 3. Principles
+
+### 3.1 Open Standards
+
+- The specification is freely available (CC0/CC BY licensed)
+- Anyone can implement the protocol without licensing fees
+- Multiple implementations ensure ecosystem health
+
+### 3.2 Technical Excellence
+
+- Decisions are driven by technical merit and evidence
+- Claims require validation through experimentation
+- Flaky tests and unverified claims are unacceptable
+
+### 3.3 Inclusive Collaboration
+
+- Contributions are welcome from individuals, companies, and governments
+- Merit-based advancement regardless of affiliation
+- Transparent decision-making processes
+
+### 3.4 Practical Utility
+
+- The protocol must solve real operational problems
+- Standards must be implementable on constrained platforms
+- Complexity is justified only by operational need
+
+## 4. Scope
+
+### 4.1 In Scope
+
+- Protocol specification development and maintenance
+- Reference implementation development
+- Conformance test suite development
+- Documentation and educational materials
+- Interoperability testing and certification
+- Standards body submissions (IETF, NATO, etc.)
+
+### 4.2 Out of Scope
+
+- Specific platform integrations (except as examples)
+- Proprietary extensions incompatible with the standard
+- Military doctrine or tactics development
+- Weapon system development
+
+## 5. Governance Structure
+
+### 5.1 Project Lead
+
+The Project Lead provides technical direction and makes final decisions when consensus cannot be reached.
+
+**Current Project Lead**: Kit Plummer (kit@revolveteam.com)
+
+### 5.2 Contributors
+
+Anyone who contributes to the project through:
+- Code contributions
+- Documentation improvements
+- Bug reports and feature requests
+- Testing and validation
+- Specification review and feedback
+
+### 5.3 Maintainers
+
+Contributors who have demonstrated:
+- Sustained, quality contributions
+- Understanding of project goals and architecture
+- Commitment to collaborative development
+
+Maintainers have commit access and participate in design decisions.
+
+### 5.4 Technical Steering Committee (Future)
+
+When the project reaches sufficient scale, a Technical Steering Committee will be formed to:
+- Guide technical direction
+- Resolve design disputes
+- Approve specification changes
+- Manage standards submissions
+
+## 6. Decision Making
+
+### 6.1 Consensus-Seeking
+
+Decisions are made through consensus-seeking:
+
+1. Proposal is submitted (GitHub issue or RFC)
+2. Community discussion and feedback
+3. Iteration based on feedback
+4. Call for consensus
+5. If consensus, decision is adopted
+6. If not, escalation to Project Lead
+
+### 6.2 Specification Changes
+
+Changes to the normative specification require:
+
+1. RFC document describing the change
+2. Reference implementation demonstrating feasibility
+3. Review period (minimum 2 weeks)
+4. No unresolved objections from Maintainers
+
+### 6.3 Breaking Changes
+
+Breaking changes to the wire format require:
+
+1. New major version number
+2. Migration guide
+3. Extended review period (minimum 4 weeks)
+4. Explicit approval from Project Lead
+
+## 7. Intellectual Property
+
+### 7.1 Specification License
+
+- Specification documents: CC BY 4.0
+- Protocol Buffer definitions: CC0 1.0 (public domain)
+
+### 7.2 Implementation License
+
+- Reference implementation: MIT OR Apache-2.0
+- Contributors retain copyright, grant license to project
+
+### 7.3 Patent Policy
+
+See [PATENT_PLEDGE.md](PATENT_PLEDGE.md) for the project's patent commitment.
+
+Key points:
+- Patent grant for conforming implementations
+- Defensive termination for patent aggressors
+- Royalty-free for standards compliance
+
+## 8. Standards Strategy
+
+### 8.1 IETF Track
+
+1. Internet-Draft submission
+2. Working group adoption (if applicable)
+3. Standards track publication
+
+### 8.2 NATO Track
+
+1. Technical demonstrations with allied nations
+2. Study submission to NATO Standardization Office
+3. STANAG proposal development
+4. Ratification process
+
+### 8.3 Other Standards Bodies
+
+The project may engage with:
+- IEEE (robotics standards)
+- SAE (autonomous vehicle standards)
+- ISO (quality and safety standards)
+
+## 9. Code of Conduct
+
+All participants are expected to:
+
+- Be respectful and constructive
+- Focus on technical merit
+- Welcome newcomers
+- Assume good faith
+- Respect confidentiality when required
+
+Violations should be reported to the Project Lead.
+
+## 10. Amendments
+
+This charter may be amended by:
+
+1. Proposal submitted as GitHub issue
+2. Community discussion (minimum 2 weeks)
+3. Approval by Project Lead
+4. For major changes, approval by majority of Maintainers
+
+---
+
+## Document History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2025-12 | Initial charter |
+
+---
+
+## Contact
+
+- GitHub: https://github.com/kitplummer/hive
+- Email: kit@revolveteam.com

--- a/governance/CONTRIBUTING.md
+++ b/governance/CONTRIBUTING.md
@@ -1,0 +1,301 @@
+# Contributing to HIVE Protocol
+
+Thank you for your interest in contributing to the HIVE Protocol! This document provides guidelines for contributing to both the specification and the reference implementation.
+
+## Table of Contents
+
+1. [Ways to Contribute](#ways-to-contribute)
+2. [Getting Started](#getting-started)
+3. [Specification Contributions](#specification-contributions)
+4. [Code Contributions](#code-contributions)
+5. [Review Process](#review-process)
+6. [Style Guidelines](#style-guidelines)
+7. [Legal](#legal)
+
+---
+
+## Ways to Contribute
+
+### For Everyone
+
+- **Report bugs**: Found an issue? Open a GitHub issue with details
+- **Suggest features**: Have an idea? Start a discussion
+- **Improve documentation**: Typos, clarifications, examples welcome
+- **Test and validate**: Run the test suite, report flaky tests
+
+### For Developers
+
+- **Fix bugs**: Check issues labeled `good first issue` or `help wanted`
+- **Implement features**: Coordinate via issue before starting large work
+- **Write tests**: Increase coverage, especially E2E tests
+- **Review PRs**: Help review pending pull requests
+
+### For Researchers
+
+- **Validate claims**: Run experiments, publish results
+- **Propose improvements**: Back proposals with evidence
+- **Compare alternatives**: Benchmark against other approaches
+
+### For Standards Experts
+
+- **Review specification**: Check for ambiguity, inconsistency
+- **Suggest clarifications**: Where is the spec unclear?
+- **Alignment**: How does HIVE relate to existing standards?
+
+---
+
+## Getting Started
+
+### 1. Fork and Clone
+
+```bash
+git clone https://github.com/YOUR_USERNAME/hive.git
+cd hive
+```
+
+### 2. Set Up Development Environment
+
+```bash
+# Install Rust (1.70+)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Build
+cargo build
+
+# Run tests
+cargo test -- --test-threads=1
+```
+
+### 3. Create a Branch
+
+```bash
+git checkout -b feature/your-feature-name
+# or
+git checkout -b fix/issue-number-description
+```
+
+### 4. Make Changes
+
+- Follow the style guidelines below
+- Add tests for new functionality
+- Update documentation as needed
+
+### 5. Submit Pull Request
+
+```bash
+git push origin your-branch-name
+# Then open PR on GitHub
+```
+
+---
+
+## Specification Contributions
+
+### Location
+
+Specification content lives in `/spec/`:
+
+```
+spec/
+├── draft-hive-protocol-00.md   # Main specification
+├── proto/                       # Protocol Buffer definitions
+│   └── cap/v1/*.proto
+└── README.md
+```
+
+### Types of Spec Changes
+
+#### Editorial (Minor)
+
+- Typo fixes
+- Clarifications that don't change meaning
+- Formatting improvements
+
+Process: Direct PR, quick review
+
+#### Substantive (Major)
+
+- New protocol features
+- Changed semantics
+- Wire format modifications
+
+Process:
+1. Open issue describing proposed change
+2. Discussion period (2+ weeks)
+3. Draft RFC if significant
+4. Implementation proof-of-concept
+5. PR with specification change
+
+### RFC 2119 Language
+
+Use requirement keywords correctly:
+
+- **MUST** / **MUST NOT**: Absolute requirement
+- **SHOULD** / **SHOULD NOT**: Recommended
+- **MAY**: Optional
+
+### Versioning
+
+- Patch: Editorial, clarifications
+- Minor: Backward-compatible additions
+- Major: Breaking changes (new proto package version)
+
+---
+
+## Code Contributions
+
+### Repository Structure
+
+```
+hive/
+├── spec/                    # Normative specification (CC0/CC BY)
+├── reference/               # Reference implementation (MIT/Apache-2.0)
+│   └── rust/
+│       ├── hive-protocol/   # Core library
+│       ├── hive-mesh/       # Mesh management
+│       └── ...
+├── tools/                   # Utilities and testing tools
+├── labs/                    # Experiments
+└── governance/              # Project governance
+```
+
+### Code Quality
+
+All code contributions must:
+
+1. **Build without warnings**: `cargo build` clean
+2. **Pass all tests**: `cargo test -- --test-threads=1`
+3. **Pass linting**: `cargo clippy`
+4. **Be formatted**: `cargo fmt`
+
+### Testing Requirements
+
+- **Unit tests**: For new functions/modules
+- **Integration tests**: For component interactions
+- **E2E tests**: For distributed behavior (when applicable)
+
+**Critical**: Flaky tests are not acceptable. If a test fails intermittently, it must be fixed or removed before merge.
+
+### Pre-Commit Checklist
+
+```bash
+# Run all checks
+make pre-commit
+
+# Or individually:
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test -- --test-threads=1
+```
+
+---
+
+## Review Process
+
+### Pull Request Guidelines
+
+1. **Clear title**: Describe the change concisely
+2. **Description**: Explain what and why
+3. **Issue link**: Reference related issues
+4. **Small PRs**: Easier to review, faster to merge
+
+### Review Criteria
+
+Reviewers check for:
+
+- [ ] Correctness: Does it do what it claims?
+- [ ] Tests: Are changes tested?
+- [ ] Style: Does it follow guidelines?
+- [ ] Documentation: Are docs updated?
+- [ ] Security: Any security implications?
+- [ ] Performance: Any performance impact?
+
+### Approval Requirements
+
+- **Documentation/minor**: 1 maintainer approval
+- **Code changes**: 1 maintainer approval
+- **Spec changes**: 2 maintainer approvals + review period
+- **Breaking changes**: Project Lead approval
+
+### Merge Process
+
+1. All CI checks pass
+2. Required approvals obtained
+3. No unresolved conversations
+4. Squash and merge (clean history)
+
+---
+
+## Style Guidelines
+
+### Rust Code
+
+Follow the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/):
+
+- Use `rustfmt` defaults
+- Prefer explicit error handling over `unwrap()`
+- Document public APIs with `///` comments
+- Use meaningful variable names
+
+### Protocol Buffers
+
+- Use `snake_case` for field names
+- Use `SCREAMING_SNAKE_CASE` for enum values
+- Include comments explaining each message and field
+- Use RFC 2119 keywords in normative comments
+
+### Markdown
+
+- Use ATX-style headers (`#`)
+- One sentence per line (easier diffs)
+- Reference links at document end
+- Code blocks with language specifier
+
+### Git Commits
+
+Format:
+```
+type(scope): short description
+
+Longer explanation if needed.
+
+Fixes #123
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+---
+
+## Legal
+
+### Contributor License
+
+By contributing, you agree that:
+
+1. Your contributions are your original work
+2. You have the right to submit them
+3. You license them under the project's licenses:
+   - Specification: CC BY 4.0 / CC0 1.0
+   - Code: MIT OR Apache-2.0
+
+### Patent Grant
+
+Contributors grant a patent license consistent with [PATENT_PLEDGE.md](PATENT_PLEDGE.md).
+
+### Third-Party Code
+
+If including third-party code:
+
+1. Ensure license compatibility
+2. Preserve copyright notices
+3. Document the source
+
+---
+
+## Questions?
+
+- **GitHub Issues**: For bugs, features, questions
+- **GitHub Discussions**: For open-ended discussion
+- **Email**: kit@revolveteam.com
+
+Welcome to the HIVE community!

--- a/governance/PATENT_PLEDGE.md
+++ b/governance/PATENT_PLEDGE.md
@@ -1,0 +1,221 @@
+# HIVE Protocol Patent Pledge
+
+## Purpose
+
+This document establishes the intellectual property commitments for the HIVE Protocol, ensuring that the protocol can be freely implemented while protecting the ecosystem from patent aggression.
+
+## Patent Holdings
+
+(r)evolve, Inc. holds the following provisional patent applications related to the HIVE Protocol:
+
+### Provisional Application 1: Hierarchical Capability Composition
+
+**Title**: "Method and System for Hierarchical Capability Composition in Distributed Autonomous Systems Using Conflict-Free Replicated Data Types"
+
+**Key Claims**:
+- CRDT-based hierarchical aggregation achieving O(n log n) message complexity
+- Four composition patterns (additive, emergent, redundant, constraint)
+- Bandwidth reduction through differential hierarchical updates
+
+### Provisional Application 2: Authority-Weighted Leader Election
+
+**Title**: "Method and System for Authority-Weighted Leader Election in Human-Machine Teams with Dynamic Cognitive Load Adjustment"
+
+**Key Claims**:
+- Hybrid scoring combining military rank with technical capability
+- Configurable authority policies for human-machine teaming
+- Dynamic adjustment based on cognitive load and fatigue
+
+---
+
+## Patent Grant
+
+### Grant Terms
+
+Subject to the conditions below, (r)evolve, Inc. grants to any person or entity ("You") a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to:
+
+- **Make** implementations of the HIVE Protocol
+- **Have made** implementations of the HIVE Protocol
+- **Use** implementations of the HIVE Protocol
+- **Offer to sell** implementations of the HIVE Protocol
+- **Sell** implementations of the HIVE Protocol
+- **Import** implementations of the HIVE Protocol
+- **Otherwise transfer** implementations of the HIVE Protocol
+
+This grant covers any patent claims owned or controlled by (r)evolve, Inc. that are necessarily infringed by implementing the HIVE Protocol specification as published in the `/spec/` directory of the official repository.
+
+### Covered Uses
+
+This patent grant explicitly covers:
+
+| Use Case | Covered |
+|----------|---------|
+| Open source implementations (Apache 2.0, MIT, GPL, etc.) | ✅ Yes |
+| Commercial products implementing the specification | ✅ Yes |
+| Government/defense implementations | ✅ Yes |
+| Academic and research use | ✅ Yes |
+| NATO and allied nation implementations | ✅ Yes |
+| Interoperability testing and certification | ✅ Yes |
+| Derivative works that remain specification-compliant | ✅ Yes |
+
+### Excluded Uses
+
+This patent grant does NOT cover:
+
+| Use Case | Covered |
+|----------|---------|
+| Proprietary extensions incompatible with the specification | ❌ No |
+| Implementations that deviate from the specification | ❌ No |
+| Uses unrelated to the HIVE Protocol | ❌ No |
+| Patent assertion against HIVE implementations (see Defensive Termination) | ❌ No |
+
+---
+
+## Defensive Termination
+
+### Automatic Termination
+
+This patent grant automatically terminates with respect to You if You (or any entity You control, or any entity that controls You, or any entity under common control with You):
+
+1. **Initiate patent litigation** against any entity alleging that the HIVE Protocol, or any implementation thereof, infringes a patent; or
+
+2. **Assert patent claims** against any implementation of the HIVE Protocol in any legal proceeding; or
+
+3. **Acquire patents** with the intent to assert them against HIVE Protocol implementations.
+
+### Reinstatement
+
+Termination is permanent unless:
+
+1. The patent claims are withdrawn or dismissed within 60 days; and
+2. (r)evolve, Inc. provides written reinstatement (at sole discretion)
+
+### Scope of Termination
+
+Upon termination, You lose all rights under this grant. This does not affect the rights of others who have not triggered termination.
+
+---
+
+## Compatibility with Standards Bodies
+
+### IETF Compatibility
+
+This pledge is compatible with IETF IPR disclosure requirements:
+
+- Royalty-free licensing available
+- Non-discriminatory terms
+- Irrevocable commitment
+
+Upon IETF submission, (r)evolve, Inc. will file appropriate IPR disclosures.
+
+### NATO Compatibility
+
+This pledge supports NATO standardization:
+
+- Member nations may implement without licensing fees
+- Allied interoperability is explicitly permitted
+- No restrictions on government use
+
+### W3C/OWFa Compatibility
+
+This pledge aligns with W3C Patent Policy and Open Web Foundation Agreement principles:
+
+- Royalty-free
+- Non-exclusive
+- Non-discriminatory
+- Perpetual (subject to termination provisions)
+
+---
+
+## Commitments to the Community
+
+### No Submarine Patents
+
+(r)evolve, Inc. commits to:
+
+1. Disclose all patent applications related to HIVE Protocol
+2. Not acquire patents for offensive assertion against implementations
+3. Maintain this pledge for any future related patents
+
+### Open Ecosystem
+
+(r)evolve, Inc. commits to:
+
+1. Not use patents to create vendor lock-in
+2. Not discriminate between implementers
+3. Support multi-vendor, multi-national ecosystem
+
+### Transparency
+
+(r)evolve, Inc. commits to:
+
+1. Maintain this pledge publicly
+2. Provide reasonable notice of any changes
+3. Not retroactively modify terms for existing implementations
+
+---
+
+## Relationship to Code Licenses
+
+### Specification vs. Implementation
+
+| Component | License | Patent Status |
+|-----------|---------|---------------|
+| Specification (`/spec/`) | CC BY 4.0 / CC0 | Covered by this pledge |
+| Reference implementation (`/reference/`) | MIT OR Apache-2.0 | Apache 2.0 includes patent grant |
+| Third-party implementations | Implementer's choice | Covered by this pledge if spec-compliant |
+
+### Apache 2.0 Patent Grant
+
+The reference implementation uses Apache 2.0, which includes its own patent grant. This pledge supplements (does not replace) the Apache 2.0 grant.
+
+---
+
+## FAQ
+
+### Q: Can I make a commercial product using HIVE?
+
+**A**: Yes. Commercial use is explicitly permitted under this pledge, provided your implementation conforms to the specification.
+
+### Q: What if I add proprietary extensions?
+
+**A**: Extensions that remain compatible with the specification are covered. Extensions that break compatibility or create incompatible forks are not covered.
+
+### Q: Does this cover all CRDT-related patents?
+
+**A**: No. This covers only patents necessarily infringed by implementing the HIVE Protocol specification. It does not cover CRDT implementations in general (which are covered by their own patents, if any).
+
+### Q: What if a patent troll sues me?
+
+**A**: This pledge only covers (r)evolve, Inc.'s patents. We cannot make commitments for third parties. However, the defensive termination clause means patent aggressors lose their rights under this pledge.
+
+### Q: Can this pledge be revoked?
+
+**A**: The grant is irrevocable for implementations that exist as of the date of any change. New implementations may be subject to updated terms.
+
+---
+
+## Contact
+
+For questions about this patent pledge:
+
+- Email: kit@revolveteam.com
+- GitHub: https://github.com/kitplummer/hive/issues
+
+For legal questions, please consult your own legal counsel.
+
+---
+
+## Document History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2025-12 | Initial patent pledge |
+
+---
+
+## Legal Notice
+
+This document constitutes a binding commitment by (r)evolve, Inc. regarding the patents identified above. It is not legal advice. Recipients should consult their own legal counsel regarding their specific situations.
+
+HIVE Protocol is a trademark of (r)evolve, Inc. Use of the trademark is permitted for implementations that conform to the specification.

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,0 +1,36 @@
+# HIVE Protocol Governance
+
+This directory contains the governance documents for the HIVE Protocol project.
+
+## Documents
+
+| Document | Purpose |
+|----------|---------|
+| [CHARTER.md](CHARTER.md) | Project mission, principles, and governance structure |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | How to contribute to the project |
+| [PATENT_PLEDGE.md](PATENT_PLEDGE.md) | Intellectual property commitments |
+
+## Quick Links
+
+### For Contributors
+
+- Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started
+- Follow the [Code of Conduct](CHARTER.md#9-code-of-conduct)
+- Submit issues and PRs on [GitHub](https://github.com/kitplummer/hive)
+
+### For Implementers
+
+- Review [PATENT_PLEDGE.md](PATENT_PLEDGE.md) for IP terms
+- Specification in `/spec/` is your normative reference
+- Reference implementation in `/reference/` for guidance
+
+### For Standards Bodies
+
+- The specification (`/spec/`) is CC BY 4.0 / CC0 licensed
+- Protocol Buffers are public domain (CC0)
+- Patent pledge is compatible with IETF, NATO, W3C policies
+
+## Contact
+
+- GitHub Issues: [github.com/kitplummer/hive/issues](https://github.com/kitplummer/hive/issues)
+- Email: kit@revolveteam.com

--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -302,6 +302,7 @@ impl Drop for SubscriptionHandle {
 #[derive(uniffi::Object)]
 pub struct HiveNode {
     /// The sync backend with FormationKey authentication
+    #[allow(dead_code)] // Kept for potential future use in mesh operations
     sync_backend: Arc<AutomergeIrohBackend>,
     /// Storage backend for document operations
     storage_backend: Arc<RwLock<AutomergeBackend>>,
@@ -700,100 +701,6 @@ impl From<anyhow::Error> for HiveError {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_hive_version() {
-        let version = hive_version();
-        assert!(!version.is_empty());
-        assert!(version.contains('.'));
-    }
-
-    #[test]
-    fn test_encode_track() {
-        let track = TrackData {
-            track_id: "track-001".to_string(),
-            source_platform: "platform-1".to_string(),
-            position: Position {
-                lat: 34.0522,
-                lon: -118.2437,
-                hae: Some(100.0),
-            },
-            velocity: Some(Velocity {
-                bearing: 90.0,
-                speed_mps: 10.0,
-            }),
-            classification: "a-f-G-U-C".to_string(),
-            confidence: 0.95,
-            cell_id: Some("cell-1".to_string()),
-            formation_id: None,
-        };
-
-        let result = encode_track_to_cot(track);
-        assert!(result.is_ok());
-
-        let xml = result.unwrap();
-        assert!(xml.contains("<event"));
-        assert!(xml.contains("track-001"));
-    }
-
-    #[test]
-    fn test_encode_minimal_track() {
-        let track = TrackData {
-            track_id: "t1".to_string(),
-            source_platform: "p1".to_string(),
-            position: Position {
-                lat: 0.0,
-                lon: 0.0,
-                hae: None,
-            },
-            velocity: None,
-            classification: "a-u-G".to_string(),
-            confidence: 0.5,
-            cell_id: None,
-            formation_id: None,
-        };
-
-        let result = encode_track_to_cot(track);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_invalid_track_id() {
-        let track = TrackData {
-            track_id: "".to_string(), // Empty - should fail
-            source_platform: "p1".to_string(),
-            position: Position {
-                lat: 0.0,
-                lon: 0.0,
-                hae: None,
-            },
-            velocity: None,
-            classification: "a-u-G".to_string(),
-            confidence: 0.5,
-            cell_id: None,
-            formation_id: None,
-        };
-
-        let result = encode_track_to_cot(track);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_helper_functions() {
-        let pos = create_position(34.0, -118.0, Some(50.0));
-        assert_eq!(pos.lat, 34.0);
-        assert_eq!(pos.lon, -118.0);
-        assert_eq!(pos.hae, Some(50.0));
-
-        let vel = create_velocity(45.0, 15.0);
-        assert_eq!(vel.bearing, 45.0);
-        assert_eq!(vel.speed_mps, 15.0);
-    }
-}
-
 // =============================================================================
 // JNI Bindings - Direct Android native method support
 // =============================================================================
@@ -820,7 +727,7 @@ mod tests {
 /// Kotlin signature: external fun hiveVersion(): String
 #[no_mangle]
 pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_hiveVersion(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
 ) -> jstring {
     let version = hive_version();
@@ -834,7 +741,7 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_hiveVersion(
 /// Kotlin signature: external fun testJni(): String
 #[no_mangle]
 pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_testJni(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
 ) -> jstring {
     let msg = "JNI bindings working! HIVE FFI loaded successfully.";
@@ -849,12 +756,13 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_testJni(
 #[cfg(feature = "sync")]
 #[no_mangle]
 pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_createNodeJni(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
     app_id: JString,
     shared_key: JString,
     storage_path: JString,
 ) -> i64 {
+    let mut env = env;
     let app_id: String = match env.get_string(&app_id) {
         Ok(s) => s.into(),
         Err(_) => return 0,
@@ -888,9 +796,9 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_createNodeJni(
             // Return the Arc pointer as a handle
             Arc::into_raw(node) as i64
         }
-        Err(e) => {
+        Err(_e) => {
             #[cfg(target_os = "android")]
-            android_log(&format!("createNodeJni: Error creating node: {:?}", e));
+            android_log(&format!("createNodeJni: Error creating node: {:?}", _e));
             0
         }
     }
@@ -902,7 +810,7 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_createNodeJni(
 #[cfg(feature = "sync")]
 #[no_mangle]
 pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_nodeIdJni(
-    mut env: JNIEnv,
+    env: JNIEnv,
     _class: JClass,
     handle: i64,
 ) -> jstring {
@@ -1011,9 +919,10 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_freeNodeJni(
 /// ```
 #[no_mangle]
 pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_nativeInit(
-    mut env: JNIEnv,
+    env: JNIEnv,
     class: JClass,
 ) {
+    let mut env = env;
     use jni::NativeMethod;
 
     let methods: Vec<NativeMethod> = vec![
@@ -1060,7 +969,7 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_nativeInit(
     ];
 
     // Register native methods - the class is passed in from Kotlin so it's valid
-    if let Err(e) = env.register_native_methods(&class, &methods) {
+    if let Err(_e) = env.register_native_methods(&class, &methods) {
         // Log error but don't crash - caller will see methods not registered
         let _ = env.exception_describe();
         let _ = env.exception_clear();
@@ -1071,9 +980,14 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_nativeInit(
 ///
 /// This is our chance to register native methods while we have access to
 /// the JNI environment from inside the library's linker namespace.
+///
+/// # Safety
+///
+/// This function dereferences raw pointers passed from the JVM.
+/// It is only safe to call from the JVM's library loading mechanism.
 #[no_mangle]
 #[allow(non_snake_case)]
-pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
+pub unsafe extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
     // Log that we're being called
     #[cfg(target_os = "android")]
     {
@@ -1081,14 +995,14 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
     }
 
     // Get JNIEnv from JavaVM
-    let mut env = unsafe {
+    let mut env = {
         let mut env_ptr: *mut jni::sys::JNIEnv = std::ptr::null_mut();
-        let get_env_result = (**vm).GetEnv.unwrap()(
+        let get_env_result = (*(*vm)).GetEnv.unwrap()(
             vm,
             &mut env_ptr as *mut _ as *mut *mut c_void,
-            JNI_VERSION_1_6 as i32,
+            JNI_VERSION_1_6,
         );
-        if get_env_result != jni::sys::JNI_OK as i32 {
+        if get_env_result != jni::sys::JNI_OK {
             #[cfg(target_os = "android")]
             android_log("JNI_OnLoad: GetEnv failed");
             return jni::sys::JNI_ERR;
@@ -1203,5 +1117,103 @@ fn android_log(msg: &str) {
             fn __android_log_write(prio: i32, tag: *const c_char, text: *const c_char) -> i32;
         }
         __android_log_write(4, tag.as_ptr(), msg.as_ptr());
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hive_version() {
+        let version = hive_version();
+        assert!(!version.is_empty());
+        assert!(version.contains('.'));
+    }
+
+    #[test]
+    fn test_encode_track() {
+        let track = TrackData {
+            track_id: "track-001".to_string(),
+            source_platform: "platform-1".to_string(),
+            position: Position {
+                lat: 34.0522,
+                lon: -118.2437,
+                hae: Some(100.0),
+            },
+            velocity: Some(Velocity {
+                bearing: 90.0,
+                speed_mps: 10.0,
+            }),
+            classification: "a-f-G-U-C".to_string(),
+            confidence: 0.95,
+            cell_id: Some("cell-1".to_string()),
+            formation_id: None,
+        };
+
+        let result = encode_track_to_cot(track);
+        assert!(result.is_ok());
+
+        let xml = result.unwrap();
+        assert!(xml.contains("<event"));
+        assert!(xml.contains("track-001"));
+    }
+
+    #[test]
+    fn test_encode_minimal_track() {
+        let track = TrackData {
+            track_id: "t1".to_string(),
+            source_platform: "p1".to_string(),
+            position: Position {
+                lat: 0.0,
+                lon: 0.0,
+                hae: None,
+            },
+            velocity: None,
+            classification: "a-u-G".to_string(),
+            confidence: 0.5,
+            cell_id: None,
+            formation_id: None,
+        };
+
+        let result = encode_track_to_cot(track);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_invalid_track_id() {
+        let track = TrackData {
+            track_id: "".to_string(), // Empty - should fail
+            source_platform: "p1".to_string(),
+            position: Position {
+                lat: 0.0,
+                lon: 0.0,
+                hae: None,
+            },
+            velocity: None,
+            classification: "a-u-G".to_string(),
+            confidence: 0.5,
+            cell_id: None,
+            formation_id: None,
+        };
+
+        let result = encode_track_to_cot(track);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_helper_functions() {
+        let pos = create_position(34.0, -118.0, Some(50.0));
+        assert_eq!(pos.lat, 34.0);
+        assert_eq!(pos.lon, -118.0);
+        assert_eq!(pos.hae, Some(50.0));
+
+        let vel = create_velocity(45.0, 15.0);
+        assert_eq!(vel.bearing, 45.0);
+        assert_eq!(vel.speed_mps, 15.0);
     }
 }

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,97 @@
+# HIVE Protocol Specification
+
+This directory contains the **normative specification** for the Hierarchical Intelligence for Versatile Entities (HIVE) Protocol.
+
+## Purpose
+
+The contents of this directory define the **standard**—the protocol that any compliant implementation MUST follow. This specification is designed to be:
+
+1. **Implementation-agnostic**: Any language or platform can implement HIVE using these specifications
+2. **Testable**: Clear requirements enable conformance testing
+3. **Extensible**: Versioned schemas with backward compatibility guarantees
+
+## Directory Structure
+
+```
+spec/
+├── README.md                           # This file
+├── draft-hive-protocol-00.md           # Main protocol specification (RFC-style)
+├── proto/                              # Normative Protocol Buffer definitions
+│   └── cap/
+│       └── v1/
+│           ├── common.proto            # Common types
+│           ├── node.proto              # Node model
+│           ├── capability.proto        # Capability model
+│           ├── cell.proto              # Cell (squad) model
+│           ├── beacon.proto            # Discovery beacons
+│           ├── composition.proto       # Composition rules
+│           ├── hierarchy.proto         # Hierarchical aggregation
+│           ├── command.proto           # Command dissemination
+│           └── security.proto          # Security messages
+├── examples/                           # Normative message examples
+└── diagrams/                           # Specification diagrams
+```
+
+## Normative vs. Informative
+
+| Content | Location | Status |
+|---------|----------|--------|
+| Protocol specification | `spec/` | **Normative** - defines REQUIRED behavior |
+| Protocol Buffer schemas | `spec/proto/` | **Normative** - wire format definition |
+| Reference implementation | `reference/` | **Informative** - one valid implementation |
+| Architecture decisions | `docs/adr/` | **Informative** - design rationale |
+| Experiments | `labs/` | **Informative** - research and validation |
+
+## Versioning
+
+The specification follows [Semantic Versioning](https://semver.org/):
+
+- **Major version**: Breaking changes to wire format or protocol semantics
+- **Minor version**: Backward-compatible additions
+- **Patch version**: Clarifications and editorial changes
+
+Current version: **0.1.0** (Draft)
+
+## RFC 2119 Keywords
+
+This specification uses keywords as defined in [RFC 2119](https://tools.ietf.org/html/rfc2119):
+
+| Keyword | Meaning |
+|---------|---------|
+| **MUST** | Absolute requirement |
+| **MUST NOT** | Absolute prohibition |
+| **SHOULD** | Recommended but not required |
+| **SHOULD NOT** | Not recommended but not prohibited |
+| **MAY** | Optional |
+
+## License
+
+- **Specification documents** (`.md` files): [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/) - share and adapt with attribution
+- **Protocol Buffer definitions** (`.proto` files): [CC0 1.0](https://creativecommons.org/publicdomain/zero/1.0/) - public domain, no restrictions
+- **Reference implementation** (in `/reference/`): MIT OR Apache-2.0
+
+This licensing ensures anyone can implement the HIVE Protocol without legal barriers while maintaining attribution for the specification work.
+
+## Standards Track
+
+This specification is being developed with the goal of submission to:
+
+1. **IETF** - Internet-Draft for broader internet/networking community adoption
+2. **NATO** - STANAG proposal for defense interoperability (complements STANAG 4586, 7023)
+3. **Open standards recognition** - enabling multi-vendor, multi-national implementations
+
+## Related Documents
+
+| Document | Purpose |
+|----------|---------|
+| [draft-hive-protocol-00.md](draft-hive-protocol-00.md) | Main protocol specification |
+| [proto/README.md](proto/README.md) | Schema documentation |
+| [../governance/CHARTER.md](../governance/CHARTER.md) | Project governance |
+| [../governance/CONTRIBUTING.md](../governance/CONTRIBUTING.md) | Contribution guidelines |
+| [../governance/PATENT_PLEDGE.md](../governance/PATENT_PLEDGE.md) | IP commitments for implementers |
+
+## Contact
+
+For questions about this specification:
+- GitHub Issues: [github.com/kitplummer/hive/issues](https://github.com/kitplummer/hive/issues)
+- Email: kit@revolveteam.com

--- a/spec/diagrams/README.md
+++ b/spec/diagrams/README.md
@@ -1,0 +1,53 @@
+# HIVE Protocol Diagrams
+
+This directory contains normative diagrams for the HIVE Protocol specification.
+
+## Purpose
+
+These diagrams illustrate protocol concepts, message flows, and architectural patterns. They are referenced from the main specification document.
+
+## Planned Diagrams
+
+### Architecture
+
+- [ ] `three-phase-overview.svg` - Protocol phase diagram
+- [ ] `hierarchy-structure.svg` - Squad → Platoon → Company
+- [ ] `data-flow.svg` - Upward aggregation, downward commands
+
+### Message Flows
+
+- [ ] `discovery-flow.svg` - Beacon exchange sequence
+- [ ] `cell-formation-flow.svg` - Cell join protocol
+- [ ] `command-dissemination.svg` - Command and ack flow
+
+### CRDT Semantics
+
+- [ ] `crdt-types.svg` - CRDT type usage diagram
+- [ ] `conflict-resolution.svg` - LWW merge example
+
+### Composition
+
+- [ ] `composition-patterns.svg` - Four composition types
+- [ ] `emergent-capability.svg` - ISR chain example
+
+## Format
+
+Diagrams should be provided as:
+
+- **SVG** (preferred) - Scalable, editable
+- **PNG** - For compatibility (300 DPI minimum)
+
+Source files (if applicable):
+
+- Mermaid markdown
+- PlantUML
+- Draw.io XML
+
+## Contributing
+
+To add diagrams:
+
+1. Create source file and rendered output
+2. Use consistent styling (colors, fonts)
+3. Include in specification with figure reference
+4. Add entry to this README

--- a/spec/draft-hive-protocol-00.md
+++ b/spec/draft-hive-protocol-00.md
@@ -1,0 +1,640 @@
+# HIVE Protocol Specification
+
+```
+Internet-Draft                                              K. Plummer
+Intended Status: Standards Track                       (r)evolve, Inc.
+                                                           December 2025
+
+      Hierarchical Intelligence for Versatile Entities (HIVE) Protocol
+                        draft-hive-protocol-00
+```
+
+## Abstract
+
+This document specifies the Hierarchical Intelligence for Versatile Entities (HIVE) Protocol, a distributed coordination protocol for autonomous systems operating in constrained, partition-prone networks. HIVE enables scalable coordination through CRDT-based hierarchical capability composition, achieving O(n log n) message complexity while maintaining eventual consistency guarantees.
+
+## Status of This Memo
+
+This Internet-Draft is submitted in full conformance with the provisions of BCP 78 and BCP 79.
+
+Internet-Drafts are working documents of the Internet Engineering Task Force (IETF). Note that other groups may also distribute working documents as Internet-Drafts.
+
+## Copyright Notice
+
+This specification is released under CC BY 4.0. The Protocol Buffer definitions are released under CC0 1.0 (public domain).
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Terminology](#2-terminology)
+3. [Protocol Overview](#3-protocol-overview)
+4. [Node Model](#4-node-model)
+5. [Capability Model](#5-capability-model)
+6. [Phase 1: Discovery](#6-phase-1-discovery)
+7. [Phase 2: Cell Formation](#7-phase-2-cell-formation)
+8. [Phase 3: Hierarchical Operations](#8-phase-3-hierarchical-operations)
+9. [CRDT Semantics](#9-crdt-semantics)
+10. [Message Complexity Analysis](#10-message-complexity-analysis)
+11. [Security Considerations](#11-security-considerations)
+12. [IANA Considerations](#12-iana-considerations)
+13. [References](#13-references)
+
+---
+
+## 1. Introduction
+
+### 1.1 Problem Statement
+
+Autonomous systems operating in tactical environments face a fundamental coordination challenge: traditional all-to-all communication architectures exhibit O(n²) message complexity, causing network saturation at approximately 20 platforms on bandwidth-constrained links (9.6Kbps - 1Mbps).
+
+Existing approaches suffer from:
+
+- **Centralized architectures**: Single points of failure incompatible with partition-prone networks
+- **Consensus protocols** (Paxos, Raft): Require majority availability, fail during partitions
+- **Broadcast mesh**: O(n²) scaling limits practical deployment to small teams
+
+### 1.2 Solution Overview
+
+HIVE addresses these challenges through:
+
+1. **Hierarchical organization**: Bounded cells with elected leaders reduce message paths
+2. **CRDT-based state**: Eventual consistency without coordination overhead
+3. **Capability composition**: Team capabilities emerge from individual platform capabilities
+4. **Differential updates**: Only changes propagate, reducing bandwidth by 95%+
+
+### 1.3 Design Goals
+
+| Goal | Target |
+|------|--------|
+| Message complexity | O(n log n) vs O(n²) baseline |
+| Bandwidth reduction | 95%+ via differential updates |
+| Priority 1 latency | < 5 seconds through 4-level hierarchy |
+| Scale | 100+ nodes validated, 1000+ architected |
+| Partition tolerance | Full operation during network splits |
+
+### 1.4 Scope
+
+This specification defines:
+
+- Node and capability data models
+- Three-phase protocol operation (Discovery, Cell Formation, Hierarchical Operations)
+- CRDT semantics for state synchronization
+- Hierarchical aggregation and command dissemination
+- Message formats (Protocol Buffers)
+
+This specification does NOT define:
+
+- Transport layer binding (implementation-specific)
+- CRDT implementation details (use conforming CRDT library)
+- Physical/link layer requirements
+- Specific platform integrations
+
+---
+
+## 2. Terminology
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all capitals, as shown here.
+
+### 2.1 Protocol Terms
+
+| Term | Definition |
+|------|------------|
+| **Node** | A single platform (UAV, UGV, sensor, soldier system) participating in the HIVE mesh |
+| **Cell** | A bounded group of nodes (typically 5-8) with a single elected leader |
+| **Beacon** | Discovery broadcast message advertising node presence and capabilities |
+| **Capability** | A discrete function a node or cell can perform (sense, compute, relay, etc.) |
+| **Composition** | The process of aggregating individual capabilities into team capabilities |
+| **Phase** | One of three operational stages: Discovery, Cell, Hierarchy |
+
+### 2.2 CRDT Terms
+
+| Term | Definition |
+|------|------------|
+| **CRDT** | Conflict-free Replicated Data Type - data structure that can be replicated and updated independently with guaranteed convergence |
+| **LWW-Register** | Last-Writer-Wins Register - CRDT where most recent write (by timestamp) wins |
+| **G-Set** | Grow-only Set - CRDT supporting only additions, never removals |
+| **OR-Set** | Observed-Remove Set - CRDT supporting additions and removals |
+| **PN-Counter** | Positive-Negative Counter - CRDT supporting increment and decrement |
+
+### 2.3 Military Terms
+
+| Term | Definition |
+|------|------------|
+| **Squad** | Smallest tactical unit, typically 5-8 personnel/platforms (maps to Cell) |
+| **Platoon** | 3-4 squads, typically 24-32 personnel/platforms |
+| **Company** | 3-4 platoons, typically 96-128 personnel/platforms |
+| **Echelon** | Level in the military hierarchy |
+
+---
+
+## 3. Protocol Overview
+
+### 3.1 Three-Phase Operation
+
+HIVE operates in three sequential phases:
+
+```
+┌──────────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│   Phase 1:       │     │   Phase 2:       │     │   Phase 3:       │
+│   DISCOVERY      │ ──▶ │   CELL           │ ──▶ │   HIERARCHY      │
+│                  │     │                  │     │                  │
+│ • Beacon broadcast│     │ • Cell formation │     │ • Normal ops     │
+│ • Peer discovery │     │ • Leader election│     │ • Aggregation    │
+│ • Geohash bucket │     │ • Capability     │     │ • Commands       │
+│                  │     │   exchange       │     │ • Differential   │
+│                  │     │                  │     │   updates        │
+└──────────────────┘     └──────────────────┘     └──────────────────┘
+     O(√n)                    O(k²)                   O(n log n)
+```
+
+### 3.2 Phase Transitions
+
+Nodes MUST start in `PHASE_DISCOVERY`.
+
+Transitions:
+
+1. **DISCOVERY → CELL**: When node joins or forms a cell with sufficient members
+2. **CELL → HIERARCHY**: When cell has elected leader and is assigned to a zone
+3. **Regression**: Nodes MAY regress to earlier phases on partition recovery
+
+### 3.3 Data Flow Architecture
+
+```
+                    ┌─────────────────────────────────┐
+                    │         Company Summary         │
+                    │    (aggregated from platoons)   │
+                    └─────────────────────────────────┘
+                                    ▲
+                    ┌───────────────┴───────────────┐
+                    │                               │
+           ┌────────┴────────┐             ┌───────┴────────┐
+           │ Platoon Summary │             │ Platoon Summary│
+           │ (from squads)   │             │ (from squads)  │
+           └────────┬────────┘             └───────┬────────┘
+                    │                              │
+        ┌───────────┼───────────┐                  │
+        │           │           │                  │
+   ┌────┴────┐ ┌────┴────┐ ┌────┴────┐       ┌────┴────┐
+   │ Squad   │ │ Squad   │ │ Squad   │       │ Squad   │
+   │ Summary │ │ Summary │ │ Summary │       │ Summary │
+   └────┬────┘ └────┬────┘ └────┬────┘       └────┬────┘
+        │           │           │                 │
+     Nodes       Nodes       Nodes             Nodes
+```
+
+**Upward flow** (data/status): Individual state → Squad summary → Platoon summary → Company summary
+
+**Downward flow** (commands): Company → Platoons → Squads → Individual nodes
+
+---
+
+## 4. Node Model
+
+### 4.1 Node Structure
+
+A Node consists of static configuration (`NodeConfig`) and dynamic state (`NodeState`).
+
+```
+Node
+├── NodeConfig (immutable)
+│   ├── id: UUID v4 (REQUIRED)
+│   ├── platform_type: string (REQUIRED)
+│   ├── capabilities: [Capability] (REQUIRED, G-Set)
+│   ├── comm_range_m: float (OPTIONAL)
+│   ├── max_speed_mps: float (OPTIONAL)
+│   ├── operator_binding: HumanMachinePair (OPTIONAL)
+│   └── created_at: Timestamp (OPTIONAL)
+│
+└── NodeState (CRDT-backed)
+    ├── position: Position (REQUIRED, LWW-Register)
+    ├── fuel_minutes: uint32 (OPTIONAL, PN-Counter)
+    ├── health: HealthStatus (REQUIRED, LWW-Register)
+    ├── phase: Phase (REQUIRED, LWW-Register)
+    ├── cell_id: string (OPTIONAL, LWW-Register)
+    ├── zone_id: string (OPTIONAL, LWW-Register)
+    └── timestamp: Timestamp (REQUIRED)
+```
+
+### 4.2 Node Identity
+
+- Node `id` MUST be a valid UUID version 4
+- Node `id` MUST be unique across the entire mesh
+- Node `id` MUST NOT change during node lifetime
+
+### 4.3 Health Status
+
+Implementations MUST support the following health states:
+
+| Status | Value | Description |
+|--------|-------|-------------|
+| NOMINAL | 1 | Fully operational |
+| DEGRADED | 2 | Reduced capability but operational |
+| CRITICAL | 3 | Failure imminent, limited operations |
+| FAILED | 4 | Non-operational |
+
+Nodes with `FAILED` health SHOULD be excluded from:
+- Leader election candidates
+- Capability aggregation
+- Active mission assignment
+
+### 4.4 Human-Machine Teaming
+
+When a node has an associated human operator (`operator_binding`), the operator's rank and authority level affect:
+
+1. **Leader election scoring**: Higher rank/authority increases leadership score
+2. **Command authorization**: ROE may require specific authority levels
+3. **Cognitive load adjustment**: Degraded operator performance reduces effective authority
+
+---
+
+## 5. Capability Model
+
+### 5.1 Capability Types
+
+| Type | Value | Description |
+|------|-------|-------------|
+| SENSOR | 1 | Sensing: cameras, radar, sonar, SIGINT |
+| COMPUTE | 2 | Processing: inference, analysis |
+| COMMUNICATION | 3 | Relay, mesh networking, BLOS |
+| MOBILITY | 4 | Flight, ground movement, maritime |
+| PAYLOAD | 5 | Cargo, weapons, countermeasures |
+| EMERGENT | 6 | Created through composition |
+
+### 5.2 Capability Composition
+
+Cell leaders aggregate member capabilities using four composition patterns:
+
+#### 5.2.1 Additive Composition
+
+Sum individual capabilities:
+
+```
+team_capability = Σ individual_capabilities
+```
+
+Example: Total sensor coverage = sum of individual coverage areas
+
+#### 5.2.2 Emergent Composition
+
+New capabilities from combinations:
+
+```
+IF (sensor ∈ team AND compute ∈ team AND comms ∈ team)
+THEN team.add(ISR_Chain)
+```
+
+Example: ISR chain emerges when team has sensor, compute, and communications
+
+#### 5.2.3 Redundant Composition
+
+Improved reliability through overlap:
+
+```
+team_reliability = 1 - Π(1 - individual_reliability)
+```
+
+Example: Detection probability improves with multiple sensors
+
+#### 5.2.4 Constraint Composition
+
+Team limited by weakest/strongest member:
+
+```
+team_speed = min(individual_speeds)
+team_range = max(individual_ranges)
+```
+
+---
+
+## 6. Phase 1: Discovery
+
+### 6.1 Beacon Broadcasting
+
+During Phase 1, nodes MUST:
+
+1. Broadcast `Beacon` messages at configurable intervals (default: 1 second)
+2. Include current position, capabilities, and state in beacons
+3. Increment `sequence_number` monotonically with each beacon
+4. Process received beacons from peers
+
+### 6.2 Geographic Scoping
+
+To achieve O(√n) discovery complexity, implementations SHOULD use geographic hashing:
+
+1. Compute geohash from current position (precision 5-6)
+2. Broadcast beacons only within geohash bucket
+3. Query neighboring buckets for boundary conditions
+
+### 6.3 Beacon TTL
+
+For multi-hop relay:
+
+1. Initial beacon TTL SHOULD be 3 (configurable)
+2. Each relay node decrements TTL
+3. Beacons with TTL=0 MUST NOT be relayed
+
+### 6.4 Phase Transition
+
+Node transitions to `PHASE_CELL` when:
+
+- Sufficient peers discovered (implementation-defined threshold)
+- OR cell formation request received
+- OR C2 directive received
+
+---
+
+## 7. Phase 2: Cell Formation
+
+### 7.1 Cell Structure
+
+A Cell consists of:
+
+- 1 elected leader
+- 4-11 members (configurable, default max_size=8)
+- Aggregated capabilities
+
+### 7.2 Leader Election
+
+Leader election uses deterministic scoring:
+
+```
+score = technical_score × technical_weight + authority_score × authority_weight
+```
+
+Where:
+- `technical_score` = f(compute, comms, sensors, power, reliability)
+- `authority_score` = f(rank, authority_level, cognitive_load, fatigue) [if human present]
+- Weights are policy-configurable
+
+Tie-breaking: Lexicographically lowest node ID wins.
+
+### 7.3 Membership Protocol
+
+1. **Join Request**: Node sends `CellFormationRequest` to discovered peers
+2. **Join Response**: Existing cell leader responds with `CellFormationResponse`
+3. **State Update**: New member updates `cell_id` in `NodeState`
+4. **Capability Recomputation**: Leader recomputes aggregated capabilities
+
+### 7.4 Phase Transition
+
+Cell transitions to `PHASE_HIERARCHY` when:
+
+- Leader elected AND confirmed
+- Minimum membership threshold met
+- Zone assignment received (for multi-tier hierarchies)
+
+---
+
+## 8. Phase 3: Hierarchical Operations
+
+### 8.1 Hierarchical Aggregation
+
+Leaders at each level publish aggregated summaries:
+
+| Level | Summary Type | Typical Size | Aggregates |
+|-------|--------------|--------------|------------|
+| Squad | `SquadSummary` | 5-8 nodes | Individual NodeState |
+| Platoon | `PlatoonSummary` | 24-32 nodes | SquadSummary |
+| Company | `CompanySummary` | 96-128 nodes | PlatoonSummary |
+
+Each level achieves approximately 95% bandwidth reduction through:
+- Averaging positions to centroids
+- Summarizing health to worst-case
+- Aggregating capabilities through composition
+
+### 8.2 Summary Contents
+
+All summaries MUST include:
+
+- Unit identifier
+- Leader identifier
+- Member/subordinate count
+- Position centroid
+- Worst health status
+- Operational count
+- Aggregated capabilities
+- Readiness score [0.0, 1.0]
+- Aggregation timestamp
+
+### 8.3 Command Dissemination
+
+Commands flow downward through the hierarchy:
+
+1. Originator creates `HierarchicalCommand` with target scope
+2. Command propagates to target level (platoon/squad/individual)
+3. Targets execute command and send `CommandAcknowledgment`
+4. Acknowledgments flow upward to originator
+
+### 8.4 Priority Handling
+
+| Priority | Behavior |
+|----------|----------|
+| ROUTINE (1) | Normal queue processing |
+| PRIORITY (2) | Expedited processing |
+| IMMEDIATE (3) | Preempts lower priority |
+| FLASH (4) | Immediate execution, conflict override |
+
+---
+
+## 9. CRDT Semantics
+
+### 9.1 CRDT Types Used
+
+| Data | CRDT Type | Merge Semantics |
+|------|-----------|-----------------|
+| Position | LWW-Register | Latest timestamp wins |
+| Health | LWW-Register | Latest timestamp wins |
+| Phase | LWW-Register | Latest timestamp wins |
+| Capabilities | G-Set | Union of all observed |
+| Cell members | OR-Set | Add/remove with tombstones |
+| Fuel | PN-Counter | Sum of increments minus decrements |
+
+### 9.2 Timestamp Requirements
+
+- Timestamps MUST use Unix epoch with nanosecond precision
+- Implementations SHOULD use synchronized time sources (NTP, GPS)
+- For LWW semantics, implementations MUST ensure monotonically increasing timestamps per node
+
+### 9.3 Conflict Resolution
+
+When concurrent updates conflict:
+
+1. **LWW fields**: Higher timestamp wins
+2. **G-Set fields**: Union (all values preserved)
+3. **OR-Set fields**: Observed-remove semantics (see CRDT literature)
+4. **Tie-breaking**: Lexicographically lowest node ID wins
+
+### 9.4 Consistency Guarantees
+
+HIVE provides **eventual consistency**:
+
+- All replicas converge to the same state
+- No coordination required during partitions
+- Updates are durable once observed by any node
+
+HIVE does NOT provide:
+
+- Linearizability
+- Strong consistency
+- Total ordering of operations
+
+---
+
+## 10. Message Complexity Analysis
+
+### 10.1 Discovery Phase: O(√n)
+
+Geographic hashing limits discovery to local peers:
+
+- n nodes distributed over area A
+- Geohash bucket covers area A/b
+- Expected peers per bucket: n/b
+- With appropriate b: O(√n) messages per node
+
+### 10.2 Cell Formation: O(k²) per cell
+
+Within cells of bounded size k:
+
+- Full state exchange within cell: k² messages
+- Total across n/k cells: O(kn)
+- With constant k: O(n)
+
+### 10.3 Hierarchical Operations: O(n log n)
+
+With hierarchy depth d = log(n/k):
+
+- Each level aggregates ~95% of updates
+- Updates propagate through d levels
+- Total: O(n log n)
+
+### 10.4 Comparison to Baseline
+
+| Architecture | Messages (100 nodes) | Messages (1000 nodes) |
+|--------------|---------------------|----------------------|
+| All-to-all | 9,900 | 999,000 |
+| HIVE | ~664 | ~6,644 |
+| Reduction | 93% | 99.3% |
+
+---
+
+## 11. Security Considerations
+
+### 11.1 Authentication
+
+Implementations SHOULD provide:
+
+- Node identity authentication (PKI/certificates)
+- Operator credential verification
+- Message integrity (signatures)
+
+### 11.2 Authorization
+
+Implementations SHOULD enforce:
+
+- Role-based access control for commands
+- Authority level requirements for ROE
+- Cell membership authorization
+
+### 11.3 Confidentiality
+
+For classified environments, implementations SHOULD provide:
+
+- Message encryption (ChaCha20-Poly1305 RECOMMENDED)
+- Key management (X25519 RECOMMENDED)
+- Forward secrecy
+
+### 11.4 Denial of Service
+
+Implementations SHOULD mitigate:
+
+- Beacon flooding (rate limiting)
+- Invalid capability claims (validation)
+- Leader election manipulation (deterministic scoring)
+
+---
+
+## 12. IANA Considerations
+
+This document has no IANA actions at this time.
+
+Future versions may request:
+
+- Protocol port assignment
+- Capability type registry
+- Command type registry
+
+---
+
+## 13. References
+
+### 13.1 Normative References
+
+- [RFC2119] Bradner, S., "Key words for use in RFCs to Indicate Requirement Levels", BCP 14, RFC 2119, March 1997.
+- [RFC8174] Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words", BCP 14, RFC 8174, May 2017.
+- [RFC4122] Leach, P., Mealling, M., and R. Salz, "A Universally Unique IDentifier (UUID) URN Namespace", RFC 4122, July 2005.
+
+### 13.2 Informative References
+
+- Shapiro, M., Preguiça, N., Baquero, C., and M. Zawirski, "Conflict-free Replicated Data Types", SSS 2011.
+- Kleppmann, M., "Making Sense of Stream Processing", O'Reilly Media, 2016.
+- NATO STANAG 4586, "Standard Interfaces of UAV Control System (UCS) for NATO UAV Interoperability".
+
+---
+
+## Appendix A. Protocol Buffer Schema
+
+The normative Protocol Buffer definitions are available in the `proto/` directory:
+
+- `cap/v1/common.proto` - Common types
+- `cap/v1/node.proto` - Node model
+- `cap/v1/capability.proto` - Capability model
+- `cap/v1/cell.proto` - Cell model
+- `cap/v1/beacon.proto` - Discovery beacons
+- `cap/v1/composition.proto` - Composition rules
+- `cap/v1/hierarchy.proto` - Hierarchical summaries
+- `cap/v1/command.proto` - Command dissemination
+
+---
+
+## Appendix B. Example Message Flows
+
+### B.1 Discovery and Cell Formation
+
+```
+Node A                    Node B                    Node C
+  │                         │                         │
+  │──── Beacon ────────────▶│                         │
+  │                         │──── Beacon ────────────▶│
+  │◀──────────── Beacon ────│                         │
+  │                         │◀──────────── Beacon ────│
+  │◀─────────────────────────────────── Beacon ───────│
+  │                         │                         │
+  │── CellFormationReq ────▶│                         │
+  │                         │── CellFormationReq ────▶│
+  │◀── CellFormationResp ───│                         │
+  │                         │◀── CellFormationResp ───│
+  │                         │                         │
+  │        [Leader Election: B wins]                  │
+  │                         │                         │
+  │◀─── SquadSummary ───────│─── SquadSummary ───────▶│
+```
+
+### B.2 Hierarchical Command Flow
+
+```
+Company Cmd ─────▶ Platoon Leader ─────▶ Squad Leader ─────▶ Node
+                        │                     │               │
+                        │◀──── Squad Ack ─────│◀──── Ack ─────│
+    ◀── Platoon Ack ────│                     │               │
+```
+
+---
+
+## Author's Address
+
+Kit Plummer
+(r)evolve, Inc.
+Email: kit@revolveteam.com
+GitHub: https://github.com/kitplummer/hive

--- a/spec/examples/README.md
+++ b/spec/examples/README.md
@@ -1,0 +1,52 @@
+# HIVE Protocol Examples
+
+This directory contains normative message examples for the HIVE Protocol.
+
+## Purpose
+
+These examples demonstrate correct message formation and protocol flows. Implementations SHOULD use these examples as test vectors for conformance validation.
+
+## Planned Examples
+
+### Discovery Phase
+
+- [ ] `beacon-basic.json` - Minimal valid beacon
+- [ ] `beacon-full.json` - Beacon with all optional fields
+- [ ] `beacon-query.json` - Discovery query examples
+
+### Cell Formation
+
+- [ ] `cell-formation-request.json` - Join request
+- [ ] `cell-formation-response.json` - Join response
+- [ ] `cell-leader-election.json` - Leader election scenario
+
+### Hierarchical Operations
+
+- [ ] `squad-summary.json` - Squad aggregation
+- [ ] `platoon-summary.json` - Platoon aggregation
+- [ ] `command-flow.json` - Command and acknowledgment
+
+### Composition
+
+- [ ] `composition-additive.json` - Additive composition
+- [ ] `composition-emergent.json` - Emergent capability discovery
+- [ ] `composition-redundant.json` - Redundant composition
+- [ ] `composition-constraint.json` - Constraint-based composition
+
+## Format
+
+Examples are provided in JSON (human-readable) format. Implementations should verify they can:
+
+1. Parse the JSON
+2. Convert to Protocol Buffer binary
+3. Deserialize back to JSON
+4. Verify semantic equivalence
+
+## Contributing
+
+To add examples:
+
+1. Create JSON file in appropriate subdirectory
+2. Include comments explaining the example
+3. Verify example passes schema validation
+4. Add entry to this README

--- a/spec/proto/README.md
+++ b/spec/proto/README.md
@@ -1,0 +1,187 @@
+# HIVE Protocol Buffer Definitions
+
+This directory contains the **normative** Protocol Buffer schema definitions for the HIVE Protocol.
+
+## License
+
+These Protocol Buffer definitions are released under [CC0 1.0 Universal (Public Domain Dedication)](https://creativecommons.org/publicdomain/zero/1.0/).
+
+You are free to:
+- Implement these schemas in any language
+- Use them in commercial or non-commercial projects
+- Modify and redistribute without restriction
+- No attribution required (though appreciated)
+
+## Schema Overview
+
+### Core Types (`cap.common.v1`)
+
+| Message | Purpose |
+|---------|---------|
+| `Uuid` | Unique identifier wrapper |
+| `Timestamp` | Unix epoch timestamp with nanosecond precision |
+| `Position` | WGS84 geographic coordinates |
+| `Confidence` | Normalized confidence score [0.0, 1.0] |
+| `Metadata` | Generic key-value pairs |
+
+### Node Model (`cap.node.v1`)
+
+| Message/Enum | Purpose |
+|--------------|---------|
+| `Node` | Complete node representation |
+| `NodeConfig` | Static platform configuration |
+| `NodeState` | Dynamic platform state (CRDT-backed) |
+| `Operator` | Human operator information |
+| `HumanMachinePair` | Human-machine teaming binding |
+| `Phase` | Protocol phase (Discovery, Cell, Hierarchy) |
+| `HealthStatus` | Platform health enumeration |
+| `OperatorRank` | Military rank mapping |
+| `AuthorityLevel` | Human authority levels |
+
+### Capability Model (`cap.capability.v1`)
+
+| Message/Enum | Purpose |
+|--------------|---------|
+| `Capability` | Individual platform capability |
+| `CapabilityType` | Capability classification |
+| `CapabilityQuery` | Discovery query filter |
+| `CapabilityResponse` | Query response |
+
+### Cell Model (`cap.cell.v1`)
+
+| Message | Purpose |
+|---------|---------|
+| `Cell` | Squad-level formation |
+| `CellConfig` | Cell configuration |
+| `CellState` | Cell dynamic state |
+| `CellFormationRequest/Response` | Formation protocol |
+| `CellMembershipChange` | Membership events |
+
+### Discovery (`cap.beacon.v1`)
+
+| Message | Purpose |
+|---------|---------|
+| `Beacon` | Discovery broadcast message |
+| `BeaconQuery` | Beacon filter criteria |
+| `BeaconQueryResponse` | Query results |
+| `BeaconRecord` | Persistence wrapper |
+
+### Composition (`cap.composition.v1`)
+
+| Message/Enum | Purpose |
+|--------------|---------|
+| `CompositionRule` | Capability composition definition |
+| `CompositionRuleType` | Rule types (Additive, Emergent, Redundant, Constraint) |
+| `CompositionResult` | Composition output |
+
+### Hierarchy (`cap.hierarchy.v1`)
+
+| Message | Purpose |
+|---------|---------|
+| `SquadSummary` | Squad-level aggregation |
+| `PlatoonSummary` | Platoon-level aggregation |
+| `CompanySummary` | Company-level aggregation |
+| `BoundingBox` | Spatial extent |
+| `AggregationMetadata` | Aggregation provenance |
+
+### Command (`cap.command.v1`)
+
+| Message/Enum | Purpose |
+|--------------|---------|
+| `HierarchicalCommand` | Command dissemination |
+| `CommandTarget` | Target specification |
+| `CommandPriority` | Priority levels |
+| `MissionOrder` | Mission commands |
+| `EngagementOrder` | Engagement commands |
+| `FormationChange` | Formation commands |
+| `CommandAcknowledgment` | Acknowledgment flow |
+| Policy enums | Configurable behavior |
+
+## CRDT Semantics
+
+The schema documents which CRDT types back each field:
+
+| Annotation | CRDT Type | Semantics |
+|------------|-----------|-----------|
+| `LWW-Register` | Last-Writer-Wins Register | Most recent timestamp wins |
+| `G-Set` | Grow-only Set | Add-only, no removal |
+| `OR-Set` | Observed-Remove Set | Add and remove with tombstones |
+| `PN-Counter` | Positive-Negative Counter | Increment and decrement |
+
+## Code Generation
+
+### Rust (with prost)
+
+```toml
+[build-dependencies]
+prost-build = "0.13"
+```
+
+```rust
+// build.rs
+fn main() {
+    prost_build::compile_protos(
+        &["spec/proto/cap/v1/node.proto"],
+        &["spec/proto/"]
+    ).unwrap();
+}
+```
+
+### Python (with grpcio-tools)
+
+```bash
+python -m grpc_tools.protoc \
+    -I spec/proto \
+    --python_out=. \
+    --grpc_python_out=. \
+    spec/proto/cap/v1/*.proto
+```
+
+### Go (with protoc-gen-go)
+
+```bash
+protoc \
+    -I spec/proto \
+    --go_out=. \
+    --go_opt=paths=source_relative \
+    spec/proto/cap/v1/*.proto
+```
+
+### Java (with protoc)
+
+```bash
+protoc \
+    -I spec/proto \
+    --java_out=src/main/java \
+    spec/proto/cap/v1/*.proto
+```
+
+## Versioning
+
+Schemas are versioned via package namespace:
+- `cap.*.v1` - Version 1 (current)
+- `cap.*.v2` - Version 2 (future, breaking changes)
+
+Within a major version, only backward-compatible changes are permitted:
+- Adding new fields (with new field numbers)
+- Adding new enum values
+- Adding new messages
+
+Breaking changes require a new major version.
+
+## Validation Requirements
+
+Implementations MUST validate:
+
+1. **UUID format**: `id` fields MUST be valid UUID v4
+2. **Confidence range**: Values MUST be in [0.0, 1.0]
+3. **Position validity**: Latitude [-90, 90], Longitude [-180, 180]
+4. **Timestamp monotonicity**: For LWW fields, timestamps MUST increase
+5. **Required fields**: Fields marked in spec as REQUIRED MUST be present
+
+## Wire Format
+
+All messages use Protocol Buffers binary encoding (proto3 syntax). Implementations:
+- MUST support proto3 binary format
+- MAY support JSON encoding for debugging/interoperability
+- MUST preserve unknown fields for forward compatibility

--- a/spec/proto/cap/v1/beacon.proto
+++ b/spec/proto/cap/v1/beacon.proto
@@ -1,0 +1,119 @@
+// HIVE Protocol - Discovery Beacon
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines the beacon model for the HIVE Protocol discovery phase.
+// Beacons are broadcast by nodes to announce their presence and capabilities.
+
+syntax = "proto3";
+
+package cap.beacon.v1;
+
+import "cap/v1/common.proto";
+import "cap/v1/node.proto";
+import "cap/v1/capability.proto";
+
+// Beacon is the discovery broadcast message.
+//
+// During Phase 1 (Discovery), nodes broadcast beacons to announce their
+// presence, capabilities, and current state to nearby peers.
+//
+// Requirements:
+// - Nodes in PHASE_DISCOVERY MUST broadcast beacons periodically
+// - Beacon interval SHOULD be configurable (default: 1 second)
+// - Beacons MUST include accurate position and capabilities
+// - sequence_number MUST monotonically increase per node
+//
+// Message Complexity:
+// - Beacons are geographically scoped using geohash bucketing
+// - This achieves O(sqrt(n)) discovery complexity vs O(n^2) broadcast
+message Beacon {
+  // REQUIRED. Node ID broadcasting this beacon.
+  string node_id = 1;
+
+  // REQUIRED. Summary of node configuration.
+  node.v1.NodeConfig node_config = 2;
+
+  // REQUIRED. Current node state.
+  node.v1.NodeState node_state = 3;
+
+  // REQUIRED. Capabilities being advertised.
+  repeated capability.v1.Capability capabilities = 4;
+
+  // REQUIRED. Monotonically increasing sequence number.
+  // Used to detect beacon gaps and ordering.
+  uint64 sequence_number = 5;
+
+  // OPTIONAL. Time-to-live for multi-hop relay.
+  // Decremented by each relay; dropped when TTL=0.
+  // Default: 3 (typical for tactical networks)
+  uint32 ttl = 6;
+
+  // REQUIRED. Timestamp when beacon was generated.
+  common.v1.Timestamp timestamp = 7;
+
+  // OPTIONAL. Cell ID if node is already part of a cell.
+  // Used to inform discoverers of existing cell membership.
+  optional string current_cell_id = 8;
+}
+
+// BeaconQuery filters for discovering nodes.
+//
+// All filter criteria use AND logic (all must match).
+// An empty query matches all beacons.
+message BeaconQuery {
+  // OPTIONAL. Filter by platform type.
+  optional string platform_type = 1;
+
+  // OPTIONAL. Filter by required capabilities.
+  repeated capability.v1.CapabilityType required_capabilities = 2;
+
+  // OPTIONAL. Filter by protocol phase.
+  optional node.v1.Phase phase = 3;
+
+  // OPTIONAL. Maximum distance from reference position (meters).
+  // Requires reference_position to be set.
+  optional float max_distance_m = 4;
+
+  // OPTIONAL. Reference position for distance filtering.
+  optional common.v1.Position reference_position = 5;
+
+  // OPTIONAL. Minimum health status required.
+  optional node.v1.HealthStatus min_health = 6;
+
+  // OPTIONAL. Minimum fuel remaining (minutes).
+  optional uint32 min_fuel_minutes = 7;
+}
+
+// BeaconQueryResponse contains beacons matching a query.
+message BeaconQueryResponse {
+  // Beacons matching the query criteria.
+  repeated Beacon beacons = 1;
+
+  // Total count of matching beacons.
+  uint32 total_count = 2;
+
+  // Timestamp when query was executed.
+  common.v1.Timestamp queried_at = 3;
+}
+
+// BeaconRecord is the storage representation of a beacon.
+//
+// Used for CRDT persistence and tracking beacon freshness.
+message BeaconRecord {
+  // The beacon itself.
+  Beacon beacon = 1;
+
+  // When this beacon was first observed.
+  common.v1.Timestamp first_seen = 2;
+
+  // When this beacon was last observed.
+  common.v1.Timestamp last_seen = 3;
+
+  // Number of times this beacon has been received.
+  uint64 seen_count = 4;
+
+  // Whether this beacon is still considered active.
+  // Implementations SHOULD mark inactive after TTL expiration.
+  bool active = 5;
+}

--- a/spec/proto/cap/v1/capability.proto
+++ b/spec/proto/cap/v1/capability.proto
@@ -1,0 +1,116 @@
+// HIVE Protocol - Capability Model
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines the capability model for HIVE Protocol.
+// Capabilities represent what a node or cell can do (sense, compute, move, etc.)
+// and are fundamental to the composition and matching algorithms.
+
+syntax = "proto3";
+
+package cap.capability.v1;
+
+import "cap/v1/common.proto";
+
+// CapabilityType enumerates the fundamental categories of platform capabilities.
+//
+// These categories enable capability-based discovery and composition.
+// Implementations MUST support all defined types.
+// Implementations MAY define additional types using CAPABILITY_TYPE_CUSTOM.
+enum CapabilityType {
+  // Default value. Implementations MUST NOT use this for valid capabilities.
+  CAPABILITY_TYPE_UNSPECIFIED = 0;
+
+  // Sensing capabilities: cameras, radar, sonar, SIGINT, etc.
+  CAPABILITY_TYPE_SENSOR = 1;
+
+  // Computing capabilities: processing, inference, analysis
+  CAPABILITY_TYPE_COMPUTE = 2;
+
+  // Communication capabilities: relay, mesh networking, BLOS
+  CAPABILITY_TYPE_COMMUNICATION = 3;
+
+  // Mobility capabilities: flight, ground movement, maritime
+  CAPABILITY_TYPE_MOBILITY = 4;
+
+  // Payload capabilities: cargo, weapons, countermeasures
+  CAPABILITY_TYPE_PAYLOAD = 5;
+
+  // Emergent capabilities: created through composition of other capabilities
+  CAPABILITY_TYPE_EMERGENT = 6;
+
+  // Reserved for future specification use
+  // Values 7-99 are reserved
+
+  // Custom/application-defined capabilities (100+)
+  // Implementations MAY define custom types starting at 100
+}
+
+// Capability represents a single capability of a node or cell.
+//
+// Requirements:
+// - Each capability MUST have a unique id within its containing node/cell
+// - The confidence score MUST be in range [0.0, 1.0]
+// - Implementations MUST preserve capabilities during CRDT sync (G-Set semantics)
+//
+// CRDT Semantics: Capabilities use G-Set (grow-only set) semantics.
+// Once advertised, a capability cannot be removed, only marked with confidence=0.
+message Capability {
+  // REQUIRED. Unique identifier for this capability.
+  // MUST be unique within the containing node or cell.
+  // Format: lowercase alphanumeric with hyphens, e.g., "eo-camera-1"
+  string id = 1;
+
+  // REQUIRED. Human-readable capability name.
+  // SHOULD be descriptive, e.g., "Electro-Optical Camera"
+  string name = 2;
+
+  // REQUIRED. Capability category.
+  // MUST NOT be CAPABILITY_TYPE_UNSPECIFIED.
+  CapabilityType capability_type = 3;
+
+  // REQUIRED. Confidence score indicating capability reliability/availability.
+  // Range: [0.0, 1.0] where 1.0 = fully operational, 0.0 = non-functional
+  // Implementations MUST update confidence based on health/status changes.
+  float confidence = 4;
+
+  // OPTIONAL. Application-specific metadata as JSON.
+  // MAY include: range_m, resolution, bandwidth_mbps, etc.
+  // Implementations MUST preserve unknown metadata fields.
+  string metadata_json = 5;
+
+  // OPTIONAL. Timestamp when capability was first registered.
+  // Used for ordering and provenance.
+  common.v1.Timestamp registered_at = 6;
+}
+
+// CapabilityQuery defines filters for discovering nodes/cells by capability.
+//
+// Requirements:
+// - An empty query (no filters) matches all capabilities
+// - Multiple required_types use AND logic (all must be present)
+// - min_confidence filters out capabilities below the threshold
+message CapabilityQuery {
+  // OPTIONAL. Required capability types.
+  // Matching nodes MUST have at least one capability of each listed type.
+  // Empty list matches any type.
+  repeated CapabilityType required_types = 1;
+
+  // OPTIONAL. Minimum confidence threshold.
+  // Only capabilities with confidence >= this value match.
+  // Default: 0.0 (match all confidence levels)
+  float min_confidence = 2;
+
+  // OPTIONAL. Metadata filters as key-value pairs.
+  // All specified filters must match (AND logic).
+  map<string, string> metadata_filters = 3;
+}
+
+// CapabilityResponse contains the result of a capability query.
+message CapabilityResponse {
+  // Capabilities matching the query criteria.
+  repeated Capability capabilities = 1;
+
+  // Total count of matching capabilities.
+  uint32 total_count = 2;
+}

--- a/spec/proto/cap/v1/cell.proto
+++ b/spec/proto/cap/v1/cell.proto
@@ -1,0 +1,144 @@
+// HIVE Protocol - Cell Model
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines the cell (squad) model for HIVE Protocol.
+// A Cell is a group of nodes that operate together, with a single leader.
+// Cells are the fundamental unit of hierarchical organization.
+
+syntax = "proto3";
+
+package cap.cell.v1;
+
+import "cap/v1/common.proto";
+import "cap/v1/capability.proto";
+
+// CellConfig contains static configuration for a cell.
+//
+// Requirements:
+// - Cell id MUST be a valid UUID v4
+// - max_size SHOULD be in range [3, 12] for tactical effectiveness
+// - min_size MUST be >= 2 (a cell requires at least a leader and one member)
+message CellConfig {
+  // REQUIRED. Unique cell identifier (UUID v4).
+  string id = 1;
+
+  // REQUIRED. Maximum number of members in this cell.
+  // Implementations SHOULD reject join requests when at capacity.
+  uint32 max_size = 2;
+
+  // OPTIONAL. Minimum number of members for the cell to be operational.
+  // Default: 2
+  uint32 min_size = 3;
+
+  // OPTIONAL. Timestamp when cell was created.
+  common.v1.Timestamp created_at = 4;
+}
+
+// CellState contains dynamic state for a cell.
+//
+// Requirements:
+// - Exactly one member MUST be designated as leader
+// - All members MUST have the cell_id in their NodeState
+// - Leader is responsible for publishing aggregated capabilities
+//
+// CRDT Semantics:
+// - leader_id: LWW-Register with deterministic tie-breaking
+// - members: OR-Set (allows add and remove with tombstones)
+// - capabilities: G-Set (aggregated from member capabilities)
+message CellState {
+  // Cell configuration.
+  CellConfig config = 1;
+
+  // OPTIONAL. Current leader node ID.
+  // CRDT: LWW-Register
+  // If absent, cell is in leader election state.
+  optional string leader_id = 2;
+
+  // REQUIRED. Set of member node IDs.
+  // CRDT: OR-Set
+  // MUST include the leader_id if leader is set.
+  repeated string members = 3;
+
+  // REQUIRED. Aggregated cell capabilities.
+  // CRDT: G-Set
+  // Computed by leader from member capabilities using composition rules.
+  repeated capability.v1.Capability capabilities = 4;
+
+  // OPTIONAL. Parent zone/platoon ID for hierarchical organization.
+  // CRDT: LWW-Register
+  optional string platoon_id = 5;
+
+  // REQUIRED. Last update timestamp for LWW conflict resolution.
+  common.v1.Timestamp timestamp = 6;
+}
+
+// Cell represents the complete state of a cell (squad).
+message Cell {
+  // Static configuration.
+  CellConfig config = 1;
+
+  // Dynamic state.
+  CellState state = 2;
+}
+
+// CellFormationRequest is sent by a node to initiate or join cell formation.
+//
+// Requirements:
+// - Nodes in PHASE_DISCOVERY MAY send formation requests
+// - Formation requests SHOULD include required capabilities for matching
+message CellFormationRequest {
+  // REQUIRED. ID of the node requesting formation/joining.
+  string node_id = 1;
+
+  // OPTIONAL. Required capability types for the cell.
+  // Used for capability-based cell matching.
+  repeated capability.v1.CapabilityType required_capabilities = 2;
+
+  // REQUIRED. Timestamp of the request.
+  common.v1.Timestamp requested_at = 3;
+}
+
+// CellFormationResponse is returned in response to a formation request.
+message CellFormationResponse {
+  // The formed/joined cell (if successful).
+  optional Cell cell = 1;
+
+  // Whether formation/join was successful.
+  bool success = 2;
+
+  // Reason for failure (if not successful).
+  optional string failure_reason = 3;
+}
+
+// CellMembershipChange represents a change in cell membership.
+//
+// These events are used to track cell composition changes for
+// auditing and hierarchical notification.
+message CellMembershipChange {
+  // REQUIRED. ID of the cell affected.
+  string cell_id = 1;
+
+  // Type of membership change.
+  enum ChangeType {
+    CHANGE_TYPE_UNSPECIFIED = 0;
+
+    // A node joined the cell
+    CHANGE_TYPE_JOIN = 1;
+
+    // A node left the cell
+    CHANGE_TYPE_LEAVE = 2;
+
+    // Leadership changed
+    CHANGE_TYPE_LEADER = 3;
+  }
+
+  // REQUIRED. Type of change.
+  ChangeType change_type = 2;
+
+  // REQUIRED. Node ID involved in the change.
+  string node_id = 3;
+
+  // REQUIRED. Timestamp of the change.
+  common.v1.Timestamp timestamp = 4;
+}

--- a/spec/proto/cap/v1/command.proto
+++ b/spec/proto/cap/v1/command.proto
@@ -1,0 +1,410 @@
+// HIVE Protocol - Command Dissemination
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines the command dissemination model for HIVE Protocol.
+// Commands flow downward through the hierarchy (company -> platoon -> squad -> node)
+// while acknowledgments flow upward.
+
+syntax = "proto3";
+
+package cap.command.v1;
+
+import "cap/v1/common.proto";
+
+// HierarchicalCommand is the primary command message.
+//
+// Commands are issued by higher echelons and disseminated to subordinate units.
+// The protocol supports configurable policies for handling partitions,
+// conflicts, acknowledgments, and leader changes.
+//
+// Requirements:
+// - Commands MUST have unique command_id (UUID v4)
+// - Implementations MUST honor priority ordering
+// - Implementations MUST apply configured policies
+message HierarchicalCommand {
+  // REQUIRED. Unique command identifier (UUID v4).
+  string command_id = 1;
+
+  // REQUIRED. Node ID of the command originator.
+  string originator_id = 2;
+
+  // REQUIRED. Target specification for the command.
+  CommandTarget target = 3;
+
+  // REQUIRED. Command payload (one of the command types).
+  oneof command_type {
+    MissionOrder mission_order = 10;
+    EngagementOrder engagement_order = 11;
+    FormationChange formation_change = 12;
+    ConfigurationUpdate configuration_update = 13;
+  }
+
+  // REQUIRED. Command priority level.
+  CommandPriority priority = 20;
+
+  // REQUIRED. Policy configurations.
+  BufferPolicy buffer_policy = 30;
+  ConflictPolicy conflict_policy = 31;
+  AcknowledgmentPolicy acknowledgment_policy = 32;
+  LeaderChangePolicy leader_change_policy = 33;
+
+  // REQUIRED. When command was issued.
+  common.v1.Timestamp issued_at = 40;
+
+  // OPTIONAL. Expiration time (command invalid after this).
+  optional common.v1.Timestamp expires_at = 41;
+
+  // REQUIRED. Version for conflict resolution.
+  uint32 version = 42;
+}
+
+// CommandTarget specifies which nodes/units receive a command.
+message CommandTarget {
+  // Target scope enumeration.
+  enum Scope {
+    SCOPE_UNSPECIFIED = 0;
+
+    // Single node by ID
+    INDIVIDUAL = 1;
+
+    // All members of specified squad(s)
+    SQUAD = 2;
+
+    // All members of specified platoon(s)
+    PLATOON = 3;
+
+    // All nodes in the network
+    BROADCAST = 4;
+  }
+
+  // REQUIRED. Scope of targeting.
+  Scope scope = 1;
+
+  // REQUIRED. Target identifiers (interpretation depends on scope).
+  // INDIVIDUAL: node_ids, SQUAD: squad_ids, PLATOON: platoon_ids
+  repeated string target_ids = 2;
+}
+
+// CommandPriority defines urgency levels for commands.
+//
+// Requirements:
+// - Higher priority commands preempt lower priority in queues
+// - FLASH commands SHOULD be delivered immediately
+enum CommandPriority {
+  COMMAND_PRIORITY_UNSPECIFIED = 0;
+
+  // Standard operations, normal processing
+  ROUTINE = 1;
+
+  // Time-sensitive but not critical
+  PRIORITY = 2;
+
+  // Requires immediate action
+  IMMEDIATE = 3;
+
+  // Mission-critical, override conflicts
+  FLASH = 4;
+}
+
+// BufferPolicy defines behavior during network partitions.
+enum BufferPolicy {
+  BUFFER_POLICY_UNSPECIFIED = 0;
+
+  // Queue commands during partition, deliver on reconnection
+  BUFFER_AND_RETRY = 1;
+
+  // Drop commands if target is unreachable
+  DROP_ON_PARTITION = 2;
+
+  // Fail immediately if cannot deliver
+  REQUIRE_IMMEDIATE_DELIVERY = 3;
+}
+
+// ConflictPolicy defines how to resolve conflicting commands.
+enum ConflictPolicy {
+  CONFLICT_POLICY_UNSPECIFIED = 0;
+
+  // Most recent command wins (by timestamp)
+  LAST_WRITE_WINS = 1;
+
+  // Higher priority command wins
+  HIGHEST_PRIORITY_WINS = 2;
+
+  // Command from higher authority wins
+  HIGHEST_AUTHORITY_WINS = 3;
+
+  // Merge if commands are compatible
+  MERGE_COMPATIBLE = 4;
+
+  // Reject any conflicting commands
+  REJECT_CONFLICT = 5;
+}
+
+// AcknowledgmentPolicy defines acknowledgment requirements.
+enum AcknowledgmentPolicy {
+  ACKNOWLEDGMENT_POLICY_UNSPECIFIED = 0;
+
+  // Fire-and-forget, no acknowledgment required
+  NO_ACK_REQUIRED = 1;
+
+  // Require acknowledgment from all targets
+  ACK_REQUIRED = 2;
+
+  // Require acks from >50% of targets
+  ACK_MAJORITY_REQUIRED = 3;
+
+  // Only squad/platoon leader must acknowledge
+  ACK_LEADER_ONLY = 4;
+}
+
+// LeaderChangePolicy defines behavior when leadership changes.
+enum LeaderChangePolicy {
+  LEADER_CHANGE_POLICY_UNSPECIFIED = 0;
+
+  // New leader reissues the command
+  REISSUE_FROM_NEW_LEADER = 1;
+
+  // Command continues without reissuance
+  CONTINUE_AS_IS = 2;
+
+  // Cancel command when leader changes
+  CANCEL_ON_LEADER_CHANGE = 3;
+}
+
+// MissionOrder assigns a mission to target units.
+message MissionOrder {
+  // Mission type enumeration.
+  enum MissionType {
+    MISSION_TYPE_UNSPECIFIED = 0;
+    ISR = 1;           // Intelligence, Surveillance, Reconnaissance
+    KINETIC = 2;       // Strike/engagement
+    HUMANITARIAN = 3;  // Aid/relief
+    TRANSPORT = 4;     // Movement/logistics
+    DEFENSIVE = 5;     // Defensive posture
+  }
+
+  // REQUIRED. Type of mission.
+  MissionType mission_type = 1;
+
+  // REQUIRED. Mission identifier.
+  string mission_id = 2;
+
+  // OPTIONAL. Human-readable description.
+  string description = 3;
+
+  // OPTIONAL. Primary objective location.
+  common.v1.Position objective_location = 4;
+
+  // OPTIONAL. Mission start time.
+  optional common.v1.Timestamp start_time = 5;
+
+  // OPTIONAL. Mission end time.
+  optional common.v1.Timestamp end_time = 6;
+
+  // OPTIONAL. Rules of engagement.
+  optional RulesOfEngagement roe = 7;
+}
+
+// RulesOfEngagement constrain autonomous engagement decisions.
+message RulesOfEngagement {
+  // Authority level required for engagement.
+  enum EngagementAuthority {
+    ENGAGEMENT_AUTHORITY_UNSPECIFIED = 0;
+
+    // System can engage autonomously
+    AUTONOMOUS = 1;
+
+    // Requires human operator approval
+    OPERATOR_APPROVAL = 2;
+
+    // Requires commander approval
+    COMMANDER_APPROVAL = 3;
+  }
+
+  // REQUIRED. Authority level for engagement decisions.
+  EngagementAuthority engagement_authority = 1;
+
+  // OPTIONAL. Allowed weapon systems.
+  repeated string allowed_weapons = 2;
+
+  // OPTIONAL. Prohibited weapon systems.
+  repeated string prohibited_weapons = 3;
+
+  // OPTIONAL. Maximum acceptable collateral damage [0.0, 1.0].
+  optional float max_collateral_damage_estimate = 4;
+
+  // OPTIONAL. Require standoff if civilians present.
+  bool civilians_present_standoff = 5;
+}
+
+// EngagementOrder directs specific engagement actions.
+message EngagementOrder {
+  // Engagement type enumeration.
+  enum EngagementType {
+    ENGAGEMENT_TYPE_UNSPECIFIED = 0;
+    DEFENSIVE_FIRE = 1;
+    SUPPRESSIVE_FIRE = 2;
+    PRECISION_STRIKE = 3;
+    WARNING_SHOT = 4;
+  }
+
+  // REQUIRED. Type of engagement.
+  EngagementType engagement_type = 1;
+
+  // REQUIRED. Target identifier.
+  string target_id = 2;
+
+  // REQUIRED. Target location.
+  common.v1.Position target_location = 3;
+
+  // OPTIONAL. Target description.
+  optional string target_description = 4;
+
+  // REQUIRED. Weapon system to employ.
+  string weapon_system_id = 5;
+
+  // OPTIONAL. Maximum collateral radius (meters).
+  optional float max_collateral_radius_meters = 6;
+
+  // OPTIONAL. Require visual confirmation before engagement.
+  bool require_visual_confirmation = 7;
+}
+
+// FormationChange directs units to change formation.
+message FormationChange {
+  // Formation type enumeration.
+  enum FormationType {
+    FORMATION_TYPE_UNSPECIFIED = 0;
+    LINE = 1;
+    COLUMN = 2;
+    WEDGE = 3;
+    DIAMOND = 4;
+    DISPERSED = 5;
+    RALLY = 6;
+  }
+
+  // REQUIRED. Target formation type.
+  FormationType formation_type = 1;
+
+  // OPTIONAL. Rally point for RALLY formation.
+  optional common.v1.Position rally_point = 2;
+
+  // OPTIONAL. Spacing between elements (meters).
+  optional float spacing_meters = 3;
+
+  // OPTIONAL. Formation heading (degrees).
+  optional float heading_degrees = 4;
+
+  // OPTIONAL. Individual position assignments.
+  repeated NodePositionAssignment assignments = 5;
+}
+
+// NodePositionAssignment assigns a specific position to a node.
+message NodePositionAssignment {
+  // REQUIRED. Node to position.
+  string node_id = 1;
+
+  // REQUIRED. Assigned position.
+  common.v1.Position position = 2;
+
+  // OPTIONAL. Assigned heading (degrees).
+  optional float heading_degrees = 3;
+}
+
+// ConfigurationUpdate modifies system configuration.
+message ConfigurationUpdate {
+  // Update type enumeration.
+  enum UpdateType {
+    UPDATE_TYPE_UNSPECIFIED = 0;
+    AGGREGATION_POLICY = 1;
+    SYNC_INTERVAL = 2;
+    CAPABILITY_FILTER = 3;
+    AUTHORITY_LEVEL = 4;
+  }
+
+  // REQUIRED. Type of configuration update.
+  UpdateType update_type = 1;
+
+  // REQUIRED. Configuration data (JSON).
+  string configuration_json = 2;
+}
+
+// CommandAcknowledgment flows upward to confirm command receipt/execution.
+message CommandAcknowledgment {
+  // REQUIRED. Command being acknowledged.
+  string command_id = 1;
+
+  // REQUIRED. Node sending acknowledgment.
+  string node_id = 2;
+
+  // REQUIRED. Acknowledgment status.
+  AckStatus status = 3;
+
+  // OPTIONAL. Reason for rejection or failure.
+  optional string reason = 4;
+
+  // REQUIRED. Acknowledgment timestamp.
+  common.v1.Timestamp timestamp = 5;
+}
+
+// AckStatus indicates the command handling status.
+enum AckStatus {
+  ACK_STATUS_UNSPECIFIED = 0;
+
+  // Command received
+  ACK_RECEIVED = 1;
+
+  // Command accepted and executing
+  ACK_ACCEPTED = 2;
+
+  // Command completed successfully
+  ACK_COMPLETED = 3;
+
+  // Command rejected (see reason)
+  ACK_REJECTED = 4;
+
+  // Command execution failed (see reason)
+  ACK_FAILED = 5;
+}
+
+// CommandStatus tracks the state of a command for originators.
+message CommandStatus {
+  // Command being tracked.
+  string command_id = 1;
+
+  // Current state.
+  CommandState state = 2;
+
+  // Collected acknowledgments.
+  repeated CommandAcknowledgment acknowledgments = 3;
+
+  // Last status update.
+  common.v1.Timestamp last_updated = 4;
+}
+
+// CommandState tracks overall command execution state.
+enum CommandState {
+  COMMAND_STATE_UNSPECIFIED = 0;
+
+  // Command issued, awaiting delivery
+  STATE_PENDING = 1;
+
+  // Delivered to at least one target
+  STATE_DELIVERED = 2;
+
+  // Currently being executed
+  STATE_EXECUTING = 3;
+
+  // Completed successfully
+  STATE_COMPLETED = 4;
+
+  // Failed to execute
+  STATE_FAILED = 5;
+
+  // Cancelled by originator
+  STATE_CANCELLED = 6;
+
+  // Expired (past expires_at)
+  STATE_EXPIRED = 7;
+}

--- a/spec/proto/cap/v1/common.proto
+++ b/spec/proto/cap/v1/common.proto
@@ -1,0 +1,83 @@
+// HIVE Protocol - Common Types
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines common message types used throughout the HIVE Protocol.
+// All implementations MUST support these types as the foundation for protocol messages.
+
+syntax = "proto3";
+
+package cap.common.v1;
+
+// Uuid represents a universally unique identifier.
+//
+// Requirements:
+// - Implementations MUST generate UUIDs conforming to RFC 4122 version 4
+// - The value field MUST contain a valid UUID string representation
+// - Format: "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx" where x is hex and y is [89ab]
+// - Implementations MUST reject malformed UUID strings
+message Uuid {
+  // REQUIRED. The UUID string value.
+  string value = 1;
+}
+
+// Timestamp represents a point in time with nanosecond precision.
+//
+// Requirements:
+// - Implementations MUST use Unix epoch (1970-01-01T00:00:00Z) as the reference
+// - The nanos field MUST be in the range [0, 999999999]
+// - For CRDT LWW semantics, implementations MUST ensure timestamp monotonicity
+// - Implementations SHOULD use synchronized time sources (NTP, GPS) when available
+message Timestamp {
+  // REQUIRED. Seconds since Unix epoch.
+  uint64 seconds = 1;
+
+  // OPTIONAL. Nanoseconds within the second. MUST be [0, 999999999].
+  // If omitted, implementations SHOULD treat as 0.
+  uint32 nanos = 2;
+}
+
+// Position represents a geographic location using WGS84 coordinates.
+//
+// Requirements:
+// - Implementations MUST use WGS84 datum (EPSG:4326)
+// - Latitude MUST be in the range [-90.0, 90.0] degrees
+// - Longitude MUST be in the range [-180.0, 180.0] degrees
+// - Altitude is meters above the WGS84 ellipsoid (not mean sea level)
+// - Implementations MUST reject positions outside valid ranges
+message Position {
+  // REQUIRED. Latitude in decimal degrees. Range: [-90.0, 90.0].
+  double latitude = 1;
+
+  // REQUIRED. Longitude in decimal degrees. Range: [-180.0, 180.0].
+  double longitude = 2;
+
+  // OPTIONAL. Altitude in meters above WGS84 ellipsoid.
+  // If omitted, altitude is unknown or not applicable.
+  double altitude = 3;
+}
+
+// Confidence represents a normalized confidence or probability score.
+//
+// Requirements:
+// - The value MUST be in the range [0.0, 1.0]
+// - 0.0 represents no confidence / impossible
+// - 1.0 represents full confidence / certain
+// - Implementations MUST reject values outside this range
+message Confidence {
+  // REQUIRED. Confidence value. Range: [0.0, 1.0].
+  float value = 1;
+}
+
+// Metadata provides extensible key-value storage for application-specific data.
+//
+// Requirements:
+// - Keys MUST be non-empty strings
+// - Keys SHOULD use lowercase with underscores (snake_case)
+// - Values MAY be any string (including JSON for complex data)
+// - Implementations MUST preserve unknown metadata during sync
+// - Reserved key prefixes: "hive_" (protocol use), "x_" (experimental)
+message Metadata {
+  // Key-value pairs for extensible metadata.
+  map<string, string> fields = 1;
+}

--- a/spec/proto/cap/v1/composition.proto
+++ b/spec/proto/cap/v1/composition.proto
@@ -1,0 +1,169 @@
+// HIVE Protocol - Capability Composition
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines the capability composition model for HIVE Protocol.
+// Composition rules transform individual platform capabilities into
+// aggregated team capabilities, including emergent capabilities.
+
+syntax = "proto3";
+
+package cap.composition.v1;
+
+import "cap/v1/common.proto";
+import "cap/v1/capability.proto";
+
+// CompositionRuleType defines how capabilities are combined.
+//
+// The four composition patterns enable different aggregation behaviors:
+// - ADDITIVE: Sum of capabilities (e.g., coverage area)
+// - EMERGENT: New capabilities from combinations (e.g., ISR chain)
+// - REDUNDANT: Improved reliability through overlap (e.g., detection probability)
+// - CONSTRAINT: Limiting factors (e.g., team speed = slowest member)
+enum CompositionRuleType {
+  COMPOSITION_RULE_TYPE_UNSPECIFIED = 0;
+
+  // Additive: team_capability = sum(individual_capabilities)
+  // Example: Total sensor coverage = sum of individual coverage areas
+  COMPOSITION_RULE_TYPE_ADDITIVE = 1;
+
+  // Emergent: new capability created when prerequisites are met
+  // Example: ISR_Chain = sensor AND compute AND communications
+  COMPOSITION_RULE_TYPE_EMERGENT = 2;
+
+  // Redundant: improved reliability through multiple providers
+  // Example: detection_prob = 1 - product(1 - individual_prob)
+  COMPOSITION_RULE_TYPE_REDUNDANT = 3;
+
+  // Constraint: team limited by weakest link or best performer
+  // Example: team_speed = min(individual_speeds)
+  COMPOSITION_RULE_TYPE_CONSTRAINT = 4;
+}
+
+// CompositionRule defines how to compose capabilities.
+//
+// Rules are evaluated by cell leaders to aggregate member capabilities
+// into team-level capabilities, including discovering emergent capabilities.
+//
+// Requirements:
+// - Each rule MUST have a unique id within the rule set
+// - Emergent rules MUST specify output_capability
+// - min_inputs MUST be >= 1
+message CompositionRule {
+  // REQUIRED. Unique rule identifier.
+  string id = 1;
+
+  // REQUIRED. Human-readable rule name.
+  string name = 2;
+
+  // REQUIRED. Composition pattern to apply.
+  CompositionRuleType rule_type = 3;
+
+  // REQUIRED. Input capability types required for this rule.
+  // For EMERGENT rules, all types must be present.
+  // For other rules, capabilities of these types are aggregated.
+  repeated capability.v1.CapabilityType input_capabilities = 4;
+
+  // CONDITIONAL. Output capability produced (REQUIRED for EMERGENT rules).
+  // This is the new capability created when the rule conditions are met.
+  optional capability.v1.Capability output_capability = 5;
+
+  // REQUIRED. Minimum number of input capabilities required.
+  // Must be >= 1.
+  uint32 min_inputs = 6;
+
+  // OPTIONAL. Maximum number of inputs to consider.
+  // If not set, all available inputs are used.
+  optional uint32 max_inputs = 7;
+
+  // Method for calculating output confidence from inputs.
+  enum ConfidenceMethod {
+    CONFIDENCE_METHOD_UNSPECIFIED = 0;
+
+    // Output confidence = minimum of all input confidences
+    CONFIDENCE_METHOD_MIN = 1;
+
+    // Output confidence = maximum of all input confidences
+    CONFIDENCE_METHOD_MAX = 2;
+
+    // Output confidence = average of all input confidences
+    CONFIDENCE_METHOD_AVERAGE = 3;
+
+    // Output confidence = product of all input confidences
+    CONFIDENCE_METHOD_PRODUCT = 4;
+
+    // Custom calculation defined in metadata
+    CONFIDENCE_METHOD_CUSTOM = 5;
+  }
+
+  // REQUIRED. How to calculate output confidence.
+  ConfidenceMethod confidence_method = 8;
+
+  // OPTIONAL. Additional rule configuration (JSON).
+  // For CUSTOM confidence method, must include calculation formula.
+  string metadata_json = 9;
+
+  // OPTIONAL. Rule priority for ordering (higher = evaluated first).
+  uint32 priority = 10;
+
+  // OPTIONAL. Whether this rule is currently enabled.
+  // Default: true
+  bool enabled = 11;
+
+  // OPTIONAL. When this rule was defined.
+  common.v1.Timestamp created_at = 12;
+}
+
+// CompositionResult contains the output of composition rule evaluation.
+//
+// Cell leaders publish composition results to advertise team capabilities.
+message CompositionResult {
+  // REQUIRED. Cell ID this composition applies to.
+  string cell_id = 1;
+
+  // Rules that were applied.
+  repeated CompositionRule applied_rules = 2;
+
+  // Input capabilities from cell members.
+  repeated capability.v1.Capability input_capabilities = 3;
+
+  // Output capabilities after composition (including emergent).
+  repeated capability.v1.Capability output_capabilities = 4;
+
+  // Overall composition confidence score.
+  float composition_confidence = 5;
+
+  // When composition was performed.
+  common.v1.Timestamp composed_at = 6;
+
+  // Whether all constraint rules were satisfied.
+  bool valid = 7;
+
+  // Validation errors (if any constraints failed).
+  repeated string validation_errors = 8;
+}
+
+// ApplyCompositionRequest triggers composition rule evaluation.
+message ApplyCompositionRequest {
+  // REQUIRED. Cell ID to apply composition rules.
+  string cell_id = 1;
+
+  // OPTIONAL. Specific rule IDs to apply.
+  // If empty, all enabled rules are applied.
+  repeated string rule_ids = 2;
+
+  // REQUIRED. Input capabilities from cell members.
+  repeated capability.v1.Capability input_capabilities = 3;
+}
+
+// ApplyCompositionResponse contains the composition result.
+message ApplyCompositionResponse {
+  // The composition result.
+  CompositionResult result = 1;
+
+  // Whether composition succeeded.
+  bool success = 2;
+
+  // Error message if composition failed.
+  optional string error_message = 3;
+}

--- a/spec/proto/cap/v1/hierarchy.proto
+++ b/spec/proto/cap/v1/hierarchy.proto
@@ -1,0 +1,208 @@
+// HIVE Protocol - Hierarchical Aggregation
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines hierarchical aggregation summaries for HIVE Protocol.
+// These summaries enable O(n log n) message complexity by aggregating state
+// at each level of the hierarchy (squad -> platoon -> company).
+
+syntax = "proto3";
+
+package cap.hierarchy.v1;
+
+import "cap/v1/common.proto";
+import "cap/v1/capability.proto";
+import "cap/v1/node.proto";
+
+// SquadSummary is the aggregated state of a squad (cell).
+//
+// Squad leaders publish these summaries for consumption by platoon leaders.
+// This reduces N individual NodeState messages to 1 aggregated summary,
+// achieving approximately 95% bandwidth reduction per level.
+//
+// Requirements:
+// - Squad leaders MUST publish summaries at configurable intervals
+// - Summaries MUST reflect the current state of all operational members
+// - Position centroid MUST be weighted by member count
+//
+// Typical squad: 5-8 nodes
+message SquadSummary {
+  // REQUIRED. Squad identifier (matches cell_id).
+  string squad_id = 1;
+
+  // REQUIRED. Current squad leader node ID.
+  string leader_id = 2;
+
+  // Member node IDs (for reference, not full state).
+  repeated string member_ids = 3;
+
+  // REQUIRED. Total member count.
+  uint32 member_count = 4;
+
+  // REQUIRED. Geographic centroid of member positions.
+  // Calculated as average of member lat/lon/alt.
+  common.v1.Position position_centroid = 5;
+
+  // REQUIRED. Average fuel remaining across squad (minutes).
+  float avg_fuel_minutes = 6;
+
+  // REQUIRED. Worst health status in squad.
+  // CRDT: LWW with "worst wins" merge semantics.
+  node.v1.HealthStatus worst_health = 7;
+
+  // REQUIRED. Count of operational members (health >= DEGRADED).
+  uint32 operational_count = 8;
+
+  // REQUIRED. Aggregated capabilities from composition.
+  // These are cell-level capabilities, not individual platform capabilities.
+  repeated capability.v1.Capability aggregated_capabilities = 9;
+
+  // REQUIRED. Squad readiness score [0.0, 1.0].
+  // Computed from: operational_count, fuel, health, capability completeness.
+  float readiness_score = 10;
+
+  // OPTIONAL. Geographic bounding box of the squad.
+  BoundingBox bounding_box = 11;
+
+  // REQUIRED. Timestamp of this aggregation.
+  common.v1.Timestamp aggregated_at = 12;
+}
+
+// PlatoonSummary is the aggregated state of a platoon (3-4 squads).
+//
+// Platoon leaders aggregate SquadSummary messages into PlatoonSummary.
+// This provides a second level of bandwidth reduction.
+//
+// Typical platoon: 24-32 nodes (3-4 squads of 8)
+message PlatoonSummary {
+  // REQUIRED. Platoon identifier.
+  string platoon_id = 1;
+
+  // REQUIRED. Current platoon leader node ID.
+  string leader_id = 2;
+
+  // REQUIRED. Squad IDs in this platoon.
+  repeated string squad_ids = 3;
+
+  // REQUIRED. Number of squads.
+  uint32 squad_count = 4;
+
+  // REQUIRED. Total members across all squads.
+  uint32 total_member_count = 5;
+
+  // REQUIRED. Centroid of squad centroids.
+  common.v1.Position position_centroid = 6;
+
+  // REQUIRED. Average fuel across all squads.
+  float avg_fuel_minutes = 7;
+
+  // REQUIRED. Worst health across all squads.
+  node.v1.HealthStatus worst_health = 8;
+
+  // REQUIRED. Total operational members across all squads.
+  uint32 operational_count = 9;
+
+  // REQUIRED. Platoon-level aggregated capabilities.
+  // Composed from squad-level capabilities.
+  repeated capability.v1.Capability aggregated_capabilities = 10;
+
+  // REQUIRED. Platoon readiness score [0.0, 1.0].
+  // Weighted average of squad readiness scores.
+  float readiness_score = 11;
+
+  // OPTIONAL. Platoon bounding box.
+  BoundingBox bounding_box = 12;
+
+  // REQUIRED. Timestamp of this aggregation.
+  common.v1.Timestamp aggregated_at = 13;
+}
+
+// CompanySummary is the aggregated state of a company (3-4 platoons).
+//
+// This is the third tier of aggregation, enabling battalion+ commanders
+// to maintain situational awareness without processing individual nodes.
+//
+// Typical company: 96-128 nodes (3-4 platoons)
+message CompanySummary {
+  // REQUIRED. Company identifier.
+  string company_id = 1;
+
+  // REQUIRED. Company commander node ID.
+  string leader_id = 2;
+
+  // REQUIRED. Platoon IDs in this company.
+  repeated string platoon_ids = 3;
+
+  // REQUIRED. Number of platoons.
+  uint32 platoon_count = 4;
+
+  // REQUIRED. Total members across all platoons.
+  uint32 total_member_count = 5;
+
+  // REQUIRED. Centroid of platoon centroids.
+  common.v1.Position position_centroid = 6;
+
+  // REQUIRED. Average fuel across all platoons.
+  float avg_fuel_minutes = 7;
+
+  // REQUIRED. Worst health across all platoons.
+  node.v1.HealthStatus worst_health = 8;
+
+  // REQUIRED. Total operational members.
+  uint32 operational_count = 9;
+
+  // REQUIRED. Company-level aggregated capabilities.
+  repeated capability.v1.Capability aggregated_capabilities = 10;
+
+  // REQUIRED. Company readiness score [0.0, 1.0].
+  float readiness_score = 11;
+
+  // OPTIONAL. Company bounding box.
+  BoundingBox bounding_box = 12;
+
+  // REQUIRED. Timestamp of this aggregation.
+  common.v1.Timestamp aggregated_at = 13;
+}
+
+// BoundingBox defines the geographic extent of a formation.
+//
+// Used for spatial queries and tactical situational awareness.
+message BoundingBox {
+  // REQUIRED. Southwest corner (minimum lat/lon).
+  common.v1.Position southwest = 1;
+
+  // REQUIRED. Northeast corner (maximum lat/lon).
+  common.v1.Position northeast = 2;
+
+  // OPTIONAL. Maximum altitude in the formation (meters).
+  float max_altitude = 3;
+
+  // OPTIONAL. Minimum altitude in the formation (meters).
+  float min_altitude = 4;
+
+  // OPTIONAL. Approximate radius from centroid (meters).
+  float radius_m = 5;
+}
+
+// AggregationMetadata provides provenance for aggregated data.
+//
+// Useful for debugging, staleness detection, and audit trails.
+message AggregationMetadata {
+  // Number of source documents aggregated.
+  uint32 source_count = 1;
+
+  // Number of sources excluded (e.g., non-operational).
+  uint32 excluded_count = 2;
+
+  // Aggregation method identifier.
+  string aggregation_method = 3;
+
+  // When aggregation was performed.
+  common.v1.Timestamp performed_at = 4;
+
+  // Timestamp of oldest source (for staleness detection).
+  common.v1.Timestamp oldest_source = 5;
+
+  // Timestamp of newest source.
+  common.v1.Timestamp newest_source = 6;
+}

--- a/spec/proto/cap/v1/node.proto
+++ b/spec/proto/cap/v1/node.proto
@@ -1,0 +1,270 @@
+// HIVE Protocol - Node Model
+// Specification Version: 0.1.0
+// License: CC0 1.0 Universal (Public Domain)
+//
+// This file defines the node model for HIVE Protocol.
+// A Node represents a single platform (UAV, UGV, soldier system, sensor, etc.)
+// participating in the HIVE mesh.
+
+syntax = "proto3";
+
+package cap.node.v1;
+
+import "cap/v1/common.proto";
+import "cap/v1/capability.proto";
+
+// Phase represents the current operational phase of a node in the HIVE Protocol.
+//
+// The protocol operates in three sequential phases:
+// 1. DISCOVERY - Nodes broadcast beacons and discover peers
+// 2. CELL - Nodes form cells (squads) and elect leaders
+// 3. HIERARCHY - Cells organize hierarchically and begin operations
+//
+// Requirements:
+// - Nodes MUST start in PHASE_DISCOVERY
+// - Phase transitions MUST follow the sequence: DISCOVERY -> CELL -> HIERARCHY
+// - Nodes MAY regress to earlier phases on network partition recovery
+enum Phase {
+  // Default value. Implementations MUST NOT use for active nodes.
+  PHASE_UNSPECIFIED = 0;
+
+  // Discovery phase: broadcasting beacons, discovering peers
+  PHASE_DISCOVERY = 1;
+
+  // Cell formation phase: joining/forming cells, leader election
+  PHASE_CELL = 2;
+
+  // Hierarchical operations phase: normal operations within hierarchy
+  PHASE_HIERARCHY = 3;
+}
+
+// HealthStatus represents the operational health of a node.
+//
+// Requirements:
+// - Implementations MUST update health status based on platform diagnostics
+// - Health status affects leader election scoring (lower health = lower score)
+// - Nodes with HEALTH_STATUS_FAILED SHOULD be excluded from operations
+enum HealthStatus {
+  HEALTH_STATUS_UNSPECIFIED = 0;
+
+  // Fully operational, all systems nominal
+  HEALTH_STATUS_NOMINAL = 1;
+
+  // Degraded but operational (reduced capability)
+  HEALTH_STATUS_DEGRADED = 2;
+
+  // Critical failure imminent, limited operations
+  HEALTH_STATUS_CRITICAL = 3;
+
+  // Failed/offline, non-operational
+  HEALTH_STATUS_FAILED = 4;
+}
+
+// OperatorRank maps to standard military rank structures.
+//
+// This enumeration supports human-machine teaming by encoding
+// military rank for authority calculations.
+//
+// Requirements:
+// - Implementations MUST map these values to appropriate rank scores
+// - Rank contributes to leader election when humans are present
+enum OperatorRank {
+  OPERATOR_RANK_UNSPECIFIED = 0;
+
+  // Enlisted ranks (E1-E9)
+  OPERATOR_RANK_E1 = 1;   // Private / Seaman Recruit
+  OPERATOR_RANK_E2 = 2;   // Private First Class
+  OPERATOR_RANK_E3 = 3;   // Lance Corporal / Specialist
+  OPERATOR_RANK_E4 = 4;   // Corporal / Specialist
+  OPERATOR_RANK_E5 = 5;   // Sergeant (Squad Leader level)
+  OPERATOR_RANK_E6 = 6;   // Staff Sergeant
+  OPERATOR_RANK_E7 = 7;   // Sergeant First Class (Platoon Sergeant)
+  OPERATOR_RANK_E8 = 8;   // Master Sergeant
+  OPERATOR_RANK_E9 = 9;   // Sergeant Major
+
+  // Commissioned Officer ranks (O1-O10)
+  OPERATOR_RANK_O1 = 11;  // Second Lieutenant (Platoon Leader)
+  OPERATOR_RANK_O2 = 12;  // First Lieutenant
+  OPERATOR_RANK_O3 = 13;  // Captain (Company Commander)
+  OPERATOR_RANK_O4 = 14;  // Major
+  OPERATOR_RANK_O5 = 15;  // Lieutenant Colonel (Battalion Commander)
+  OPERATOR_RANK_O6 = 16;  // Colonel (Brigade Commander)
+  OPERATOR_RANK_O7 = 17;  // Brigadier General
+  OPERATOR_RANK_O8 = 18;  // Major General
+  OPERATOR_RANK_O9 = 19;  // Lieutenant General
+  OPERATOR_RANK_O10 = 20; // General
+
+  // Warrant Officer ranks (W1-W5)
+  OPERATOR_RANK_W1 = 21;
+  OPERATOR_RANK_W2 = 22;
+  OPERATOR_RANK_W3 = 23;
+  OPERATOR_RANK_W4 = 24;
+  OPERATOR_RANK_W5 = 25;
+}
+
+// AuthorityLevel defines the human authority level for autonomous operations.
+//
+// Based on Sheridan & Verplank autonomy levels, this defines how much
+// authority a human operator has over autonomous platform decisions.
+//
+// Requirements:
+// - Higher authority levels increase influence in leader election
+// - Rules of Engagement MAY mandate minimum authority levels for certain actions
+enum AuthorityLevel {
+  AUTHORITY_LEVEL_UNSPECIFIED = 0;
+
+  // Observer: can view system state, cannot influence decisions
+  AUTHORITY_LEVEL_OBSERVER = 1;
+
+  // Advisor: can provide recommendations, systems may consider but not require
+  AUTHORITY_LEVEL_ADVISOR = 2;
+
+  // Supervisor: provides intent, approves/rejects autonomous plans
+  AUTHORITY_LEVEL_SUPERVISOR = 3;
+
+  // Commander: approves all significant autonomous decisions
+  AUTHORITY_LEVEL_COMMANDER = 4;
+}
+
+// BindingType defines the relationship cardinality between operators and platforms.
+enum BindingType {
+  BINDING_TYPE_UNSPECIFIED = 0;
+
+  // One operator controlling one platform
+  BINDING_TYPE_ONE_TO_ONE = 1;
+
+  // One operator supervising multiple platforms (swarm control)
+  BINDING_TYPE_ONE_TO_MANY = 2;
+
+  // Multiple operators collaborating on one platform
+  BINDING_TYPE_MANY_TO_ONE = 3;
+
+  // Multiple operators supervising multiple platforms
+  BINDING_TYPE_MANY_TO_MANY = 4;
+}
+
+// Operator represents a human operator for human-machine teaming.
+//
+// Requirements:
+// - Operator id MUST be unique across the network
+// - Rank and authority_level affect leader election calculations
+message Operator {
+  // REQUIRED. Unique operator identifier.
+  string id = 1;
+
+  // OPTIONAL. Operator display name.
+  string name = 2;
+
+  // REQUIRED. Military rank of the operator.
+  OperatorRank rank = 3;
+
+  // REQUIRED. Authority level for autonomous operations.
+  AuthorityLevel authority_level = 4;
+
+  // OPTIONAL. Military Occupational Specialty code.
+  string mos = 5;
+
+  // OPTIONAL. Additional operator metadata (JSON).
+  // MAY include: cognitive_load, fatigue, certifications
+  string metadata_json = 6;
+}
+
+// HumanMachinePair represents a binding between operators and platforms.
+//
+// This enables human-machine teaming where humans supervise autonomous platforms.
+message HumanMachinePair {
+  // Operators in this binding.
+  repeated Operator operators = 1;
+
+  // Platform/node IDs bound to these operators.
+  repeated string platform_ids = 2;
+
+  // Cardinality of the binding.
+  BindingType binding_type = 3;
+
+  // When this binding was established.
+  common.v1.Timestamp bound_at = 4;
+}
+
+// NodeConfig contains static configuration for a node.
+//
+// Requirements:
+// - NodeConfig is immutable after node initialization
+// - The id MUST be a valid UUID v4
+// - Implementations MUST NOT modify NodeConfig during operation
+//
+// CRDT Semantics: NodeConfig is treated as immutable and replicated as-is.
+message NodeConfig {
+  // REQUIRED. Unique platform identifier (UUID v4).
+  string id = 1;
+
+  // REQUIRED. Platform type identifier.
+  // Examples: "UAV", "UGV", "SOLDIER_SYSTEM", "SENSOR_NODE"
+  string platform_type = 2;
+
+  // REQUIRED. Static capabilities of this platform.
+  // CRDT: G-Set semantics (grow-only)
+  repeated capability.v1.Capability capabilities = 3;
+
+  // OPTIONAL. Maximum communication range in meters.
+  float comm_range_m = 4;
+
+  // OPTIONAL. Maximum platform speed in meters per second.
+  float max_speed_mps = 5;
+
+  // OPTIONAL. Human-machine binding for this platform.
+  optional HumanMachinePair operator_binding = 6;
+
+  // OPTIONAL. Timestamp when node was configured/initialized.
+  common.v1.Timestamp created_at = 7;
+}
+
+// NodeState contains dynamic state for a node.
+//
+// Requirements:
+// - NodeState MUST be updated by the owning node
+// - Timestamp MUST be updated on every state change
+// - Implementations MUST use LWW semantics for conflict resolution
+//
+// CRDT Semantics: Uses LWW-Register for most fields, PN-Counter for fuel.
+message NodeState {
+  // REQUIRED. Current geographic position.
+  // CRDT: LWW-Register
+  common.v1.Position position = 1;
+
+  // OPTIONAL. Fuel/battery remaining in minutes.
+  // CRDT: PN-Counter (can increment and decrement)
+  uint32 fuel_minutes = 2;
+
+  // REQUIRED. Current health status.
+  // CRDT: LWW-Register
+  HealthStatus health = 3;
+
+  // REQUIRED. Current protocol phase.
+  // CRDT: LWW-Register
+  Phase phase = 4;
+
+  // OPTIONAL. ID of the cell this node belongs to.
+  // CRDT: LWW-Register
+  optional string cell_id = 5;
+
+  // OPTIONAL. ID of the zone for hierarchical routing.
+  // CRDT: LWW-Register
+  optional string zone_id = 6;
+
+  // REQUIRED. Last update timestamp for LWW conflict resolution.
+  // Implementations MUST update this on every state change.
+  common.v1.Timestamp timestamp = 7;
+}
+
+// Node represents the complete state of a platform in the HIVE mesh.
+//
+// This is the primary entity synchronized across the CRDT mesh.
+// Each physical platform MUST have exactly one Node representation.
+message Node {
+  // REQUIRED. Static configuration (immutable).
+  NodeConfig config = 1;
+
+  // REQUIRED. Dynamic state (CRDT-backed).
+  NodeState state = 2;
+}


### PR DESCRIPTION
## Summary

Restructures repository to support NATO/IETF standards submission by clearly separating normative specification from reference implementation.

### New Directories

**`spec/` - Normative Specification**
- `draft-hive-protocol-00.md`: RFC-style protocol specification with RFC 2119 keywords
- `proto/cap/v1/*.proto`: Normative Protocol Buffer definitions (8 schema files)
- Licensing: CC0 (public domain) for protos, CC BY 4.0 for docs

**`governance/` - Project Governance**
- `CHARTER.md`: Project mission, principles, decision-making
- `CONTRIBUTING.md`: Contribution guidelines
- `PATENT_PLEDGE.md`: IP commitments (royalty-free, defensive termination)

### Key Features

- **RFC-style specification** with MUST/SHOULD/MAY requirements
- **CRDT semantics documented** in proto comments (LWW-Register, G-Set, OR-Set)
- **Standards-compatible licensing**: Protos are CC0 (public domain) for maximum adoption
- **Patent pledge** compatible with IETF, NATO, and W3C policies

### Code Quality Fixes

Fixed clippy warnings in `hive-ffi`:
- Removed unused `mut` bindings
- Moved test module to end of file (per `items_after_test_module` lint)
- Added safety documentation for `JNI_OnLoad`
- Made `JNI_OnLoad` properly `unsafe`

## Test plan

- [x] `cargo clippy --all-features` passes
- [x] `cargo test` passes
- [x] Pre-commit hooks pass
- [ ] Review specification for accuracy against implementation
- [ ] Review patent pledge language with legal counsel

## Next Steps

1. Complete remaining proto files (security.proto, role.proto, zone.proto)
2. Add example JSON test vectors to `spec/examples/`
3. Add specification diagrams to `spec/diagrams/`
4. When stable, submit as IETF Internet-Draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)