### PR TITLE
feat: Implement automatic reconnection with exponential backoff (#253)

### DIFF
--- a/hive-protocol/src/ffi/peer.rs
+++ b/hive-protocol/src/ffi/peer.rs
@@ -57,6 +57,10 @@ pub const HIVE_EVENT_CONNECTED: c_int = 1;
 pub const HIVE_EVENT_DISCONNECTED: c_int = 2;
 /// Peer connection degraded event type
 pub const HIVE_EVENT_DEGRADED: c_int = 3;
+/// Event: Reconnection attempt in progress (Issue #253)
+pub const HIVE_EVENT_RECONNECTING: c_int = 4;
+/// Event: Reconnection attempt failed (Issue #253)
+pub const HIVE_EVENT_RECONNECT_FAILED: c_int = 5;
 
 // =============================================================================
 // Global State
@@ -537,6 +541,42 @@ fn invoke_callback(callback: PeerEventCallback, event: &PeerEvent) {
                 health_cstr.as_ptr(),
             );
         }
+        PeerEvent::Reconnecting {
+            peer_id,
+            attempt,
+            max_attempts,
+        } => {
+            let peer_id_cstr = CString::new(peer_id.to_string()).unwrap_or_default();
+            let info_cstr = CString::new(format!(
+                "attempt={}/{}",
+                attempt,
+                max_attempts.map_or("∞".to_string(), |m| m.to_string())
+            ))
+            .unwrap_or_default();
+            callback(
+                HIVE_EVENT_RECONNECTING,
+                peer_id_cstr.as_ptr(),
+                info_cstr.as_ptr(),
+            );
+        }
+        PeerEvent::ReconnectFailed {
+            peer_id,
+            attempt,
+            error,
+            will_retry,
+        } => {
+            let peer_id_cstr = CString::new(peer_id.to_string()).unwrap_or_default();
+            let info_cstr = CString::new(format!(
+                "attempt={}, error={}, will_retry={}",
+                attempt, error, will_retry
+            ))
+            .unwrap_or_default();
+            callback(
+                HIVE_EVENT_RECONNECT_FAILED,
+                peer_id_cstr.as_ptr(),
+                info_cstr.as_ptr(),
+            );
+        }
     }
 }
 
@@ -736,6 +776,8 @@ mod tests {
         assert_eq!(HIVE_EVENT_CONNECTED, 1);
         assert_eq!(HIVE_EVENT_DISCONNECTED, 2);
         assert_eq!(HIVE_EVENT_DEGRADED, 3);
+        assert_eq!(HIVE_EVENT_RECONNECTING, 4);
+        assert_eq!(HIVE_EVENT_RECONNECT_FAILED, 5);
     }
 
     #[test]

--- a/hive-protocol/src/transport/iroh.rs
+++ b/hive-protocol/src/transport/iroh.rs
@@ -9,6 +9,7 @@
 //! - **Peer Events (Issue #252)**: Emits `PeerEvent` notifications on connect/disconnect
 //! - **Connection Health**: Tracks connection establishment time and disconnect reasons
 
