### PR TITLE
fix: Enable static peer configuration for AutomergeIroh sync (#235)

### DIFF
--- a/hive-protocol/src/storage/automerge_backend.rs
+++ b/hive-protocol/src/storage/automerge_backend.rs
@@ -444,6 +444,23 @@ impl SyncCapable for AutomergeBackend {
                         // Mark as having active handler
                         active_handlers.write().unwrap().insert(peer_id);
 
+                        // Issue #235: Trigger sync of all existing documents with new peer
+                        // Documents created before this peer connected need to be synced
+                        let coord_for_initial_sync = Arc::clone(&coordinator);
+                        let initial_sync_peer_id = peer_id;
+                        tokio::spawn(async move {
+                            if let Err(e) = coord_for_initial_sync
+                                .sync_all_documents_with_peer(initial_sync_peer_id)
+                                .await
+                            {
+                                tracing::warn!(
+                                    "Failed to sync existing documents with new peer {:?}: {}",
+                                    initial_sync_peer_id,
+                                    e
+                                );
+                            }
+                        });
+
                         let coordinator_clone = Arc::clone(&coordinator);
                         let sync_active_clone = Arc::clone(&sync_active);
                         let active_handlers_clone = Arc::clone(&active_handlers);

--- a/hive-protocol/src/storage/automerge_sync.rs
+++ b/hive-protocol/src/storage/automerge_sync.rs
@@ -492,6 +492,38 @@ impl AutomergeSyncCoordinator {
         Ok(())
     }
 
+    /// Sync all existing documents with a newly connected peer (Issue #235)
+    ///
+    /// This is called when a new peer connection is established to ensure
+    /// documents created before the peer connected are synchronized.
+    ///
+    /// # Arguments
+    ///
+    /// * `peer_id` - The EndpointId of the newly connected peer
+    pub async fn sync_all_documents_with_peer(&self, peer_id: EndpointId) -> Result<()> {
+        // Get all document keys from the store
+        let all_docs = self.store.scan_prefix("")?;
+
+        tracing::info!(
+            "Syncing {} existing documents with new peer {:?}",
+            all_docs.len(),
+            peer_id
+        );
+
+        for (doc_key, _doc) in all_docs {
+            if let Err(e) = self.sync_document_with_peer(&doc_key, peer_id).await {
+                tracing::warn!(
+                    "Failed to sync document {} with new peer {:?}: {}",
+                    doc_key,
+                    peer_id,
+                    e
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     /// Handle an incoming sync connection from a peer
     ///
     /// This is called when a peer initiates sync with us.

--- a/hive-protocol/src/sync/automerge.rs
+++ b/hive-protocol/src/sync/automerge.rs
@@ -1389,6 +1389,7 @@ impl PeerDiscovery for IrohPeerDiscovery {
 // SyncEngine implementation for AutomergeIrohBackend
 struct IrohSyncEngine {
     backend: Arc<crate::storage::AutomergeBackend>,
+    transport: Arc<crate::network::IrohTransport>,
 }
 
 #[async_trait]
@@ -1428,6 +1429,87 @@ impl SyncEngine for IrohSyncEngine {
             source: None,
         })?;
         Ok(stats.peer_count > 0)
+    }
+
+    /// Connect to a peer using their EndpointId and addresses (Issue #235)
+    ///
+    /// This enables static peer configuration in containerlab and similar environments
+    /// where mDNS discovery may not work across network namespaces.
+    async fn connect_to_peer(&self, endpoint_id_hex: &str, addresses: &[String]) -> Result<bool> {
+        use crate::network::PeerInfo as NetworkPeerInfo;
+
+        // Parse the endpoint ID from hex
+        let endpoint_id_bytes = hex::decode(endpoint_id_hex)
+            .map_err(|e| Error::Internal(format!("Invalid endpoint_id_hex: {}", e)))?;
+
+        if endpoint_id_bytes.len() != 32 {
+            return Err(Error::Internal(format!(
+                "Invalid endpoint_id_hex length: expected 32 bytes, got {}",
+                endpoint_id_bytes.len()
+            )));
+        }
+
+        // Tie-breaking: only the peer with the lower EndpointId initiates the connection
+        // This prevents duplicate connections where both peers try to connect to each other
+        let our_endpoint_id = self.transport.endpoint_id();
+        let our_endpoint_hex = hex::encode(our_endpoint_id.as_bytes());
+
+        if our_endpoint_hex.as_str() > endpoint_id_hex {
+            // We have the higher EndpointId, so we should wait for them to connect to us
+            tracing::debug!(
+                our_endpoint = %our_endpoint_hex,
+                peer_endpoint = %endpoint_id_hex,
+                "Tie-breaking: peer has lower EndpointId, waiting for them to connect"
+            );
+            return Ok(false);
+        }
+
+        tracing::debug!(
+            our_endpoint = %our_endpoint_hex,
+            peer_endpoint = %endpoint_id_hex,
+            addresses = ?addresses,
+            "Tie-breaking: we have lower EndpointId, initiating connection"
+        );
+
+        // Create PeerInfo for the transport
+        let peer_info = NetworkPeerInfo {
+            name: format!("peer-{}", &endpoint_id_hex[..8]),
+            node_id: endpoint_id_hex.to_string(),
+            addresses: addresses.to_vec(),
+            relay_url: None,
+        };
+
+        // Attempt to connect via transport
+        // Returns Some(conn) if new connection, None if already connected
+        match self.transport.connect_peer(&peer_info).await {
+            Ok(Some(_conn)) => {
+                tracing::info!(
+                    peer_endpoint = %endpoint_id_hex,
+                    "Successfully connected to peer"
+                );
+                Ok(true)
+            }
+            Ok(None) => {
+                // Already connected (they initiated)
+                tracing::debug!(
+                    peer_endpoint = %endpoint_id_hex,
+                    "Already connected to peer (they initiated)"
+                );
+                Ok(true)
+            }
+            Err(e) => {
+                tracing::warn!(
+                    peer_endpoint = %endpoint_id_hex,
+                    error = %e,
+                    "Failed to connect to peer"
+                );
+                Err(Error::Network {
+                    message: format!("Failed to connect to peer: {}", e),
+                    peer_id: Some(endpoint_id_hex.to_string()),
+                    source: None,
+                })
+            }
+        }
     }
 }
 
@@ -1493,6 +1575,7 @@ impl DataSyncBackend for AutomergeIrohBackend {
     fn sync_engine(&self) -> Arc<dyn SyncEngine> {
         Arc::new(IrohSyncEngine {
             backend: Arc::clone(&self.backend),
+            transport: Arc::clone(&self.transport),
         })
     }
 

--- a/hive-protocol/src/sync/traits.rs
+++ b/hive-protocol/src/sync/traits.rs
@@ -178,6 +178,28 @@ pub trait SyncEngine: Send + Sync {
         // Default: no-op (most backends sync automatically)
         Ok(())
     }
+
+    /// Connect to a peer using their EndpointId and addresses (Issue #235)
+    ///
+    /// Establishes a connection to a peer with a known EndpointId and network addresses.
+    /// Used for static peer configuration in containerlab and similar environments.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint_id_hex` - The peer's EndpointId as a hex string (64 chars)
+    /// * `addresses` - List of socket addresses (e.g., "192.168.1.1:12345")
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)` - Connection established successfully
+    /// * `Ok(false)` - Tie-breaking: peer will connect to us instead
+    /// * `Err(e)` - Connection failed
+    ///
+    /// Default implementation returns Ok(false) for backends that don't support this.
+    async fn connect_to_peer(&self, endpoint_id_hex: &str, addresses: &[String]) -> Result<bool> {
+        let _ = (endpoint_id_hex, addresses);
+        Ok(false)
+    }
 }
 
 /// Trait 4: Lifecycle Management and Composition

--- a/hive-sim/Cargo.toml
+++ b/hive-sim/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+hex = "0.4"
 
 # TUI dependencies (will be added later for visualization)
 # ratatui = "0.25"

--- a/hive-sim/src/main.rs
+++ b/hive-sim/src/main.rs
@@ -1180,11 +1180,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create backend
     println!("[{}] Creating {} backend...", node_id, backend_type);
-    let backend = create_backend(&backend_type, &node_id).await?;
+    let backend = create_backend(&backend_type, &node_id, tcp_listen_port).await?;
 
     // Initialize backend
     println!("[{}] Initializing backend...", node_id);
-    let config = create_backend_config(&node_id, &backend_type, tcp_listen_port, tcp_connect_addr)?;
+    let config = create_backend_config(
+        &node_id,
+        &backend_type,
+        tcp_listen_port,
+        tcp_connect_addr.clone(),
+    )?;
     backend.initialize(config).await?;
     println!("[{}] ✓ Backend initialized", node_id);
 
@@ -1227,6 +1232,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("[{}] Starting sync...", node_id);
     sync_engine.start_sync().await?;
     println!("[{}] ✓ Sync started", node_id);
+
+    // Connect to Automerge peers using static configuration (Issue #235)
+    // This is needed because mDNS doesn't work across containerlab network namespaces
+    #[cfg(feature = "automerge-backend")]
+    if backend_type == "automerge" {
+        connect_to_automerge_peers(&sync_engine, &node_id, &tcp_connect_addr).await?;
+    }
 
     // Step 4: Spawn aggregation tasks based on ROLE if in hierarchical mode
     if is_hierarchical_mode {
@@ -1678,6 +1690,7 @@ fn log_metrics(event: &MetricsEvent) {
 async fn create_backend(
     backend_type: &str,
     node_id: &str,
+    tcp_listen_port: Option<u16>,
 ) -> Result<Box<dyn DataSyncBackend>, Box<dyn std::error::Error>> {
     match backend_type {
         "ditto" => Ok(Box::new(DittoBackend::new())),
@@ -1692,10 +1705,33 @@ async fn create_backend(
                 AutomergeStore::open(&persistence_dir)
                     .map_err(|e| format!("Failed to open AutomergeStore: {}", e))?,
             );
+
+            // Get formation ID from environment (used as seed prefix for deterministic keys)
+            let formation_id =
+                std::env::var("DITTO_APP_ID").unwrap_or_else(|_| "default-formation".to_string());
+
+            // Create deterministic seed from formation ID and node ID (Issue #235)
+            // This ensures EndpointIds are predictable for static peer configuration
+            let seed = format!("{}/{}", formation_id, node_id);
+
+            // Determine bind address for QUIC transport
+            let bind_addr: std::net::SocketAddr = if let Some(port) = tcp_listen_port {
+                format!("0.0.0.0:{}", port).parse()?
+            } else {
+                "0.0.0.0:0".parse()?
+            };
+
             let transport = Arc::new(
-                IrohTransport::new()
+                IrohTransport::from_seed_with_discovery_at_addr(&seed, bind_addr)
                     .await
                     .map_err(|e| format!("Failed to create IrohTransport: {}", e))?,
+            );
+
+            eprintln!(
+                "[{}] Created Automerge transport with seed '{}', EndpointId: {}",
+                node_id,
+                seed,
+                hex::encode(transport.endpoint_id().as_bytes())
             );
 
             Ok(Box::new(AutomergeIrohBackend::from_parts(store, transport)))
@@ -1767,6 +1803,110 @@ fn create_backend_config(
     };
 
     Ok(config)
+}
+
+/// Connect to Automerge peers using static configuration (Issue #235)
+///
+/// Parses TCP_CONNECT environment variable and establishes QUIC connections
+/// to peers using their deterministically-derived EndpointIds.
+///
+/// # TCP_CONNECT Format
+///
+/// `peer_name|hostname:port,peer_name2|hostname2:port2,...`
+///
+/// Example: `node-1|clab-mesh-node-1:9000,node-2|clab-mesh-node-2:9000`
+///
+/// # EndpointId Derivation
+///
+/// EndpointIds are derived from seeds using the same algorithm as `IrohTransport::from_seed()`:
+/// - Seed format: `{formation_id}/{peer_name}`
+/// - Hash: SHA-256 with domain separator "hive-iroh-key-v1:"
+/// - Result: ed25519 public key (EndpointId)
+#[cfg(feature = "automerge-backend")]
+async fn connect_to_automerge_peers(
+    sync_engine: &Arc<dyn hive_protocol::sync::SyncEngine>,
+    node_id: &str,
+    tcp_connect_addr: &Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let tcp_connect = match tcp_connect_addr {
+        Some(addr) => addr,
+        None => return Ok(()), // No peers to connect
+    };
+
+    if tcp_connect.is_empty() {
+        return Ok(());
+    }
+
+    // Get formation ID for deriving peer EndpointIds
+    let formation_id =
+        std::env::var("DITTO_APP_ID").unwrap_or_else(|_| "default-formation".to_string());
+
+    eprintln!(
+        "[{}] Connecting to Automerge peers from TCP_CONNECT: {}",
+        node_id, tcp_connect
+    );
+
+    // Parse: "peer_name|hostname:port,peer_name2|hostname2:port2,..."
+    for peer_spec in tcp_connect.split(',') {
+        let peer_spec = peer_spec.trim();
+        if peer_spec.is_empty() {
+            continue;
+        }
+
+        let parts: Vec<&str> = peer_spec.splitn(2, '|').collect();
+        if parts.len() != 2 {
+            eprintln!(
+                "[{}] Invalid peer spec (expected 'name|address'): {}",
+                node_id, peer_spec
+            );
+            continue;
+        }
+
+        let peer_name = parts[0];
+        let peer_addr = parts[1];
+
+        // Skip connecting to self
+        if peer_name == node_id {
+            continue;
+        }
+
+        // Derive EndpointId from peer seed
+        let peer_seed = format!("{}/{}", formation_id, peer_name);
+        let peer_endpoint_id = IrohTransport::endpoint_id_from_seed(&peer_seed);
+        let peer_endpoint_hex = hex::encode(peer_endpoint_id.as_bytes());
+
+        eprintln!(
+            "[{}] Connecting to peer '{}' at {} (EndpointId: {}...)",
+            node_id,
+            peer_name,
+            peer_addr,
+            &peer_endpoint_hex[..16]
+        );
+
+        // Connect using the SyncEngine trait method
+        match sync_engine
+            .connect_to_peer(&peer_endpoint_hex, &[peer_addr.to_string()])
+            .await
+        {
+            Ok(true) => {
+                eprintln!("[{}] ✓ Connected to peer '{}'", node_id, peer_name);
+            }
+            Ok(false) => {
+                eprintln!(
+                    "[{}] → Waiting for peer '{}' to connect (tie-breaking)",
+                    node_id, peer_name
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "[{}] ✗ Failed to connect to peer '{}': {}",
+                    node_id, peer_name, e
+                );
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Event-driven hierarchical mode with capability reporting


### PR DESCRIPTION
## Summary

- Fixes AutomergeIroh peer sync not completing in containerlab environments
- Adds `connect_to_peer()` method to SyncEngine trait for static peer configuration
- Uses deterministic EndpointId derivation for predictable peer addressing
- Triggers sync of existing documents when new peers connect

## Root Cause

Two issues prevented AutomergeIroh sync from working in containerlab:

1. **TCP_CONNECT was ignored**: The `tcp_connect_address` configuration was never used to establish QUIC connections
2. **Pre-existing docs not synced**: Documents created before peer connections weren't synchronized to newly connected peers

## Changes

### SyncEngine Trait
- Add `connect_to_peer(endpoint_id_hex, addresses)` method
- Uses tie-breaking (lower EndpointId initiates) to prevent duplicate connections

### IrohSyncEngine
- Implement `connect_to_peer()` with hex EndpointId parsing
- Add transport reference for peer connections

### AutomergeSyncCoordinator  
- Add `sync_all_documents_with_peer()` for initial sync with new peers
- Uses `store.scan_prefix("")` to get all document keys

### AutomergeBackend
- Spawn `sync_all_documents_with_peer()` task when new peer detected
- Ensures pre-existing documents are synchronized

### hive-sim
- Use `from_seed_with_discovery_at_addr()` for deterministic keys
- Add `connect_to_automerge_peers()` to parse TCP_CONNECT format
- Format: `peer_name|hostname:port,peer_name2|hostname2:port2,...`

## Test plan

- [ ] Deploy 24-node automerge hierarchical test in containerlab
- [ ] Verify QUIC connections are established between peers
- [ ] Verify documents sync correctly across all nodes
- [ ] Compare sync latency with previous (non-working) implementation

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)