+use super::reconnection::{ReconnectionManager, ReconnectionPolicy};
 use super::{
     DisconnectReason, MeshConnection, MeshTransport, NodeId, PeerEvent, PeerEventReceiver,
     PeerEventSender, Result, TransportError, PEER_EVENT_CHANNEL_CAPACITY,
@@ -73,6 +74,12 @@ pub struct IrohMeshTransport {
 
     /// Cleanup interval
     cleanup_interval: Duration,
+
+    /// Reconnection manager (Issue #253)
+    reconnection: Arc<RwLock<ReconnectionManager>>,
+
+    /// Track which peers are from static config (vs discovered)
+    static_peers: Arc<RwLock<std::collections::HashSet<NodeId>>>,
 }
 
 impl IrohMeshTransport {
@@ -98,6 +105,28 @@ impl IrohMeshTransport {
         peer_config: PeerConfig,
         cleanup_interval: Duration,
     ) -> Self {
+        Self::with_reconnection_policy(
+            transport,
+            peer_config,
+            cleanup_interval,
+            ReconnectionPolicy::default(),
+        )
+    }
+
+    /// Create a new Iroh mesh transport with full configuration
+    ///
+    /// # Arguments
+    ///
+    /// * `transport` - Underlying IrohTransport
+    /// * `peer_config` - Static peer configuration for discovery
+    /// * `cleanup_interval` - Interval for stale peer cleanup
+    /// * `reconnection_policy` - Policy for automatic reconnection (Issue #253)
+    pub fn with_reconnection_policy(
+        transport: Arc<IrohTransport>,
+        peer_config: PeerConfig,
+        cleanup_interval: Duration,
+        reconnection_policy: ReconnectionPolicy,
+    ) -> Self {
         Self {
             transport,
             peer_config: Arc::new(RwLock::new(peer_config)),
@@ -107,6 +136,8 @@ impl IrohMeshTransport {
             event_senders: Arc::new(RwLock::new(Vec::new())),
             cleanup_running: Arc::new(AtomicBool::new(false)),
             cleanup_interval,
+            reconnection: Arc::new(RwLock::new(ReconnectionManager::new(reconnection_policy))),
+            static_peers: Arc::new(RwLock::new(std::collections::HashSet::new())),
         }
     }
 
@@ -195,10 +226,12 @@ impl IrohMeshTransport {
         &self.transport
     }
 
-    /// Start the background cleanup task (Issue #244)
+    /// Start the background cleanup and reconnection task (Issue #244 + #253)
     ///
-    /// This spawns a task that periodically checks for dead connections
-    /// and emits disconnect events.
+    /// This spawns a task that periodically:
+    /// 1. Checks for dead connections and emits disconnect events
+    /// 2. Schedules static peers for reconnection
+    /// 3. Attempts due reconnections with exponential backoff
     fn start_cleanup_task(&self) {
         if self
             .cleanup_running
@@ -213,9 +246,26 @@ impl IrohMeshTransport {
         let event_senders = Arc::clone(&self.event_senders);
         let cleanup_running = Arc::clone(&self.cleanup_running);
         let interval = self.cleanup_interval;
+        let reconnection = Arc::clone(&self.reconnection);
+        let static_peers = Arc::clone(&self.static_peers);
+        let transport = Arc::clone(&self.transport);
+        let peer_config = Arc::clone(&self.peer_config);
 
         tokio::spawn(async move {
-            info!("Started peer cleanup task with interval {:?}", interval);
+            info!(
+                "Started peer cleanup/reconnection task with interval {:?}",
+                interval
+            );
+
+            // Helper to emit events
+            let emit_event = |event: PeerEvent, senders: &Arc<RwLock<Vec<PeerEventSender>>>| {
+                let mut senders = senders.write().unwrap();
+                senders.retain(|sender| match sender.try_send(event.clone()) {
+                    Ok(()) => true,
+                    Err(mpsc::error::TrySendError::Full(_)) => true,
+                    Err(mpsc::error::TrySendError::Closed(_)) => false,
+                });
+            };
 
             while cleanup_running.load(Ordering::SeqCst) {
                 tokio::time::sleep(interval).await;
@@ -224,7 +274,7 @@ impl IrohMeshTransport {
                     break;
                 }
 
-                // Check for dead connections
+                // Phase 1: Check for dead connections
                 let dead_peers: Vec<_> = {
                     let conns = connections.read().unwrap();
                     conns
@@ -236,9 +286,12 @@ impl IrohMeshTransport {
                         .collect()
                 };
 
-                // Remove dead connections and emit events
+                // Remove dead connections, emit events, schedule reconnection
                 if !dead_peers.is_empty() {
                     let mut conns = connections.write().unwrap();
+                    let static_set = static_peers.read().unwrap();
+                    let mut recon = reconnection.write().unwrap();
+
                     for (peer_id, reason, connected_at) in dead_peers {
                         conns.remove(&peer_id);
 
@@ -249,19 +302,122 @@ impl IrohMeshTransport {
                         };
 
                         debug!("Cleanup: Peer {} disconnected: {:?}", peer_id, event);
+                        emit_event(event, &event_senders);
 
-                        // Emit event to subscribers
-                        let mut senders = event_senders.write().unwrap();
-                        senders.retain(|sender| match sender.try_send(event.clone()) {
-                            Ok(()) => true,
-                            Err(mpsc::error::TrySendError::Full(_)) => true,
-                            Err(mpsc::error::TrySendError::Closed(_)) => false,
-                        });
+                        // Schedule reconnection for static peers (Issue #253)
+                        let is_static = static_set.contains(&peer_id);
+                        if is_static {
+                            recon.schedule_reconnect(peer_id.clone(), true);
+                            debug!("Scheduled reconnection for static peer: {}", peer_id);
+                        }
+                    }
+                }
+
+                // Phase 2: Attempt due reconnections (Issue #253)
+                let due_peers: Vec<NodeId> = {
+                    let recon = reconnection.read().unwrap();
+                    if !recon.is_enabled() {
+                        continue;
+                    }
+                    recon.due_reconnections()
+                };
+
+                for peer_id in due_peers {
+                    // Get current attempt info
+                    let (attempt, max_attempts) = {
+                        let recon = reconnection.read().unwrap();
+                        let state = recon.get_state(&peer_id);
+                        let attempt = state.map(|s| s.attempts + 1).unwrap_or(1);
+                        let max = recon.policy().max_retries;
+                        (attempt, max)
+                    };
+
+                    // Emit reconnecting event
+                    emit_event(
+                        PeerEvent::Reconnecting {
+                            peer_id: peer_id.clone(),
+                            attempt,
+                            max_attempts,
+                        },
+                        &event_senders,
+                    );
+
+                    // Try to reconnect
+                    let peer_info_opt = {
+                        let config = peer_config.read().unwrap();
+                        config
+                            .peers
+                            .iter()
+                            .find(|p| p.name == peer_id.as_str())
+                            .cloned()
+                    };
+
+                    let result = if let Some(peer_info) = peer_info_opt {
+                        transport.connect_peer(&peer_info).await
+                    } else {
+                        Err(anyhow::anyhow!("Peer not found in config: {}", peer_id))
+                    };
+
+                    match result {
+                        Ok(Some(conn)) => {
+                            // Success - new connection
+                            let connected_at = Instant::now();
+                            let mesh_conn =
+                                IrohMeshConnection::new(peer_id.clone(), conn, connected_at);
+                            connections
+                                .write()
+                                .unwrap()
+                                .insert(peer_id.clone(), mesh_conn);
+                            reconnection.write().unwrap().reconnected(&peer_id);
+
+                            info!("Reconnected to peer: {} (attempt {})", peer_id, attempt);
+                            emit_event(
+                                PeerEvent::Connected {
+                                    peer_id: peer_id.clone(),
+                                    connected_at,
+                                },
+                                &event_senders,
+                            );
+                        }
+                        Ok(None) => {
+                            // Already connected (they initiated)
+                            reconnection.write().unwrap().reconnected(&peer_id);
+                            info!(
+                                "Peer {} already connected (remote initiated), clearing reconnection",
+                                peer_id
+                            );
+                        }
+                        Err(e) => {
+                            let error_msg = e.to_string();
+                            let will_retry = {
+                                let mut recon = reconnection.write().unwrap();
+                                let will_retry = recon.failed(&peer_id, error_msg.clone());
+                                if !will_retry {
+                                    recon.remove(&peer_id);
+                                }
+                                will_retry
+                            };
+
+                            warn!(
+                                "Reconnection to {} failed (attempt {}): {} - will_retry={}",
+                                peer_id, attempt, error_msg, will_retry
+                            );
+
+                            emit_event(
+                                PeerEvent::ReconnectFailed {
+                                    peer_id: peer_id.clone(),
+                                    attempt,
+                                    error: error_msg,
+                                    will_retry,
+                                },
+                                &event_senders,
+                            );
+                        }
                     }
                 }
             }
 
-            info!("Stopped peer cleanup task");
+            info!("Stopped peer cleanup/reconnection task");
         });
     }
 
@@ -281,12 +437,16 @@ impl MeshTransport for IrohMeshTransport {
 
         // Load static peer config and register peers
         let config = self.peer_config.read().unwrap();
+        let mut static_peers = self.static_peers.write().unwrap();
         for peer_info in &config.peers {
             let node_id = NodeId::new(peer_info.name.clone());
             if let Ok(endpoint_id) = peer_info.endpoint_id() {
-                self.register_peer(node_id, endpoint_id);
+                self.register_peer(node_id.clone(), endpoint_id);
+                // Mark as static peer for reconnection (Issue #253)
+                static_peers.insert(node_id);
             }
         }
+        drop(static_peers);
 
         // Start background cleanup task (Issue #244)
         self.start_cleanup_task();

--- a/hive-protocol/src/transport/mod.rs
+++ b/hive-protocol/src/transport/mod.rs
@@ -59,6 +59,8 @@ pub mod iroh;
 #[cfg(feature = "ditto-backend")]
 pub mod ditto;
 
+pub mod reconnection;
+
 /// Node identifier in the mesh network
 ///
 /// Uniquely identifies a node in the HIVE mesh. This is separate from
@@ -149,6 +151,28 @@ pub enum PeerEvent {
         peer_id: NodeId,
         /// Current health metrics
         health: ConnectionHealth,
+    },
+
+    /// Attempting to reconnect to a peer (Issue #253)
+    Reconnecting {
+        /// The peer's node ID
+        peer_id: NodeId,
+        /// Current attempt number (1-indexed)
+        attempt: u32,
+        /// Maximum attempts configured (None = infinite)
+        max_attempts: Option<u32>,
+    },
+
+    /// Reconnection attempt failed (Issue #253)
+    ReconnectFailed {
+        /// The peer's node ID
+        peer_id: NodeId,
+        /// Current attempt number
+        attempt: u32,
+        /// Error message
+        error: String,
+        /// Whether more retries will be attempted
+        will_retry: bool,
     },
 }
 

--- a/hive-protocol/src/transport/reconnection.rs
+++ b/hive-protocol/src/transport/reconnection.rs
@@ -1,0 +1,489 @@
+//! Automatic reconnection with exponential backoff (Issue #253)
+//!
+//! This module provides reconnection management for peers that disconnect.
+//! It implements exponential backoff with jitter to prevent thundering herd
+//! problems when multiple peers attempt to reconnect simultaneously.
+//!
+//! ## Design
+//!
+//! - **Static-config peers**: Automatically queued for reconnection on disconnect
+//! - **mDNS-discovered peers**: Rely on rediscovery, not reconnection loops
+//! - **Exponential backoff**: Delay doubles after each failure (with cap)
+//! - **Jitter**: Random variation prevents synchronized retry storms
+//!
+//! ## Example
+//!
+//! ```ignore
+//! use hive_protocol::transport::reconnection::{ReconnectionPolicy, ReconnectionManager};
+//!
+//! let policy = ReconnectionPolicy::default();
+//! let mut manager = ReconnectionManager::new(policy);
+//!
+//! // When a peer disconnects
+//! manager.schedule_reconnect(peer_id.clone());
+//!
+//! // In the background task
+//! for peer_id in manager.due_reconnections() {
+//!     match transport.connect(&peer_id).await {
+//!         Ok(_) => manager.reconnected(&peer_id),
+//!         Err(e) => manager.failed(&peer_id, e.to_string()),
+//!     }
+//! }
+//! ```
+
+use super::NodeId;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+/// Policy configuration for automatic reconnection
+///
+/// Configures how the reconnection manager handles peer disconnections.
+/// Uses exponential backoff with optional jitter to prevent thundering herd.
+#[derive(Debug, Clone)]
+pub struct ReconnectionPolicy {
+    /// Enable automatic reconnection
+    pub enabled: bool,
+    /// Initial delay before first retry
+    pub initial_delay: Duration,
+    /// Maximum delay between retries
+    pub max_delay: Duration,
+    /// Backoff multiplier (e.g., 2.0 for doubling)
+    pub backoff_multiplier: f64,
+    /// Maximum number of retries (None = infinite)
+    pub max_retries: Option<u32>,
+    /// Jitter factor (0.0-1.0) to prevent thundering herd
+    pub jitter: f64,
+}
+
+impl Default for ReconnectionPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            initial_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(60),
+            backoff_multiplier: 2.0,
+            max_retries: Some(10),
+            jitter: 0.2,
+        }
+    }
+}
+
+impl ReconnectionPolicy {
+    /// Create a policy with reconnection disabled
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            ..Default::default()
+        }
+    }
+
+    /// Create an aggressive policy for low-latency networks
+    pub fn aggressive() -> Self {
+        Self {
+            enabled: true,
+            initial_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(10),
+            backoff_multiplier: 1.5,
+            max_retries: Some(20),
+            jitter: 0.1,
+        }
+    }
+
+    /// Create a conservative policy for unreliable networks
+    pub fn conservative() -> Self {
+        Self {
+            enabled: true,
+            initial_delay: Duration::from_secs(5),
+            max_delay: Duration::from_secs(300),
+            backoff_multiplier: 2.0,
+            max_retries: Some(5),
+            jitter: 0.3,
+        }
+    }
+
+    /// Calculate delay for a given attempt number (0-indexed)
+    pub fn calculate_delay(&self, attempt: u32) -> Duration {
+        let base_delay =
+            self.initial_delay.as_secs_f64() * self.backoff_multiplier.powi(attempt as i32);
+        let capped_delay = base_delay.min(self.max_delay.as_secs_f64());
+
+        // Apply jitter: delay * (1 - jitter + random(0, 2*jitter))
+        // For deterministic testing, we use a simple hash-based "random"
+        let jitter_factor = 1.0 - self.jitter + (self.jitter * 2.0 * pseudo_random(attempt));
+        let final_delay = capped_delay * jitter_factor;
+
+        Duration::from_secs_f64(final_delay.max(0.0))
+    }
+
+    /// Check if another retry should be attempted
+    pub fn should_retry(&self, attempts: u32) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        match self.max_retries {
+            Some(max) => attempts < max,
+            None => true,
+        }
+    }
+}
+
+/// Simple pseudo-random function based on attempt number
+/// Used for deterministic jitter in tests
+fn pseudo_random(seed: u32) -> f64 {
+    // Simple hash-based pseudo-random
+    let hash = seed.wrapping_mul(2654435761);
+    (hash as f64) / (u32::MAX as f64)
+}
+
+/// State for a pending reconnection
+#[derive(Debug, Clone)]
+pub struct ReconnectionState {
+    /// Number of failed attempts so far
+    pub attempts: u32,
+    /// When to attempt next reconnection
+    pub next_attempt: Instant,
+    /// Last error message (if any)
+    pub last_error: Option<String>,
+    /// Whether this peer was from static config (vs discovered)
+    pub is_static_peer: bool,
+}
+
+impl ReconnectionState {
+    /// Create a new reconnection state
+    pub fn new(next_attempt: Instant, is_static_peer: bool) -> Self {
+        Self {
+            attempts: 0,
+            next_attempt,
+            last_error: None,
+            is_static_peer,
+        }
+    }
+}
+
+/// Manages automatic reconnection for disconnected peers
+///
+/// Tracks pending reconnections and calculates backoff delays.
+/// Should be used in conjunction with the transport's background task.
+#[derive(Debug)]
+pub struct ReconnectionManager {
+    policy: ReconnectionPolicy,
+    /// Pending reconnections by peer ID
+    pending: HashMap<NodeId, ReconnectionState>,
+}
+
+impl ReconnectionManager {
+    /// Create a new reconnection manager with the given policy
+    pub fn new(policy: ReconnectionPolicy) -> Self {
+        Self {
+            policy,
+            pending: HashMap::new(),
+        }
+    }
+
+    /// Get the current policy
+    pub fn policy(&self) -> &ReconnectionPolicy {
+        &self.policy
+    }
+
+    /// Check if reconnection is enabled
+    pub fn is_enabled(&self) -> bool {
+        self.policy.enabled
+    }
+
+    /// Schedule reconnection for a disconnected peer
+    ///
+    /// Only schedules if reconnection is enabled and the peer is from static config.
+    /// mDNS-discovered peers should rely on rediscovery instead.
+    pub fn schedule_reconnect(&mut self, peer_id: NodeId, is_static_peer: bool) {
+        if !self.policy.enabled {
+            return;
+        }
+
+        // Only auto-reconnect static peers; discovered peers should be rediscovered
+        if !is_static_peer {
+            return;
+        }
+
+        // If already pending, don't reset the backoff
+        if self.pending.contains_key(&peer_id) {
+            return;
+        }
+
+        let next_attempt = Instant::now() + self.policy.initial_delay;
+        self.pending.insert(
+            peer_id,
+            ReconnectionState::new(next_attempt, is_static_peer),
+        );
+    }
+
+    /// Get peers that are due for a reconnection attempt
+    pub fn due_reconnections(&self) -> Vec<NodeId> {
+        let now = Instant::now();
+        self.pending
+            .iter()
+            .filter(|(_, state)| state.next_attempt <= now)
+            .map(|(id, _)| id.clone())
+            .collect()
+    }
+
+    /// Get the number of pending reconnections
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Check if a peer is pending reconnection
+    pub fn is_pending(&self, peer_id: &NodeId) -> bool {
+        self.pending.contains_key(peer_id)
+    }
+
+    /// Get the state for a pending reconnection
+    pub fn get_state(&self, peer_id: &NodeId) -> Option<&ReconnectionState> {
+        self.pending.get(peer_id)
+    }
+
+    /// Record a successful reconnection
+    ///
+    /// Removes the peer from the pending queue.
+    pub fn reconnected(&mut self, peer_id: &NodeId) {
+        self.pending.remove(peer_id);
+    }
+
+    /// Record a failed reconnection attempt
+    ///
+    /// Increments the attempt counter and calculates the next retry time.
+    /// Returns `true` if another retry will be attempted, `false` if max retries exceeded.
+    pub fn failed(&mut self, peer_id: &NodeId, error: String) -> bool {
+        if let Some(state) = self.pending.get_mut(peer_id) {
+            state.attempts += 1;
+            state.last_error = Some(error);
+
+            if self.policy.should_retry(state.attempts) {
+                let delay = self.policy.calculate_delay(state.attempts);
+                state.next_attempt = Instant::now() + delay;
+                true
+            } else {
+                // Max retries exceeded, remove from pending
+                false
+            }
+        } else {
+            false
+        }
+    }
+
+    /// Remove a peer from pending reconnections (e.g., when max retries exceeded)
+    pub fn remove(&mut self, peer_id: &NodeId) -> Option<ReconnectionState> {
+        self.pending.remove(peer_id)
+    }
+
+    /// Clear all pending reconnections
+    pub fn clear(&mut self) {
+        self.pending.clear();
+    }
+
+    /// Get all pending peer IDs
+    pub fn pending_peers(&self) -> Vec<NodeId> {
+        self.pending.keys().cloned().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_policy() {
+        let policy = ReconnectionPolicy::default();
+        assert!(policy.enabled);
+        assert_eq!(policy.initial_delay, Duration::from_secs(1));
+        assert_eq!(policy.max_delay, Duration::from_secs(60));
+        assert_eq!(policy.backoff_multiplier, 2.0);
+        assert_eq!(policy.max_retries, Some(10));
+        assert_eq!(policy.jitter, 0.2);
+    }
+
+    #[test]
+    fn test_disabled_policy() {
+        let policy = ReconnectionPolicy::disabled();
+        assert!(!policy.enabled);
+        assert!(!policy.should_retry(0));
+    }
+
+    #[test]
+    fn test_exponential_backoff_calculation() {
+        let policy = ReconnectionPolicy {
+            enabled: true,
+            initial_delay: Duration::from_secs(1),
+            max_delay: Duration::from_secs(60),
+            backoff_multiplier: 2.0,
+            max_retries: Some(10),
+            jitter: 0.0, // No jitter for deterministic test
+        };
+
+        // Attempt 0: 1s * 2^0 = 1s
+        let delay0 = policy.calculate_delay(0);
+        assert_eq!(delay0, Duration::from_secs(1));
+
+        // Attempt 1: 1s * 2^1 = 2s
+        let delay1 = policy.calculate_delay(1);
+        assert_eq!(delay1, Duration::from_secs(2));
+
+        // Attempt 2: 1s * 2^2 = 4s
+        let delay2 = policy.calculate_delay(2);
+        assert_eq!(delay2, Duration::from_secs(4));
+
+        // Attempt 5: 1s * 2^5 = 32s
+        let delay5 = policy.calculate_delay(5);
+        assert_eq!(delay5, Duration::from_secs(32));
+
+        // Attempt 6: 1s * 2^6 = 64s, but capped at 60s
+        let delay6 = policy.calculate_delay(6);
+        assert_eq!(delay6, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_should_retry() {
+        let policy = ReconnectionPolicy {
+            max_retries: Some(3),
+            ..Default::default()
+        };
+
+        assert!(policy.should_retry(0));
+        assert!(policy.should_retry(1));
+        assert!(policy.should_retry(2));
+        assert!(!policy.should_retry(3));
+        assert!(!policy.should_retry(4));
+    }
+
+    #[test]
+    fn test_infinite_retries() {
+        let policy = ReconnectionPolicy {
+            max_retries: None,
+            ..Default::default()
+        };
+
+        assert!(policy.should_retry(0));
+        assert!(policy.should_retry(100));
+        assert!(policy.should_retry(1000));
+    }
+
+    #[test]
+    fn test_jitter_bounds() {
+        let policy = ReconnectionPolicy {
+            initial_delay: Duration::from_secs(10),
+            max_delay: Duration::from_secs(100),
+            jitter: 0.2,
+            ..Default::default()
+        };
+
+        // With 20% jitter, delay should be 10s * (0.8 to 1.2) = 8s to 12s
+        for attempt in 0..10 {
+            let delay = policy.calculate_delay(attempt);
+            // Just verify it's a reasonable value (not checking exact bounds due to pseudo-random)
+            assert!(delay.as_secs_f64() > 0.0);
+        }
+    }
+
+    #[test]
+    fn test_reconnection_manager_schedule() {
+        let policy = ReconnectionPolicy::default();
+        let mut manager = ReconnectionManager::new(policy);
+
+        let peer_id = NodeId::new("test-peer".to_string());
+
+        // Schedule reconnection for static peer
+        manager.schedule_reconnect(peer_id.clone(), true);
+        assert!(manager.is_pending(&peer_id));
+        assert_eq!(manager.pending_count(), 1);
+
+        // Scheduling again should not reset
+        manager.schedule_reconnect(peer_id.clone(), true);
+        assert_eq!(manager.pending_count(), 1);
+    }
+
+    #[test]
+    fn test_reconnection_manager_discovered_peer() {
+        let policy = ReconnectionPolicy::default();
+        let mut manager = ReconnectionManager::new(policy);
+
+        let peer_id = NodeId::new("discovered-peer".to_string());
+
+        // Discovered peers should not be scheduled for reconnection
+        manager.schedule_reconnect(peer_id.clone(), false);
+        assert!(!manager.is_pending(&peer_id));
+        assert_eq!(manager.pending_count(), 0);
+    }
+
+    #[test]
+    fn test_reconnection_manager_success() {
+        let policy = ReconnectionPolicy::default();
+        let mut manager = ReconnectionManager::new(policy);
+
+        let peer_id = NodeId::new("test-peer".to_string());
+        manager.schedule_reconnect(peer_id.clone(), true);
+
+        // Reconnection succeeds
+        manager.reconnected(&peer_id);
+        assert!(!manager.is_pending(&peer_id));
+        assert_eq!(manager.pending_count(), 0);
+    }
+
+    #[test]
+    fn test_reconnection_manager_failure() {
+        let policy = ReconnectionPolicy {
+            max_retries: Some(3),
+            ..Default::default()
+        };
+        let mut manager = ReconnectionManager::new(policy);
+
+        let peer_id = NodeId::new("test-peer".to_string());
+        manager.schedule_reconnect(peer_id.clone(), true);
+
+        // First failure - should retry
+        assert!(manager.failed(&peer_id, "connection refused".to_string()));
+        assert!(manager.is_pending(&peer_id));
+        assert_eq!(manager.get_state(&peer_id).unwrap().attempts, 1);
+
+        // Second failure - should retry
+        assert!(manager.failed(&peer_id, "connection refused".to_string()));
+        assert_eq!(manager.get_state(&peer_id).unwrap().attempts, 2);
+
+        // Third failure - max retries exceeded
+        assert!(!manager.failed(&peer_id, "connection refused".to_string()));
+    }
+
+    #[test]
+    fn test_due_reconnections() {
+        let policy = ReconnectionPolicy {
+            initial_delay: Duration::from_millis(1), // Very short for testing
+            ..Default::default()
+        };
+        let mut manager = ReconnectionManager::new(policy);
+
+        let peer1 = NodeId::new("peer1".to_string());
+        let peer2 = NodeId::new("peer2".to_string());
+
+        manager.schedule_reconnect(peer1.clone(), true);
+        manager.schedule_reconnect(peer2.clone(), true);
+
+        // Initially neither is due (need to wait for initial_delay)
+        // But with 1ms delay, they should be due almost immediately
+        std::thread::sleep(Duration::from_millis(5));
+
+        let due = manager.due_reconnections();
+        assert_eq!(due.len(), 2);
+        assert!(due.contains(&peer1));
+        assert!(due.contains(&peer2));
+    }
+
+    #[test]
+    fn test_disabled_reconnection() {
+        let policy = ReconnectionPolicy::disabled();
+        let mut manager = ReconnectionManager::new(policy);
+
+        let peer_id = NodeId::new("test-peer".to_string());
+        manager.schedule_reconnect(peer_id.clone(), true);
+
+        // Should not be scheduled when disabled
+        assert!(!manager.is_pending(&peer_id));
+    }
+}


### PR DESCRIPTION
## Summary

- Implements Issue #253 - automatic reconnection for disconnected static peers with configurable exponential backoff
- Adds `ReconnectionPolicy` with configurable parameters (initial delay, max delay, backoff multiplier, max retries, jitter)
- Adds `ReconnectionManager` to track pending reconnections with exponential backoff
- New `PeerEvent::Reconnecting` and `PeerEvent::ReconnectFailed` variants for FFI consumers
- Integrates reconnection into IrohMeshTransport's background cleanup task

## Implementation Details

### ReconnectionPolicy
- Configurable backoff: initial_delay (1s), max_delay (60s), multiplier (2.0)
- Max retries with infinite option
- Jitter factor (0.2) to prevent thundering herd
- Preset policies: `default()`, `disabled()`, `aggressive()`, `conservative()`

### Integration
- Static peers tracked separately (only they get auto-reconnection)
- mDNS-discovered peers rely on rediscovery instead
- Background task attempts reconnection on schedule

### FFI Events
- `HIVE_EVENT_RECONNECTING` (4): `"attempt=N/M"` info
- `HIVE_EVENT_RECONNECT_FAILED` (5): `"attempt=N, error=..., will_retry=bool"`

## Test plan

- [x] 12 unit tests for ReconnectionPolicy and ReconnectionManager
- [x] 6 transport::iroh tests pass
- [x] 5 ffi::peer tests pass  
- [ ] CI tests

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)