### PR TITLE
docs: Add comprehensive Operator and Developer guides

### DIFF
--- a/docs/DOCUMENTATION_ISSUES.md
+++ b/docs/DOCUMENTATION_ISSUES.md
@@ -1,0 +1,377 @@
+# HIVE Documentation GitHub Issues
+
+> **Purpose**: Copy these issue templates to create GitHub Issues for tracking documentation work.
+> **Last Updated**: 2025-12-08
+
+---
+
+## Issue #1: Create Comprehensive Operator Guide
+
+**Title**: `docs: Create comprehensive Operator Guide for HIVE deployment and operations`
+
+**Labels**: `documentation`, `operator`, `priority:high`, `good first issue`
+
+**Milestone**: Documentation v1.0
+
+### Description
+
+Create a production-grade operator guide that enables system administrators and mission operators to successfully deploy, configure, monitor, and troubleshoot HIVE systems without requiring deep code knowledge.
+
+### Background
+
+HIVE currently has extensive technical documentation (ADRs, design docs) but lacks structured operational documentation for the operator persona. This guide will bridge that gap and enable production deployments.
+
+### Requirements
+
+#### Must Have (P0)
+- [ ] **Installation Guide**
+  - Prerequisites (hardware, software, network)
+  - Build from source instructions
+  - Pre-built binary installation
+  - Container/Docker deployment
+  - Platform-specific notes (Linux, macOS, Android)
+
+- [ ] **Quick Start**
+  - 10-minute path to running first simulation
+  - Verification steps
+
+- [ ] **Configuration Reference**
+  - All environment variables (`DITTO_APP_ID`, `DITTO_OFFLINE_TOKEN`, etc.)
+  - Configuration file formats
+  - Feature flags and backend selection
+  - Network configuration
+
+- [ ] **Deployment Patterns**
+  - Single-node development deployment
+  - Multi-node production deployment
+  - Edge device deployment (Jetson, embedded)
+  - Cloud deployment considerations
+
+- [ ] **Troubleshooting Runbook**
+  - Common issues with solutions
+  - Diagnostic commands and tools
+  - Log analysis guidance
+  - Support escalation procedures
+
+#### Should Have (P1)
+- [ ] **Security Configuration**
+  - PKI setup and certificate management
+  - Formation key configuration
+  - Encryption settings
+  - Authentication configuration
+
+- [ ] **Monitoring & Observability**
+  - Available metrics
+  - Logging configuration
+  - Health check endpoints
+  - Alerting recommendations
+
+- [ ] **TAK/ATAK Integration**
+  - ATAK plugin installation
+  - CoT message configuration
+  - Interoperability setup
+
+#### Nice to Have (P2)
+- [ ] Capacity planning guidelines
+- [ ] Performance tuning recommendations
+- [ ] Disaster recovery procedures
+- [ ] Upgrade procedures
+
+### Acceptance Criteria
+
+1. New contributor can deploy HIVE simulation in < 10 minutes following the guide
+2. All configuration options are documented with defaults and examples
+3. At least 10 common issues documented in troubleshooting section
+4. Guide tested by someone unfamiliar with HIVE codebase
+
+### Technical Notes
+
+- Location: `docs/guides/operator/OPERATOR_GUIDE.md`
+- Use Mermaid diagrams for architecture visuals
+- Include tested code/command examples
+- Cross-reference existing ADRs where appropriate
+
+### Related Documentation
+
+- [DEVELOPMENT.md](../DEVELOPMENT.md) - Development setup (for reference)
+- [TESTING_STRATEGY.md](TESTING_STRATEGY.md) - Testing approach
+- [ADR-011](adr/011-ditto-vs-automerge-iroh.md) - Backend selection
+- [ADR-017](adr/017-p2p-mesh-management-discovery.md) - Discovery configuration
+
+---
+
+## Issue #2: Create Comprehensive Developer Guide
+
+**Title**: `docs: Create comprehensive Developer Guide for HIVE SDK and contribution`
+
+**Labels**: `documentation`, `developer`, `priority:high`
+
+**Milestone**: Documentation v1.0
+
+### Description
+
+Create a developer guide that enables software engineers to understand HIVE architecture, build applications using the HIVE SDK, contribute to the core protocol, and extend HIVE with custom functionality.
+
+### Background
+
+While ADRs provide decision rationale and code has inline documentation, there's no unified guide for developers to understand the system holistically and contribute effectively.
+
+### Requirements
+
+#### Must Have (P0)
+- [ ] **Architecture Overview**
+  - System architecture diagram
+  - Crate dependency graph
+  - Data flow through the system
+  - CRDT usage patterns
+  - Three-phase protocol walkthrough
+
+- [ ] **Getting Started**
+  - Development environment setup
+  - IDE configuration (VS Code, CLion)
+  - First build and test run
+  - Project structure orientation
+
+- [ ] **Core Concepts**
+  - Nodes, Cells, and Zones
+  - Capabilities and composition
+  - Discovery strategies
+  - Leader election
+  - Hierarchical aggregation
+
+- [ ] **API Reference**
+  - Key public APIs with examples
+  - Trait documentation
+  - Error handling patterns
+  - Async patterns used
+
+- [ ] **Testing Guide**
+  - Test pyramid and strategy
+  - Writing unit tests
+  - Writing integration tests
+  - Writing E2E tests
+  - Test fixtures and harnesses
+  - Running tests with Makefile
+
+#### Should Have (P1)
+- [ ] **Extending HIVE**
+  - Adding custom capabilities
+  - Creating discovery strategies
+  - Implementing composition rules
+  - Adding policy rules
+  - Custom QoS configurations
+
+- [ ] **Backend Abstraction**
+  - Ditto backend usage
+  - Automerge backend usage
+  - Switching between backends
+  - Backend-specific considerations
+
+- [ ] **Contributing Guide**
+  - Code style and conventions
+  - PR process and review guidelines
+  - Commit message format
+  - Documentation requirements
+
+#### Nice to Have (P2)
+- [ ] **Mobile Development**
+  - hive-ffi usage
+  - Kotlin bindings
+  - Swift bindings
+  - Android build process
+
+- [ ] **Edge AI Integration**
+  - hive-inference overview
+  - Model deployment
+  - ONNX runtime integration
+  - Video pipeline setup
+
+### Acceptance Criteria
+
+1. New developer can set up environment and run tests in < 30 minutes
+2. Architecture is clear enough to navigate codebase confidently
+3. At least 3 extension examples with working code
+4. All public APIs documented with examples
+5. Testing section enables writing all test types
+
+### Technical Notes
+
+- Location: `docs/guides/developer/DEVELOPER_GUIDE.md`
+- Generate API docs from rustdoc where possible
+- Include diagrams using Mermaid
+- Provide complete, runnable code examples
+
+### Related Documentation
+
+- [DEVELOPMENT.md](../DEVELOPMENT.md) - Current dev setup
+- [TESTING_STRATEGY.md](TESTING_STRATEGY.md) - Testing philosophy
+- [All ADRs](adr/) - Technical decisions
+- [PROTOBUF_MIGRATION_GUIDE.md](PROTOBUF_MIGRATION_GUIDE.md) - Schema work
+
+---
+
+## Issue #3: Create Quickstart Tutorial Series
+
+**Title**: `docs: Create hands-on tutorial series for common HIVE use cases`
+
+**Labels**: `documentation`, `tutorials`, `priority:medium`, `good first issue`
+
+**Milestone**: Documentation v1.0
+
+### Description
+
+Create a series of hands-on tutorials that guide users through common HIVE use cases, from running their first simulation to building custom applications.
+
+### Tutorials to Create
+
+#### Tutorial 1: Your First HIVE Simulation (10 minutes)
+- Clone and build
+- Run hive-sim
+- Observe cell formation
+- Understand the output
+
+#### Tutorial 2: Building a HIVE Application
+- Set up a new Rust project
+- Add hive-protocol dependency
+- Create nodes with capabilities
+- Join a cell
+- Exchange messages
+
+#### Tutorial 3: Adding Custom Capabilities
+- Define a new capability type
+- Implement composition rules
+- Add to existing nodes
+- Test the capability
+
+#### Tutorial 4: Integrating with TAK/ATAK
+- Install ATAK plugin
+- Configure CoT translation
+- Send position updates
+- Receive commands
+
+### Acceptance Criteria
+
+1. Each tutorial completable in stated time by target audience
+2. All code tested and runnable
+3. Clear prerequisites and verification steps
+4. Progressive complexity (Tutorial 1 → 4)
+
+### Technical Notes
+
+- Location: `docs/tutorials/`
+- Include starter code repositories where helpful
+- Provide "checkpoint" code for each major step
+
+---
+
+## Issue #4: Set Up Documentation Infrastructure
+
+**Title**: `chore: Set up documentation infrastructure and automation`
+
+**Labels**: `documentation`, `infrastructure`, `priority:medium`
+
+**Milestone**: Documentation v1.0
+
+### Description
+
+Establish documentation infrastructure to ensure quality and maintainability of HIVE documentation.
+
+### Requirements
+
+- [ ] **Link Checking**
+  - Add markdown link checker to CI
+  - Check internal and external links
+  - Report broken links in PR checks
+
+- [ ] **Documentation Linting**
+  - Consistent markdown formatting
+  - Spelling check
+  - Style guide enforcement
+
+- [ ] **API Documentation**
+  - Generate rustdoc for public APIs
+  - Host or include in documentation site
+  - Keep in sync with code
+
+- [ ] **Search (Optional)**
+  - If hosting docs site, add search
+  - Index all documentation
+
+### Acceptance Criteria
+
+1. CI fails on broken links
+2. Rustdoc generates without warnings
+3. Documentation passes linting
+
+### Technical Notes
+
+- Consider using mdBook or similar for doc site
+- Integrate with existing GitHub Actions
+
+---
+
+## Issue #5: Documentation Review and Feedback Process
+
+**Title**: `docs: Establish documentation review and feedback process`
+
+**Labels**: `documentation`, `process`, `priority:low`
+
+**Milestone**: Documentation v1.1
+
+### Description
+
+Create processes for ongoing documentation maintenance and improvement based on user feedback.
+
+### Requirements
+
+- [ ] **Feedback Collection**
+  - Add feedback links to documentation
+  - Create documentation issue template
+  - Establish triage process
+
+- [ ] **Review Schedule**
+  - Quarterly documentation review
+  - Review checklist
+  - Owner assignments
+
+- [ ] **Metrics Tracking**
+  - Track documentation-related issues
+  - Monitor user onboarding success
+  - Survey new users/contributors
+
+### Acceptance Criteria
+
+1. Clear process for reporting documentation issues
+2. Quarterly review schedule documented
+3. Metrics baseline established
+
+---
+
+## Issue Summary Table
+
+| Issue | Title | Priority | Effort | Dependencies |
+|-------|-------|----------|--------|--------------|
+| #1 | Operator Guide | P0/High | Large | None |
+| #2 | Developer Guide | P0/High | Large | None |
+| #3 | Tutorial Series | P1/Medium | Medium | #1, #2 |
+| #4 | Doc Infrastructure | P1/Medium | Small | None |
+| #5 | Review Process | P2/Low | Small | #1, #2, #3, #4 |
+
+---
+
+## Labels to Create
+
+| Label | Description | Color |
+|-------|-------------|-------|
+| `documentation` | Documentation improvements | `#0075ca` |
+| `operator` | Operator/operations related | `#7057ff` |
+| `developer` | Developer experience related | `#008672` |
+| `tutorials` | Tutorial content | `#e4e669` |
+| `infrastructure` | Build/CI infrastructure | `#d4c5f9` |
+| `priority:high` | High priority | `#b60205` |
+| `priority:medium` | Medium priority | `#fbca04` |
+| `priority:low` | Low priority | `#0e8a16` |
+
+---
+
+**Note**: These issues can be created manually in GitHub or via the `gh` CLI when available.

--- a/docs/DOCUMENTATION_PLAN.md
+++ b/docs/DOCUMENTATION_PLAN.md
@@ -1,0 +1,368 @@
+# HIVE Documentation Plan
+
+> **Version**: 1.0
+> **Status**: Active
+> **Last Updated**: 2025-12-08
+
+## Executive Summary
+
+This document outlines the comprehensive documentation strategy for HIVE (Hierarchical Intelligence for Versatile Entities), targeting two primary personas: **Operators** and **Developers**. The goal is to transform existing technical documentation into accessible, production-grade guides that enable successful adoption and contribution.
+
+---
+
+## 1. Documentation Personas
+
+### 1.1 Operator Persona
+
+**Profile**: System administrators, DevOps engineers, and mission operators who deploy, configure, and maintain HIVE systems in production environments.
+
+**Goals**:
+- Deploy HIVE networks quickly and reliably
+- Configure systems for specific operational requirements
+- Monitor system health and performance
+- Troubleshoot issues without deep code knowledge
+- Integrate HIVE with existing infrastructure (TAK, ATAK, C2 systems)
+
+**Knowledge Level**:
+- Strong Linux/system administration skills
+- Basic understanding of distributed systems
+- Familiarity with Docker, networking, and monitoring tools
+- No Rust programming knowledge required
+
+### 1.2 Developer Persona
+
+**Profile**: Software engineers who build applications using HIVE, contribute to the core protocol, or integrate HIVE into existing systems.
+
+**Goals**:
+- Understand HIVE architecture and internals
+- Build applications using the HIVE SDK
+- Contribute features and fixes to the protocol
+- Extend HIVE with custom capabilities, policies, and integrations
+- Run and write tests effectively
+
+**Knowledge Level**:
+- Proficient in Rust programming
+- Understanding of distributed systems and CRDTs
+- Familiarity with async/await patterns (Tokio)
+- Experience with testing strategies and CI/CD
+
+---
+
+## 2. Documentation Structure
+
+```
+docs/
+├── guides/
+│   ├── operator/
+│   │   ├── OPERATOR_GUIDE.md           # Main operator guide
+│   │   ├── installation.md             # Installation procedures
+│   │   ├── configuration.md            # Configuration reference
+│   │   ├── deployment.md               # Deployment patterns
+│   │   ├── monitoring.md               # Observability and monitoring
+│   │   ├── troubleshooting.md          # Troubleshooting runbook
+│   │   └── integrations/
+│   │       ├── tak-integration.md      # TAK/ATAK integration
+│   │       └── c2-integration.md       # C2 system integration
+│   │
+│   └── developer/
+│       ├── DEVELOPER_GUIDE.md          # Main developer guide
+│       ├── architecture.md             # Architecture deep-dive
+│       ├── getting-started.md          # Quick start for devs
+│       ├── api-reference.md            # API documentation
+│       ├── extending-hive.md           # Extension patterns
+│       ├── testing.md                  # Testing guide
+│       └── contributing.md             # Contribution guide
+│
+├── tutorials/
+│   ├── quickstart-simulation.md        # First simulation in 10 minutes
+│   ├── build-first-application.md      # Build a HIVE application
+│   └── custom-capabilities.md          # Add custom capabilities
+│
+├── reference/
+│   ├── configuration-reference.md      # Complete config options
+│   ├── protobuf-schema-reference.md    # Schema documentation
+│   └── cli-reference.md                # CLI command reference
+│
+└── [existing documentation...]
+```
+
+---
+
+## 3. Requirements by Document
+
+### 3.1 Operator Guide Requirements
+
+| Section | Requirements | Priority |
+|---------|-------------|----------|
+| **Installation** | Prerequisites, build from source, pre-built binaries, container images | P0 |
+| **Quick Start** | 10-minute path to running simulation | P0 |
+| **Configuration** | All environment variables, config files, feature flags | P0 |
+| **Deployment** | Single-node, multi-node, edge deployment patterns | P0 |
+| **Networking** | Port requirements, firewall rules, NAT traversal | P0 |
+| **Security** | PKI setup, credential management, encryption | P1 |
+| **Monitoring** | Metrics, logging, alerting, health checks | P1 |
+| **Backup/Recovery** | State persistence, disaster recovery | P1 |
+| **Troubleshooting** | Common issues, diagnostic commands, support escalation | P0 |
+| **TAK Integration** | ATAK plugin setup, CoT translation, interoperability | P1 |
+| **Scaling** | Horizontal scaling, performance tuning, capacity planning | P2 |
+
+### 3.2 Developer Guide Requirements
+
+| Section | Requirements | Priority |
+|---------|-------------|----------|
+| **Architecture** | System overview, crate structure, data flow, CRDT usage | P0 |
+| **Getting Started** | Dev environment setup, first build, run tests | P0 |
+| **Core Concepts** | Three-phase protocol, capabilities, cells, zones | P0 |
+| **API Reference** | Public APIs with examples, trait documentation | P0 |
+| **Extending HIVE** | Custom capabilities, discovery strategies, policies | P1 |
+| **Backend Abstraction** | Ditto vs Automerge, switching backends | P1 |
+| **Testing** | Unit/integration/E2E tests, test fixtures, mocking | P0 |
+| **Contributing** | Code style, PR process, review guidelines | P1 |
+| **Mobile Development** | hive-ffi, Kotlin/Swift bindings, Android build | P2 |
+| **Edge AI Integration** | hive-inference, model deployment, ONNX runtime | P2 |
+
+---
+
+## 4. Content Standards
+
+### 4.1 Writing Style
+
+- **Voice**: Active, direct, imperative for procedures
+- **Tone**: Professional, technical, accessible
+- **Tense**: Present tense for descriptions, imperative for instructions
+- **Person**: Second person ("you") for guides, third person for reference
+
+### 4.2 Structure Standards
+
+Each guide must include:
+
+1. **Overview**: What and why (2-3 sentences)
+2. **Prerequisites**: Required knowledge, tools, access
+3. **Objectives**: What the reader will accomplish
+4. **Content**: Step-by-step with examples
+5. **Verification**: How to confirm success
+6. **Next Steps**: Related documentation
+7. **Troubleshooting**: Common issues for that section
+
+### 4.3 Code Examples
+
+- All code examples must be tested and runnable
+- Include expected output where applicable
+- Provide both minimal and complete examples
+- Use consistent formatting (rustfmt for Rust)
+
+### 4.4 Diagrams
+
+- Architecture diagrams in Mermaid format (rendereable in GitHub)
+- Network topology diagrams for deployment patterns
+- Data flow diagrams for protocol concepts
+
+---
+
+## 5. Implementation Phases
+
+### Phase 1: Foundation (Current)
+- [ ] Create documentation structure
+- [ ] Write comprehensive Operator Guide
+- [ ] Write comprehensive Developer Guide
+- [ ] Update INDEX.md with new navigation
+
+### Phase 2: Expansion
+- [ ] Add integration guides (TAK, C2)
+- [ ] Create video tutorials
+- [ ] Add API reference generation from rustdoc
+- [ ] Create deployment playbooks
+
+### Phase 3: Maintenance
+- [ ] Establish documentation review process
+- [ ] Add automated link checking
+- [ ] Create feedback collection mechanism
+- [ ] Schedule quarterly documentation reviews
+
+---
+
+## 6. GitHub Issues
+
+The following GitHub Issues should be created to track documentation work:
+
+### Issue 1: Create Comprehensive Operator Guide
+**Labels**: documentation, operator, priority:high
+
+**Description**: Create a production-grade operator guide covering installation, configuration, deployment, monitoring, and troubleshooting for HIVE systems.
+
+**Acceptance Criteria**:
+- Complete installation guide with all prerequisites
+- Configuration reference for all options
+- Deployment patterns (single-node, multi-node, edge)
+- Troubleshooting runbook with common issues
+- Integration section for TAK/ATAK
+
+---
+
+### Issue 2: Create Comprehensive Developer Guide
+**Labels**: documentation, developer, priority:high
+
+**Description**: Create a developer guide covering architecture, API usage, extension patterns, testing, and contribution guidelines.
+
+**Acceptance Criteria**:
+- Architecture overview with diagrams
+- Getting started guide for new contributors
+- API reference with examples
+- Testing guide covering all test types
+- Extension patterns for custom capabilities
+
+---
+
+### Issue 3: Create Tutorial Series
+**Labels**: documentation, tutorials, priority:medium
+
+**Description**: Create hands-on tutorials for common HIVE use cases.
+
+**Acceptance Criteria**:
+- Quickstart simulation tutorial (10 minutes)
+- Build first application tutorial
+- Custom capability tutorial
+- All tutorials tested and runnable
+
+---
+
+### Issue 4: Documentation Infrastructure
+**Labels**: documentation, infrastructure, priority:medium
+
+**Description**: Set up documentation infrastructure including link checking, search, and generation.
+
+**Acceptance Criteria**:
+- Automated link checking in CI
+- Search functionality (if hosting docs site)
+- API docs generated from rustdoc
+- Documentation linting
+
+---
+
+## 7. Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Time to First Simulation | < 10 minutes | User testing |
+| Developer Onboarding Time | < 2 hours | Survey new contributors |
+| Documentation Coverage | 100% public APIs | Automated check |
+| Broken Links | 0 | CI check |
+| User Satisfaction | > 4.0/5.0 | Feedback surveys |
+
+---
+
+## 8. Maintenance Schedule
+
+| Activity | Frequency | Owner |
+|----------|-----------|-------|
+| Link verification | Every PR | CI/CD |
+| Content review | Quarterly | Doc maintainer |
+| User feedback review | Monthly | Product team |
+| Major version update | Per release | Release manager |
+
+---
+
+## Appendix A: Document Templates
+
+### Operator Guide Section Template
+
+```markdown
+# Section Title
+
+## Overview
+
+Brief description of what this section covers and why it matters.
+
+## Prerequisites
+
+- Requirement 1
+- Requirement 2
+
+## Procedure
+
+### Step 1: Action
+
+Description of the step.
+
+\`\`\`bash
+command to execute
+\`\`\`
+
+Expected output:
+\`\`\`
+output here
+\`\`\`
+
+### Step 2: Next Action
+
+...
+
+## Verification
+
+How to confirm the procedure was successful.
+
+## Troubleshooting
+
+### Common Issue 1
+
+**Symptom**: What you observe
+**Cause**: Why it happens
+**Solution**: How to fix it
+
+## Next Steps
+
+- [Related Topic](link)
+```
+
+### Developer Guide Section Template
+
+```markdown
+# Section Title
+
+## Overview
+
+What this section covers and its importance in the HIVE architecture.
+
+## Concepts
+
+### Key Concept 1
+
+Explanation with code examples.
+
+\`\`\`rust
+// Example code
+\`\`\`
+
+## API Reference
+
+### `FunctionName`
+
+\`\`\`rust
+pub fn function_name(param: Type) -> Result<Output, Error>
+\`\`\`
+
+**Parameters**:
+- `param`: Description
+
+**Returns**: Description
+
+**Example**:
+\`\`\`rust
+let result = function_name(value)?;
+\`\`\`
+
+## Best Practices
+
+- Practice 1
+- Practice 2
+
+## See Also
+
+- [Related Topic](link)
+```
+
+---
+
+**Document Owner**: HIVE Documentation Team
+**Review Cycle**: Quarterly
+**Next Review**: 2026-03-01

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,31 @@
 
 > **Navigation Guide**: All documentation for the HIVE Protocol project, organized by category and purpose.
 
+---
+
+## 📚 User Guides (Start Here)
+
+| Guide | Audience | Description |
+|-------|----------|-------------|
+| [**Operator Guide**](guides/operator/OPERATOR_GUIDE.md) | System Admins, DevOps, Mission Operators | Installation, configuration, deployment, monitoring, troubleshooting |
+| [**Developer Guide**](guides/developer/DEVELOPER_GUIDE.md) | Software Engineers, Contributors | Architecture, API reference, extending HIVE, testing, contributing |
+
+### Quick Links by Task
+
+| I want to... | Go to... |
+|--------------|----------|
+| Deploy HIVE in production | [Operator Guide: Deployment](guides/operator/OPERATOR_GUIDE.md#5-deployment-patterns) |
+| Set up a development environment | [Developer Guide: Getting Started](guides/developer/DEVELOPER_GUIDE.md#2-getting-started) |
+| Understand the architecture | [Developer Guide: Architecture](guides/developer/DEVELOPER_GUIDE.md#3-architecture) |
+| Configure HIVE | [Operator Guide: Configuration](guides/operator/OPERATOR_GUIDE.md#4-configuration) |
+| Write tests | [Developer Guide: Testing](guides/developer/DEVELOPER_GUIDE.md#8-testing) |
+| Troubleshoot issues | [Operator Guide: Troubleshooting](guides/operator/OPERATOR_GUIDE.md#11-troubleshooting) |
+| Integrate with TAK/ATAK | [Operator Guide: TAK Integration](guides/operator/OPERATOR_GUIDE.md#9-takatak-integration) |
+| Extend HIVE with custom capabilities | [Developer Guide: Extending HIVE](guides/developer/DEVELOPER_GUIDE.md#7-extending-hive) |
+| Contribute to HIVE | [Developer Guide: Contributing](guides/developer/DEVELOPER_GUIDE.md#12-contributing) |
+
+---
+
 ## 🔍 For IP Due Diligence Reviewers
 
 **Start Here**:
@@ -88,11 +113,12 @@ Comprehensive testing strategy and implementation guides.
 
 ### By Audience
 
+- **Operators/System Admins**: [Operator Guide](guides/operator/OPERATOR_GUIDE.md) → Configuration → Troubleshooting
+- **Developers**: [Developer Guide](guides/developer/DEVELOPER_GUIDE.md) → Architecture → Testing → Contributing
 - **IP Evaluators**: IP_OVERVIEW.md → VALIDATION_RESULTS.md → patents/ → ADRs
 - **Technical Due Diligence**: IP_OVERVIEW.md → ADRs → TESTING_STRATEGY.md → DEVELOPMENT.md
 - **Architects**: ADRs → Technical Design Docs → TESTING_STRATEGY.md
-- **Developers**: DEVELOPMENT.md → TESTING_STRATEGY.md → Module docs
-- **QA/Testing**: TESTING_STRATEGY.md → E2E test docs
+- **QA/Testing**: TESTING_STRATEGY.md → [Developer Guide: Testing](guides/developer/DEVELOPER_GUIDE.md#8-testing)
 
 ### By Topic
 
@@ -189,6 +215,15 @@ When making significant changes:
 
 ---
 
-**Last Updated**: 2025-11-07
+## Documentation Planning & Maintenance
+
+| Document | Purpose |
+|----------|---------|
+| [DOCUMENTATION_PLAN.md](DOCUMENTATION_PLAN.md) | Documentation strategy, requirements, and standards |
+| [DOCUMENTATION_ISSUES.md](DOCUMENTATION_ISSUES.md) | GitHub issue templates for documentation work |
+
+---
+
+**Last Updated**: 2025-12-08
 **Maintained By**: HIVE Protocol Team
 **Questions?**: Check DEVELOPMENT.md for contribution guidelines

--- a/docs/guides/developer/DEVELOPER_GUIDE.md
+++ b/docs/guides/developer/DEVELOPER_GUIDE.md
@@ -1,0 +1,1711 @@
+# HIVE Developer Guide
+
+> **Version**: 1.0
+> **Last Updated**: 2025-12-08
+> **Audience**: Software Engineers, Protocol Contributors, Integration Developers
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Getting Started](#2-getting-started)
+3. [Architecture](#3-architecture)
+4. [Core Concepts](#4-core-concepts)
+5. [Crate Reference](#5-crate-reference)
+6. [API Reference](#6-api-reference)
+7. [Extending HIVE](#7-extending-hive)
+8. [Testing](#8-testing)
+9. [Backend Abstraction](#9-backend-abstraction)
+10. [Mobile Development](#10-mobile-development)
+11. [Edge AI Integration](#11-edge-ai-integration)
+12. [Contributing](#12-contributing)
+13. [Reference](#13-reference)
+
+---
+
+## 1. Introduction
+
+### 1.1 About This Guide
+
+This guide is for software engineers who want to:
+- **Build applications** using HIVE as a coordination protocol
+- **Contribute** to the HIVE core protocol
+- **Integrate** HIVE with existing systems
+- **Extend** HIVE with custom capabilities and behaviors
+
+### 1.2 Prerequisites
+
+- **Rust proficiency**: Familiarity with Rust 2021 edition
+- **Async programming**: Understanding of Tokio and async/await
+- **Distributed systems**: Basic knowledge of CRDTs, eventual consistency
+- **Development tools**: Git, cargo, IDE of choice
+
+### 1.3 What is HIVE?
+
+HIVE (Hierarchical Intelligence for Versatile Entities) is a protocol enabling scalable coordination of autonomous nodes through:
+
+- **CRDT-based state synchronization** - Conflict-free data structures for eventual consistency
+- **Three-phase protocol** - Discovery → Cell Formation → Hierarchical Operations
+- **Capability composition** - Dynamic aggregation of node capabilities
+- **O(n log n) message complexity** - Scales to 100+ nodes efficiently
+
+---
+
+## 2. Getting Started
+
+### 2.1 Development Environment Setup
+
+#### Required Tools
+
+```bash
+# Install Rust (if not already installed)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+
+# Verify Rust version (1.70+ required)
+rustc --version
+
+# Clone the repository
+git clone https://github.com/kitplummer/hive.git
+cd hive
+```
+
+#### Recommended Tools
+
+```bash
+# Fast test runner (highly recommended)
+cargo install cargo-nextest
+
+# File watcher for auto-rebuild
+cargo install cargo-watch
+
+# Code coverage
+cargo install cargo-tarpaulin
+
+# Dependency analysis
+cargo install cargo-udeps
+```
+
+#### IDE Setup
+
+**VS Code** (recommended):
+```json
+// .vscode/settings.json
+{
+    "rust-analyzer.cargo.features": "all",
+    "rust-analyzer.checkOnSave.command": "clippy",
+    "rust-analyzer.inlayHints.parameterHints.enable": true,
+    "editor.formatOnSave": true
+}
+```
+
+**Recommended Extensions**:
+- rust-analyzer
+- crates
+- Even Better TOML
+- Error Lens
+
+### 2.2 First Build
+
+```bash
+# Build all crates (first build takes 5-10 minutes)
+cargo build
+
+# Build in release mode
+cargo build --release
+
+# Check without building (faster)
+cargo check
+```
+
+### 2.3 Running Tests
+
+```bash
+# Quick unit tests only (30 seconds)
+make test-fast
+
+# All tests with nextest (faster parallel execution)
+make test-unit
+
+# Integration tests (2 minutes)
+make test-integration
+
+# End-to-end tests (5 minutes, requires real Ditto sync)
+make test-e2e
+
+# Full test suite (10 minutes)
+make test
+```
+
+### 2.4 Running the Simulator
+
+```bash
+# Run with default configuration
+cargo run --bin hive-sim
+
+# Run with debug logging
+RUST_LOG=debug cargo run --bin hive-sim
+
+# Run with specific module tracing
+RUST_LOG=hive_protocol::discovery=trace cargo run --bin hive-sim
+```
+
+### 2.5 Project Layout
+
+```
+hive/
+├── Cargo.toml                 # Workspace configuration
+├── Makefile                   # Development commands
+├── DEVELOPMENT.md             # Development quickstart
+├── CLAUDE.md                  # AI assistant context
+│
+├── hive-protocol/             # Core protocol library
+│   ├── src/
+│   │   ├── lib.rs            # Crate root, public exports
+│   │   ├── cell/             # Phase 2: Cell formation
+│   │   ├── command/          # Bidirectional commands
+│   │   ├── composition/      # Capability composition
+│   │   ├── cot/              # CoT XML translation
+│   │   ├── credentials/      # Credential management
+│   │   ├── discovery/        # Phase 1: Discovery
+│   │   ├── distribution/     # AI model distribution
+│   │   ├── hierarchy/        # Phase 3: Hierarchical ops
+│   │   ├── models/           # Core data structures
+│   │   ├── network/          # Network constraints
+│   │   ├── policy/           # Policy engine
+│   │   ├── qos/              # Quality of service
+│   │   ├── security/         # Auth, encryption
+│   │   ├── storage/          # CRDT backends
+│   │   ├── sync/             # Sync abstraction
+│   │   ├── testing/          # Test harness
+│   │   ├── traits/           # Core traits
+│   │   └── transport/        # Mesh transport
+│   ├── tests/                # Integration & E2E tests
+│   └── examples/             # Usage examples
+│
+├── hive-schema/               # Protobuf definitions
+│   ├── proto/                # .proto files
+│   └── src/                  # Generated Rust code
+│
+├── hive-mesh/                 # Mesh topology management
+├── hive-transport/            # HTTP/REST API layer
+├── hive-discovery/            # Peer discovery strategies
+├── hive-persistence/          # Storage backends
+├── hive-ffi/                  # Mobile bindings (Kotlin/Swift)
+├── hive-inference/            # Edge AI/ML pipeline
+├── hive-sim/                  # Network simulator
+├── hive-commander/            # TUI application
+│
+├── docs/                      # Documentation
+│   ├── adr/                  # Architecture Decision Records
+│   ├── guides/               # User & developer guides
+│   └── spec/                 # Protocol specification
+│
+└── spec/                      # Normative specification
+    └── proto/                # Canonical protobuf schemas
+```
+
+---
+
+## 3. Architecture
+
+### 3.1 System Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              HIVE Architecture                               │
+│                                                                              │
+│  ┌─────────────────────────────────────────────────────────────────────┐    │
+│  │                        Application Layer                             │    │
+│  │   hive-sim    hive-commander    hive-transport    hive-inference    │    │
+│  └────────────────────────────┬────────────────────────────────────────┘    │
+│                               │                                              │
+│  ┌────────────────────────────▼────────────────────────────────────────┐    │
+│  │                        Protocol Layer                                │    │
+│  │                         hive-protocol                                │    │
+│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────────┐    │    │
+│  │  │Discovery │  │   Cell   │  │Hierarchy │  │   Composition    │    │    │
+│  │  │ Phase 1  │──│ Phase 2  │──│ Phase 3  │  │     Engine       │    │    │
+│  │  └──────────┘  └──────────┘  └──────────┘  └──────────────────┘    │    │
+│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────────┐    │    │
+│  │  │ Security │  │  Policy  │  │   QoS    │  │     Command      │    │    │
+│  │  └──────────┘  └──────────┘  └──────────┘  └──────────────────┘    │    │
+│  └────────────────────────────┬────────────────────────────────────────┘    │
+│                               │                                              │
+│  ┌────────────────────────────▼────────────────────────────────────────┐    │
+│  │                       Storage Abstraction                            │    │
+│  │  ┌─────────────────────┐      ┌─────────────────────────────┐       │    │
+│  │  │    Ditto Backend    │      │    Automerge/Iroh Backend   │       │    │
+│  │  │    (Production)     │      │       (Pure OSS)            │       │    │
+│  │  └─────────────────────┘      └─────────────────────────────┘       │    │
+│  └────────────────────────────┬────────────────────────────────────────┘    │
+│                               │                                              │
+│  ┌────────────────────────────▼────────────────────────────────────────┐    │
+│  │                        Network Layer                                 │    │
+│  │            P2P Mesh (Ditto SDK / Iroh QUIC)                         │    │
+│  └─────────────────────────────────────────────────────────────────────┘    │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3.2 Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Data Flow                                 │
+│                                                                  │
+│  Local Change                                                    │
+│       │                                                          │
+│       ▼                                                          │
+│  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │
+│  │   Node      │     │   Delta     │     │   Priority  │        │
+│  │   State     │ ──► │  Generator  │ ──► │  Assigner   │        │
+│  │   (CRDT)    │     │             │     │   (QoS)     │        │
+│  └─────────────┘     └─────────────┘     └──────┬──────┘        │
+│                                                  │               │
+│                                                  ▼               │
+│  ┌─────────────┐     ┌─────────────┐     ┌─────────────┐        │
+│  │   Peer      │     │ Hierarchical│     │   Sync      │        │
+│  │   State     │ ◄── │   Router    │ ◄── │   Engine    │        │
+│  │   Merged    │     │             │     │   (CRDT)    │        │
+│  └─────────────┘     └─────────────┘     └─────────────┘        │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 3.3 Crate Dependency Graph
+
+```
+hive-sim ────────────────────────────────────┐
+    │                                        │
+    ▼                                        │
+hive-mesh ◄──────────────────────────────────┤
+    │                                        │
+    ▼                                        │
+hive-protocol (core) ◄───────────────────────┤
+    │                                        │
+    ├── hive-schema (protobuf)               │
+    │                                        │
+    ├──► Ditto Backend (default)             │
+    │    OR                                  │
+    └──► Automerge + Iroh (feature flag)     │
+                                             │
+hive-transport ──────────────────────────────┤
+    │                                        │
+    └──► hive-protocol                       │
+                                             │
+hive-persistence ────────────────────────────┤
+    │                                        │
+    └──► hive-protocol                       │
+                                             │
+hive-ffi (mobile) ───────────────────────────┤
+    │                                        │
+    └──► hive-protocol (automerge only)      │
+                                             │
+hive-inference ──────────────────────────────┘
+    │
+    └──► hive-protocol (automerge)
+```
+
+### 3.4 CRDT Usage
+
+HIVE uses specific CRDT types for different data:
+
+| Data Type | CRDT | Rationale |
+|-----------|------|-----------|
+| Node capabilities | G-Set | Capabilities only grow, never removed |
+| Cell membership | OR-Set | Members can join and leave |
+| Leader identity | LWW-Register | Latest leader wins |
+| Node position | LWW-Register | Latest position is truth |
+| Fuel/resources | PN-Counter | Can increase and decrease |
+| Message history | G-Set | Messages append-only |
+| Configuration | LWW-Map | Latest config wins per key |
+
+---
+
+## 4. Core Concepts
+
+### 4.1 Nodes
+
+A **Node** represents a single entity in the HIVE network:
+
+```rust
+use hive_protocol::models::{Node, NodeId, PlatformType};
+use hive_protocol::models::capability::Capability;
+
+// Create a node
+let node = Node::new(
+    NodeId::new(),
+    PlatformType::UAV,
+    vec![
+        Capability::sensor(SensorType::EoIr, 10_000.0),
+        Capability::compute(ComputeType::EdgeMl, 5.2),
+    ],
+);
+
+// Node has unique ID, platform type, and capabilities
+println!("Node ID: {}", node.id);
+println!("Platform: {:?}", node.platform_type);
+println!("Capabilities: {:?}", node.capabilities);
+```
+
+### 4.2 Capabilities
+
+**Capabilities** describe what a node can do:
+
+```rust
+use hive_protocol::models::capability::{Capability, CapabilityType};
+
+// Sensor capability
+let eo_ir = Capability::new(CapabilityType::Sensor)
+    .with_sensor_type(SensorType::EoIr)
+    .with_range_meters(10_000.0)
+    .with_resolution("4K");
+
+// Compute capability
+let compute = Capability::new(CapabilityType::Compute)
+    .with_compute_type(ComputeType::EdgeMl)
+    .with_tflops(5.2)
+    .with_models(vec!["yolov8", "detection"]);
+
+// Communication capability
+let comms = Capability::new(CapabilityType::Communication)
+    .with_radio_type(RadioType::TacticalRadio)
+    .with_bandwidth_kbps(256);
+```
+
+#### Capability Types
+
+| Type | Description | Composition |
+|------|-------------|-------------|
+| `Sensor` | Detection, imaging, tracking | Additive (ranges combine) |
+| `Compute` | Processing, ML inference | Additive (compute sums) |
+| `Communication` | Radio, network relay | Aggregated (best wins) |
+| `Weapon` | Kinetic effects | Not composed |
+| `Payload` | Cargo, delivery | Additive |
+| `Mobility` | Movement, speed | Constraint (slowest) |
+
+### 4.3 Cells
+
+A **Cell** is a group of nodes that coordinate together:
+
+```rust
+use hive_protocol::cell::{Cell, CellId, CellConfig};
+
+// Cell configuration
+let config = CellConfig::new()
+    .with_target_size(5)
+    .with_leader_election_timeout(Duration::from_secs(10))
+    .with_heartbeat_interval(Duration::from_secs(5));
+
+// Cells form during Phase 2
+// Leader election is deterministic based on node capabilities
+let cell = Cell::new(CellId::new(), config);
+
+// Add members
+cell.add_member(node1.id)?;
+cell.add_member(node2.id)?;
+
+// Leader is elected automatically
+let leader = cell.leader();
+```
+
+#### Cell Roles
+
+| Role | Description | Count per Cell |
+|------|-------------|----------------|
+| `Leader` | Coordinates cell, aggregates to zone | 1 |
+| `Sensor` | Primary sensing capability | 0-N |
+| `Compute` | Primary compute capability | 0-N |
+| `Relay` | Network relay/gateway | 0-N |
+| `Strike` | Kinetic capability | 0-N |
+| `Support` | Logistics, support | 0-N |
+| `Follower` | General member | 0-N |
+
+### 4.4 Zones
+
+A **Zone** aggregates multiple cells for hierarchical coordination:
+
+```rust
+use hive_protocol::hierarchy::{Zone, ZoneId, ZoneConfig};
+
+// Zone configuration
+let config = ZoneConfig::new()
+    .with_target_cells(5)
+    .with_aggregation_interval(Duration::from_secs(10));
+
+// Zones form during Phase 3
+let zone = Zone::new(ZoneId::new(), config);
+
+// Zone coordinator elected from cell leaders
+let coordinator = zone.coordinator();
+
+// Aggregated capabilities from all cells
+let zone_capabilities = zone.aggregated_capabilities();
+```
+
+### 4.5 Three-Phase Protocol
+
+#### Phase 1: Discovery
+
+Nodes discover each other and form initial groups:
+
+```rust
+use hive_protocol::discovery::{DiscoveryConfig, DiscoveryStrategy};
+
+let config = DiscoveryConfig::new()
+    .with_strategy(DiscoveryStrategy::Hybrid)
+    .with_timeout(Duration::from_secs(30))
+    .with_geohash_precision(6);
+
+// Discovery finds peers within geohash region
+let peers = discovery.discover_peers(&config).await?;
+```
+
+**Discovery Strategies**:
+- `mDNS`: Multicast DNS for local network
+- `Static`: Pre-configured peer list
+- `Hybrid`: mDNS + static fallback
+- `Geographic`: Geohash-based clustering
+
+#### Phase 2: Cell Formation
+
+Discovered nodes form cells with elected leaders:
+
+```rust
+use hive_protocol::cell::formation::{FormationConfig, FormationStrategy};
+
+let config = FormationConfig::new()
+    .with_target_cell_size(5)
+    .with_formation_strategy(FormationStrategy::CapabilityBased);
+
+// Formation groups nodes by capability diversity
+let cell = formation.form_cell(&config, &peers).await?;
+
+// Leader election uses deterministic scoring
+// Score = capability_score * uptime_weight * stability_bonus
+let leader = cell.elect_leader()?;
+```
+
+#### Phase 3: Hierarchical Operations
+
+Cells organize into zones for multi-level coordination:
+
+```rust
+use hive_protocol::hierarchy::{HierarchyConfig, AggregationPolicy};
+
+let config = HierarchyConfig::new()
+    .with_zone_size(25)
+    .with_aggregation_policy(AggregationPolicy::Differential);
+
+// Cells aggregate into zones
+let zone = hierarchy.form_zone(&config, &cells).await?;
+
+// Differential updates propagate efficiently
+hierarchy.propagate_update(&update).await?;
+```
+
+### 4.6 Capability Composition
+
+HIVE composes capabilities from multiple nodes:
+
+```rust
+use hive_protocol::composition::{Composer, CompositionRules};
+
+let composer = Composer::with_rules(CompositionRules::default());
+
+// Compose cell capabilities from members
+let cell_capabilities = composer.compose(&cell.members())?;
+
+// Composition follows rules:
+// - Additive: sum ranges, compute
+// - Emergent: detect new capabilities from combinations
+// - Redundant: count duplicates for reliability
+// - Constraint: apply limits (slowest speed wins)
+```
+
+#### Composition Patterns
+
+| Pattern | Example | Rule |
+|---------|---------|------|
+| **Additive** | Sensor ranges combine | `a + b` |
+| **Emergent** | Compute + Sensor = ML | `f(a, b) = c` |
+| **Redundant** | Multiple sensors | `count(type)` |
+| **Constraint** | Movement speed | `min(a, b)` |
+
+---
+
+## 5. Crate Reference
+
+### 5.1 hive-protocol
+
+The core protocol implementation.
+
+```toml
+# Cargo.toml
+[dependencies]
+hive-protocol = { path = "../hive-protocol" }
+```
+
+**Key Modules**:
+
+| Module | Purpose |
+|--------|---------|
+| `cell` | Cell formation, leader election |
+| `command` | Bidirectional command flow |
+| `composition` | Capability composition engine |
+| `discovery` | Peer discovery strategies |
+| `hierarchy` | Zone coordination, aggregation |
+| `models` | Core data structures |
+| `policy` | Policy engine, conflict resolution |
+| `qos` | Quality of service framework |
+| `security` | Authentication, encryption |
+| `storage` | CRDT backend abstraction |
+| `sync` | Synchronization primitives |
+
+### 5.2 hive-schema
+
+Protocol buffer definitions and generated code.
+
+```toml
+[dependencies]
+hive-schema = { path = "../hive-schema" }
+```
+
+**Protobuf Messages**:
+
+| Proto File | Messages |
+|------------|----------|
+| `node.proto` | Node, NodeState, Position |
+| `capability.proto` | Capability, CapabilityType |
+| `cell.proto` | Cell, CellState, CellRole |
+| `zone.proto` | Zone, ZoneState |
+| `message.proto` | HiveMessage, Priority |
+| `command.proto` | Command, CommandResponse |
+| `sync.proto` | SyncRequest, SyncResponse |
+| `discovery.proto` | DiscoveryRequest, Peer |
+
+### 5.3 hive-mesh
+
+Mesh topology and beacon management.
+
+```toml
+[dependencies]
+hive-mesh = { path = "../hive-mesh" }
+```
+
+**Key Types**:
+- `MeshTopology`: Peer connection graph
+- `Beacon`: Node advertisement
+- `MeshRouter`: Message routing
+
+### 5.4 hive-transport
+
+HTTP/REST API layer.
+
+```toml
+[dependencies]
+hive-transport = { path = "../hive-transport" }
+```
+
+**Endpoints**:
+- `GET /api/v1/status` - Node status
+- `GET /api/v1/peers` - Connected peers
+- `GET /api/v1/cell` - Cell information
+- `POST /api/v1/command` - Send command
+
+### 5.5 hive-discovery
+
+Peer discovery implementations.
+
+```toml
+[dependencies]
+hive-discovery = { path = "../hive-discovery" }
+```
+
+**Strategies**:
+- `MdnsDiscovery`: mDNS-based discovery
+- `StaticDiscovery`: Pre-configured peers
+- `HybridDiscovery`: Combined strategy
+
+### 5.6 hive-persistence
+
+Storage backend abstraction.
+
+```toml
+[dependencies]
+hive-persistence = { path = "../hive-persistence" }
+```
+
+**Backends**:
+- `RedbBackend`: Embedded key-value store
+- `SqliteBackend`: SQLite database
+
+### 5.7 hive-ffi
+
+Foreign function interface for mobile.
+
+```toml
+[dependencies]
+hive-ffi = { path = "../hive-ffi", features = ["automerge-backend"] }
+```
+
+**Bindings**:
+- UniFFI for Kotlin/Swift
+- JNI for direct Android
+
+### 5.8 hive-inference
+
+Edge AI/ML inference pipeline.
+
+```toml
+[dependencies]
+hive-inference = { path = "../hive-inference", features = ["onnx-inference"] }
+```
+
+**Features**:
+- ONNX runtime integration
+- Object detection pipeline
+- Model distribution
+- Video capture (GStreamer)
+
+---
+
+## 6. API Reference
+
+### 6.1 Node API
+
+```rust
+use hive_protocol::models::{Node, NodeId, NodeState};
+
+impl Node {
+    /// Create a new node with capabilities
+    pub fn new(id: NodeId, platform: PlatformType, capabilities: Vec<Capability>) -> Self;
+
+    /// Get node identifier
+    pub fn id(&self) -> &NodeId;
+
+    /// Get current state
+    pub fn state(&self) -> &NodeState;
+
+    /// Update position
+    pub fn update_position(&mut self, position: Position);
+
+    /// Add capability
+    pub fn add_capability(&mut self, capability: Capability);
+
+    /// Get all capabilities
+    pub fn capabilities(&self) -> &[Capability];
+}
+```
+
+### 6.2 Cell API
+
+```rust
+use hive_protocol::cell::{Cell, CellId, CellConfig};
+
+impl Cell {
+    /// Create a new cell
+    pub fn new(id: CellId, config: CellConfig) -> Self;
+
+    /// Add a member to the cell
+    pub fn add_member(&mut self, node_id: NodeId) -> Result<(), CellError>;
+
+    /// Remove a member from the cell
+    pub fn remove_member(&mut self, node_id: &NodeId) -> Result<(), CellError>;
+
+    /// Get current leader
+    pub fn leader(&self) -> Option<&NodeId>;
+
+    /// Trigger leader election
+    pub fn elect_leader(&mut self) -> Result<NodeId, CellError>;
+
+    /// Get all members
+    pub fn members(&self) -> &[NodeId];
+
+    /// Get aggregated capabilities
+    pub fn capabilities(&self) -> Vec<Capability>;
+}
+```
+
+### 6.3 Discovery API
+
+```rust
+use hive_protocol::discovery::{Discovery, DiscoveryConfig, Peer};
+
+impl Discovery {
+    /// Create discovery service
+    pub fn new(config: DiscoveryConfig) -> Self;
+
+    /// Start discovery process
+    pub async fn start(&self) -> Result<(), DiscoveryError>;
+
+    /// Discover peers
+    pub async fn discover_peers(&self) -> Result<Vec<Peer>, DiscoveryError>;
+
+    /// Subscribe to peer events
+    pub fn subscribe(&self) -> broadcast::Receiver<PeerEvent>;
+}
+```
+
+### 6.4 Sync API
+
+```rust
+use hive_protocol::sync::{SyncEngine, SyncConfig};
+
+impl SyncEngine {
+    /// Create sync engine with backend
+    pub fn new(backend: impl SyncBackend, config: SyncConfig) -> Self;
+
+    /// Start synchronization
+    pub async fn start(&self) -> Result<(), SyncError>;
+
+    /// Apply local change
+    pub async fn apply_change(&self, change: Change) -> Result<(), SyncError>;
+
+    /// Subscribe to remote changes
+    pub fn subscribe(&self) -> broadcast::Receiver<Change>;
+
+    /// Get current state
+    pub fn state(&self) -> State;
+}
+```
+
+### 6.5 Storage API
+
+```rust
+use hive_protocol::storage::{Storage, StorageBackend};
+
+/// Backend-agnostic storage trait
+pub trait StorageBackend: Send + Sync {
+    /// Get value by key
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, StorageError>;
+
+    /// Set value
+    async fn set(&self, key: &str, value: Vec<u8>) -> Result<(), StorageError>;
+
+    /// Delete value
+    async fn delete(&self, key: &str) -> Result<(), StorageError>;
+
+    /// List keys with prefix
+    async fn list(&self, prefix: &str) -> Result<Vec<String>, StorageError>;
+
+    /// Subscribe to changes
+    fn subscribe(&self) -> broadcast::Receiver<StorageEvent>;
+}
+```
+
+### 6.6 Error Handling
+
+HIVE uses typed errors for each domain:
+
+```rust
+use hive_protocol::error::{HiveError, CellError, DiscoveryError, SyncError};
+
+// Errors are enums with variants
+pub enum CellError {
+    MemberNotFound(NodeId),
+    CellFull { max_size: usize },
+    LeaderElectionFailed { reason: String },
+    InvalidConfiguration(String),
+}
+
+// Use Result throughout
+fn add_to_cell(cell: &mut Cell, node: NodeId) -> Result<(), CellError> {
+    if cell.members().len() >= cell.max_size() {
+        return Err(CellError::CellFull { max_size: cell.max_size() });
+    }
+    cell.add_member(node)?;
+    Ok(())
+}
+
+// Propagate with ?
+async fn join_network(config: &Config) -> Result<(), HiveError> {
+    let peers = discovery.discover_peers().await?;
+    let cell = formation.join_cell(&peers).await?;
+    Ok(())
+}
+```
+
+---
+
+## 7. Extending HIVE
+
+### 7.1 Adding Custom Capabilities
+
+Create a new capability type:
+
+```rust
+// src/models/capability.rs extension
+
+/// Add new capability type
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum CapabilityType {
+    // Existing types...
+    Sensor,
+    Compute,
+    Communication,
+
+    // Your new type
+    CustomLidar {
+        range_meters: f64,
+        points_per_second: u64,
+        fov_degrees: f64,
+    },
+}
+
+// Add composition rule
+impl CompositionRule for CustomLidar {
+    fn compose(&self, other: &Self) -> Option<Self> {
+        // Custom composition logic
+        Some(CustomLidar {
+            range_meters: self.range_meters.max(other.range_meters),
+            points_per_second: self.points_per_second + other.points_per_second,
+            fov_degrees: self.fov_degrees.max(other.fov_degrees),
+        })
+    }
+}
+```
+
+### 7.2 Custom Discovery Strategy
+
+Implement a custom discovery strategy:
+
+```rust
+use hive_protocol::discovery::{DiscoveryStrategy, Peer, DiscoveryError};
+use async_trait::async_trait;
+
+pub struct CustomDiscovery {
+    config: CustomDiscoveryConfig,
+}
+
+#[async_trait]
+impl DiscoveryStrategy for CustomDiscovery {
+    async fn discover(&self) -> Result<Vec<Peer>, DiscoveryError> {
+        // Your discovery logic
+        let peers = self.query_custom_service().await?;
+        Ok(peers)
+    }
+
+    async fn announce(&self, node: &Node) -> Result<(), DiscoveryError> {
+        // Announce this node
+        self.register_with_service(node).await?;
+        Ok(())
+    }
+
+    fn strategy_name(&self) -> &str {
+        "custom"
+    }
+}
+
+// Register with discovery coordinator
+let discovery = Discovery::new(config)
+    .with_strategy(Box::new(CustomDiscovery::new(custom_config)));
+```
+
+### 7.3 Custom Composition Rules
+
+Add custom composition rules:
+
+```rust
+use hive_protocol::composition::{CompositionRule, CompositionResult};
+
+/// Custom rule for detecting emergent capabilities
+pub struct DetectionEmergence;
+
+impl CompositionRule for DetectionEmergence {
+    fn name(&self) -> &str {
+        "detection_emergence"
+    }
+
+    fn applies_to(&self, capabilities: &[Capability]) -> bool {
+        // Check if we have both sensor and compute
+        let has_sensor = capabilities.iter().any(|c| c.is_sensor());
+        let has_compute = capabilities.iter().any(|c| c.is_compute());
+        has_sensor && has_compute
+    }
+
+    fn compose(&self, capabilities: &[Capability]) -> CompositionResult {
+        // Combine sensor + compute = detection capability
+        let sensor = capabilities.iter().find(|c| c.is_sensor())?;
+        let compute = capabilities.iter().find(|c| c.is_compute())?;
+
+        CompositionResult::Emergent(Capability::detection(
+            sensor.range(),
+            compute.tflops(),
+        ))
+    }
+}
+
+// Register the rule
+composer.add_rule(Box::new(DetectionEmergence));
+```
+
+### 7.4 Custom Policy Rules
+
+Implement policy rules for conflict resolution:
+
+```rust
+use hive_protocol::policy::{PolicyRule, PolicyContext, PolicyDecision};
+
+pub struct CustomAuthorizationPolicy;
+
+impl PolicyRule for CustomAuthorizationPolicy {
+    fn name(&self) -> &str {
+        "custom_authorization"
+    }
+
+    fn evaluate(&self, context: &PolicyContext) -> PolicyDecision {
+        // Check authorization
+        if context.requester_authority() < context.required_authority() {
+            return PolicyDecision::Deny {
+                reason: "Insufficient authority".to_string(),
+            };
+        }
+
+        // Check time-based restrictions
+        if !context.within_operation_window() {
+            return PolicyDecision::Deny {
+                reason: "Outside operation window".to_string(),
+            };
+        }
+
+        PolicyDecision::Allow
+    }
+
+    fn priority(&self) -> u32 {
+        100 // Higher priority evaluated first
+    }
+}
+
+// Register policy
+policy_engine.add_rule(Box::new(CustomAuthorizationPolicy));
+```
+
+### 7.5 Custom QoS Configuration
+
+Configure quality of service:
+
+```rust
+use hive_protocol::qos::{QosConfig, Priority, QosRule};
+
+let qos_config = QosConfig::new()
+    // Position updates are high priority
+    .with_rule(QosRule::new()
+        .message_type("position_update")
+        .priority(Priority::P1)
+        .max_latency(Duration::from_millis(100)))
+
+    // Telemetry is lower priority
+    .with_rule(QosRule::new()
+        .message_type("telemetry")
+        .priority(Priority::P3)
+        .max_latency(Duration::from_secs(5)))
+
+    // Custom message type
+    .with_rule(QosRule::new()
+        .message_type("custom_alert")
+        .priority(Priority::P0)
+        .max_latency(Duration::from_millis(50)));
+```
+
+---
+
+## 8. Testing
+
+### 8.1 Test Philosophy
+
+HIVE follows a test pyramid approach:
+
+```
+         /\
+        /E2E\         10% effort, 100% mission assurance
+       /------\
+      /Integra-\      20% effort, component validation
+     /  tion    \
+    /------------\
+   /    Unit      \   70% effort, business logic
+  /----------------\
+```
+
+**Key Principle**: E2E tests validate real CRDT sync behavior - this is critical for autonomous systems.
+
+### 8.2 Unit Tests
+
+Unit tests are inline with code:
+
+```rust
+// src/composition/rules.rs
+
+pub fn compose_additive(a: f64, b: f64) -> f64 {
+    a + b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compose_additive() {
+        assert_eq!(compose_additive(1.0, 2.0), 3.0);
+        assert_eq!(compose_additive(0.0, 5.0), 5.0);
+    }
+
+    #[test]
+    fn test_compose_additive_negative() {
+        assert_eq!(compose_additive(-1.0, 1.0), 0.0);
+    }
+}
+```
+
+Run unit tests:
+```bash
+make test-fast
+# or
+cargo test --lib
+```
+
+### 8.3 Integration Tests
+
+Integration tests are in `tests/` directory:
+
+```rust
+// tests/cell_integration.rs
+
+use hive_protocol::cell::{Cell, CellConfig};
+use hive_protocol::models::Node;
+
+#[tokio::test]
+async fn test_cell_formation_integration() {
+    // Create multiple nodes
+    let nodes = create_test_nodes(5);
+
+    // Form a cell
+    let config = CellConfig::default();
+    let mut cell = Cell::new(CellId::new(), config);
+
+    for node in &nodes {
+        cell.add_member(node.id.clone()).unwrap();
+    }
+
+    // Verify cell state
+    assert_eq!(cell.members().len(), 5);
+    assert!(cell.leader().is_some());
+}
+
+#[tokio::test]
+async fn test_leader_election_integration() {
+    let mut cell = create_test_cell(5);
+
+    // Trigger leader election
+    let leader = cell.elect_leader().unwrap();
+
+    // Leader should be the highest-scoring node
+    assert!(cell.members().contains(&leader));
+}
+```
+
+Run integration tests:
+```bash
+make test-integration
+# or
+cargo test --test '*_integration'
+```
+
+### 8.4 E2E Tests
+
+E2E tests validate real CRDT synchronization:
+
+```rust
+// tests/sync_e2e.rs
+
+use hive_protocol::testing::{E2eHarness, TestObserver};
+
+#[tokio::test]
+async fn test_state_sync_e2e() {
+    // Create E2E harness with real Ditto
+    let harness = E2eHarness::new()
+        .with_node_count(3)
+        .with_observer(TestObserver::new())
+        .build()
+        .await;
+
+    // Start all nodes
+    harness.start_all().await;
+
+    // Make change on node 0
+    let node0 = harness.node(0);
+    node0.update_position(Position::new(38.8977, -77.0365)).await;
+
+    // Wait for sync (with timeout)
+    harness.wait_for_sync(Duration::from_secs(5)).await?;
+
+    // Verify all nodes have the update
+    for i in 0..3 {
+        let node = harness.node(i);
+        let position = node.position();
+        assert_eq!(position.lat, 38.8977);
+        assert_eq!(position.lon, -77.0365);
+    }
+}
+
+#[tokio::test]
+async fn test_partition_recovery_e2e() {
+    let harness = E2eHarness::new()
+        .with_node_count(4)
+        .build()
+        .await;
+
+    harness.start_all().await;
+
+    // Create partition between nodes 0,1 and 2,3
+    harness.partition(vec![0, 1], vec![2, 3]).await;
+
+    // Make changes on both sides
+    harness.node(0).update_value("key", "value_a").await;
+    harness.node(2).update_value("key", "value_b").await;
+
+    // Heal partition
+    harness.heal_partition().await;
+
+    // Wait for reconciliation
+    harness.wait_for_sync(Duration::from_secs(10)).await?;
+
+    // CRDT ensures consistent state (LWW - last write wins)
+    let final_value = harness.node(0).get_value("key");
+    for i in 0..4 {
+        assert_eq!(harness.node(i).get_value("key"), final_value);
+    }
+}
+```
+
+Run E2E tests:
+```bash
+make test-e2e
+# or
+cargo test --test '*_e2e' -- --test-threads=1
+```
+
+### 8.5 Test Fixtures
+
+Use fixtures for consistent test data:
+
+```rust
+// src/testing/fixtures.rs
+
+pub fn create_test_node() -> Node {
+    Node::new(
+        NodeId::new(),
+        PlatformType::UAV,
+        vec![
+            Capability::sensor(SensorType::EoIr, 10_000.0),
+        ],
+    )
+}
+
+pub fn create_test_nodes(count: usize) -> Vec<Node> {
+    (0..count).map(|_| create_test_node()).collect()
+}
+
+pub fn create_test_cell(size: usize) -> Cell {
+    let mut cell = Cell::new(CellId::new(), CellConfig::default());
+    for node in create_test_nodes(size) {
+        cell.add_member(node.id).unwrap();
+    }
+    cell
+}
+```
+
+### 8.6 Mocking
+
+Use mock implementations for unit testing:
+
+```rust
+use mockall::automock;
+
+#[automock]
+pub trait StorageBackend {
+    async fn get(&self, key: &str) -> Result<Option<Vec<u8>>, StorageError>;
+    async fn set(&self, key: &str, value: Vec<u8>) -> Result<(), StorageError>;
+}
+
+#[tokio::test]
+async fn test_with_mock_storage() {
+    let mut mock = MockStorageBackend::new();
+
+    mock.expect_get()
+        .with(eq("test_key"))
+        .returning(|_| Ok(Some(b"test_value".to_vec())));
+
+    let service = Service::new(mock);
+    let result = service.read("test_key").await;
+
+    assert_eq!(result, "test_value");
+}
+```
+
+### 8.7 Test Commands
+
+```bash
+# Quick development cycle
+make test-fast              # Unit tests only (~30s)
+
+# Pre-commit (recommended)
+make pre-commit             # Format + lint + all tests
+
+# Full test suite
+make test                   # Unit + integration + E2E (~10 min)
+
+# Specific test patterns
+cargo test discovery        # Tests matching "discovery"
+cargo test --test sync_e2e  # Specific E2E test file
+
+# With output
+cargo test -- --nocapture   # Show println! output
+
+# Coverage
+cargo tarpaulin --out Html
+```
+
+---
+
+## 9. Backend Abstraction
+
+### 9.1 Backend Architecture
+
+HIVE abstracts the CRDT backend to support multiple implementations:
+
+```rust
+/// Backend-agnostic sync trait
+pub trait SyncBackend: Send + Sync {
+    /// Initialize the backend
+    async fn initialize(&self) -> Result<(), BackendError>;
+
+    /// Apply a local change
+    async fn apply_local(&self, change: Change) -> Result<(), BackendError>;
+
+    /// Subscribe to remote changes
+    fn subscribe(&self) -> broadcast::Receiver<Change>;
+
+    /// Get current state
+    async fn state(&self) -> State;
+
+    /// Sync with peers
+    async fn sync(&self) -> Result<(), BackendError>;
+}
+```
+
+### 9.2 Ditto Backend (Default)
+
+Production-ready CRDT backend using Ditto SDK:
+
+```rust
+use hive_protocol::storage::ditto::DittoBackend;
+
+// Configure Ditto
+let ditto_config = DittoConfig::new()
+    .with_app_id(env::var("DITTO_APP_ID")?)
+    .with_offline_token(env::var("DITTO_OFFLINE_TOKEN")?)
+    .with_persistence_dir("/var/lib/hive/ditto");
+
+let backend = DittoBackend::new(ditto_config).await?;
+let sync_engine = SyncEngine::new(backend);
+```
+
+**Advantages**:
+- Production-tested at scale
+- Built-in P2P mesh
+- Automatic conflict resolution
+- Mobile SDK support
+
+**Requirements**:
+- Ditto license (free for evaluation)
+- `DITTO_APP_ID` and `DITTO_OFFLINE_TOKEN`
+
+### 9.3 Automerge Backend (Pure OSS)
+
+Pure Rust implementation using Automerge + Iroh:
+
+```rust
+use hive_protocol::storage::automerge::AutomergeBackend;
+
+// Configure Automerge + Iroh
+let automerge_config = AutomergeConfig::new()
+    .with_persistence_dir("/var/lib/hive/automerge");
+
+let backend = AutomergeBackend::new(automerge_config).await?;
+let sync_engine = SyncEngine::new(backend);
+```
+
+**Advantages**:
+- 100% open source (MIT/Apache-2.0)
+- No external dependencies
+- Iroh QUIC transport
+- Works on all platforms including Android
+
+**Current Status**: ~70% feature parity with Ditto
+
+### 9.4 Switching Backends
+
+Build with specific backend:
+
+```bash
+# Ditto backend (default)
+cargo build --release
+
+# Automerge backend
+cargo build --release --no-default-features --features automerge-backend
+
+# Both backends (for testing)
+cargo build --release --features automerge-backend
+```
+
+Runtime selection (if both compiled):
+
+```rust
+use hive_protocol::storage::{DittoBackend, AutomergeBackend, BackendSelector};
+
+let backend: Box<dyn SyncBackend> = match config.backend {
+    BackendType::Ditto => Box::new(DittoBackend::new(ditto_config).await?),
+    BackendType::Automerge => Box::new(AutomergeBackend::new(am_config).await?),
+};
+```
+
+---
+
+## 10. Mobile Development
+
+### 10.1 Architecture
+
+Mobile support via hive-ffi using UniFFI:
+
+```
+┌─────────────────┐     ┌─────────────────┐
+│  Kotlin/Swift   │     │     Android     │
+│   Application   │     │      ATAK       │
+└────────┬────────┘     └────────┬────────┘
+         │                       │
+         ▼                       ▼
+┌─────────────────────────────────────────┐
+│              hive-ffi                   │
+│         (UniFFI bindings)               │
+└─────────────────┬───────────────────────┘
+                  │
+                  ▼
+┌─────────────────────────────────────────┐
+│           hive-protocol                  │
+│      (Automerge backend only)           │
+└─────────────────────────────────────────┘
+```
+
+### 10.2 Building for Android
+
+```bash
+# Install Android NDK
+# Set ANDROID_NDK_HOME environment variable
+
+# Add Android targets
+rustup target add aarch64-linux-android
+rustup target add armv7-linux-androideabi
+rustup target add x86_64-linux-android
+
+# Build FFI library
+cd hive-ffi
+cargo build --release --target aarch64-linux-android
+
+# Generate Kotlin bindings
+cargo run --bin uniffi-bindgen generate \
+    --library target/aarch64-linux-android/release/libhive_ffi.so \
+    --language kotlin \
+    --out-dir kotlin-bindings
+```
+
+### 10.3 Kotlin Usage
+
+```kotlin
+import com.hive.protocol.*
+
+class HiveService {
+    private val hive: HiveClient
+
+    init {
+        // Initialize HIVE client
+        val config = HiveConfig(
+            nodeId = UUID.randomUUID().toString(),
+            persistenceDir = context.filesDir.absolutePath
+        )
+        hive = HiveClient(config)
+    }
+
+    suspend fun start() {
+        hive.start()
+    }
+
+    suspend fun updatePosition(lat: Double, lon: Double) {
+        hive.updatePosition(Position(lat, lon, 0.0))
+    }
+
+    fun observePeers(): Flow<List<Peer>> {
+        return hive.peers().asFlow()
+    }
+}
+```
+
+### 10.4 ATAK Plugin Development
+
+The ATAK plugin provides TAK integration:
+
+```bash
+# Build ATAK plugin
+cd atak-plugin
+./gradlew assembleRelease
+
+# Install on device
+adb install -r app/build/outputs/apk/release/hive-atak-plugin.apk
+```
+
+Plugin architecture:
+- `HiveDropDownReceiver`: UI integration
+- `HiveCotTranslator`: CoT message translation
+- `HivePeerManager`: Peer discovery and management
+
+---
+
+## 11. Edge AI Integration
+
+### 11.1 hive-inference Overview
+
+The `hive-inference` crate provides edge AI/ML capabilities:
+
+```rust
+use hive_inference::{InferencePipeline, DetectionModel, VideoSource};
+
+// Create inference pipeline
+let pipeline = InferencePipeline::new()
+    .with_model(DetectionModel::YoloV8("models/yolov8n.onnx"))
+    .with_source(VideoSource::Gstreamer("v4l2src device=/dev/video0"))
+    .with_tracker(ObjectTracker::ByteTrack)
+    .build()?;
+
+// Run inference
+pipeline.start().await?;
+
+// Subscribe to detections
+let mut detections = pipeline.subscribe();
+while let Some(detection) = detections.recv().await {
+    println!("Detected: {:?} at {:?}", detection.class, detection.bbox);
+}
+```
+
+### 11.2 Model Distribution
+
+HIVE distributes AI models across the network:
+
+```rust
+use hive_protocol::distribution::{ModelDistributor, ModelManifest};
+
+// Create model manifest
+let manifest = ModelManifest::new()
+    .with_model_id("yolov8n-v1.0")
+    .with_hash("sha256:abc123...")
+    .with_size_bytes(6_000_000)
+    .with_compatible_platforms(vec![PlatformType::Jetson, PlatformType::EdgeML]);
+
+// Distribute to cell
+let distributor = ModelDistributor::new(cell.clone());
+distributor.distribute(&manifest, &model_bytes).await?;
+
+// Verify distribution
+let status = distributor.distribution_status(&manifest.model_id).await?;
+println!("Distributed to {}/{} nodes", status.completed, status.total);
+```
+
+### 11.3 Runtime Adapters
+
+Support multiple inference runtimes:
+
+```rust
+use hive_inference::runtime::{RuntimeAdapter, OnnxRuntime, TensorRtRuntime};
+
+// ONNX Runtime (cross-platform)
+let onnx = OnnxRuntime::new(OnnxConfig::default())?;
+
+// TensorRT (NVIDIA GPU acceleration)
+let tensorrt = TensorRtRuntime::new(TensorRtConfig {
+    fp16: true,
+    max_batch_size: 8,
+})?;
+
+// Select based on platform
+let runtime: Box<dyn RuntimeAdapter> = if has_nvidia_gpu() {
+    Box::new(tensorrt)
+} else {
+    Box::new(onnx)
+};
+```
+
+---
+
+## 12. Contributing
+
+### 12.1 Code Style
+
+Follow Rust conventions and project style:
+
+```rust
+// Use rustfmt defaults
+cargo fmt
+
+// Fix clippy warnings
+cargo clippy --all-targets --all-features -- -D warnings
+
+// Naming conventions
+pub struct NodeState { }        // PascalCase for types
+pub fn discover_peers() { }     // snake_case for functions
+const MAX_CELL_SIZE: usize = 10; // SCREAMING_SNAKE for constants
+```
+
+### 12.2 Commit Messages
+
+Follow Conventional Commits:
+
+```
+feat(cell): Add dynamic cell resizing
+
+Add ability for cells to grow/shrink based on operational needs.
+Includes new configuration option `dynamic_sizing` and tests.
+
+Closes #123
+```
+
+**Prefixes**:
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation
+- `test`: Tests
+- `refactor`: Code refactoring
+- `perf`: Performance improvement
+- `chore`: Maintenance
+
+### 12.3 Pull Request Process
+
+1. **Fork and branch**:
+   ```bash
+   git checkout -b feat/your-feature
+   ```
+
+2. **Make changes** with tests
+
+3. **Run pre-commit checks**:
+   ```bash
+   make pre-commit
+   ```
+
+4. **Push and create PR**:
+   ```bash
+   git push -u origin feat/your-feature
+   ```
+
+5. **PR template** includes:
+   - Description of changes
+   - Related issues
+   - Test plan
+   - Documentation updates
+
+### 12.4 Review Guidelines
+
+PRs require:
+- All CI checks passing
+- At least one approval
+- No unresolved comments
+- Documentation for public APIs
+- Tests for new functionality
+
+### 12.5 Documentation Requirements
+
+All public APIs must have doc comments:
+
+```rust
+/// Discovers peers in the local network.
+///
+/// Uses the configured discovery strategy to find other HIVE nodes.
+/// Returns a list of discovered peers within the timeout period.
+///
+/// # Arguments
+///
+/// * `timeout` - Maximum time to wait for discovery
+///
+/// # Returns
+///
+/// A vector of discovered peers, or an error if discovery fails.
+///
+/// # Examples
+///
+/// ```rust
+/// let discovery = Discovery::new(config);
+/// let peers = discovery.discover(Duration::from_secs(30)).await?;
+/// println!("Found {} peers", peers.len());
+/// ```
+///
+/// # Errors
+///
+/// Returns `DiscoveryError::Timeout` if no peers found within timeout.
+/// Returns `DiscoveryError::NetworkError` if network is unavailable.
+pub async fn discover(&self, timeout: Duration) -> Result<Vec<Peer>, DiscoveryError> {
+    // implementation
+}
+```
+
+---
+
+## 13. Reference
+
+### 13.1 Glossary
+
+| Term | Definition |
+|------|------------|
+| **Cell** | Group of nodes coordinating together |
+| **Zone** | Group of cells in hierarchical organization |
+| **Capability** | What a node can do (sense, compute, communicate) |
+| **Composition** | Combining capabilities from multiple nodes |
+| **CRDT** | Conflict-free Replicated Data Type |
+| **Differential Update** | Sending only changed data |
+| **Formation Key** | Shared secret for cell formation |
+| **Leader** | Node coordinating a cell |
+| **Coordinator** | Node coordinating a zone |
+
+### 13.2 ADR Index
+
+Key Architecture Decision Records:
+
+| ADR | Title |
+|-----|-------|
+| [001](../../adr/001-cap-protocol-poc.md) | HIVE Protocol POC |
+| [004](../../adr/004-human-machine-cell-composition.md) | Human-Machine Cell Composition |
+| [011](../../adr/011-ditto-vs-automerge-iroh.md) | Ditto vs Automerge/Iroh |
+| [012](../../adr/012-schema-definition-protocol-extensibility.md) | Schema Definition |
+| [017](../../adr/017-p2p-mesh-management-discovery.md) | P2P Mesh Discovery |
+| [018](../../adr/018-ai-model-capability-advertisement.md) | AI Model Advertisement |
+| [019](../../adr/019-qos-and-data-prioritization.md) | QoS and Prioritization |
+| [020](../../adr/020-TAK-CoT-Integration.md) | TAK/CoT Integration |
+
+### 13.3 External Resources
+
+- [Ditto Documentation](https://docs.ditto.live/rust/)
+- [Automerge Documentation](https://automerge.org/docs/)
+- [Iroh Documentation](https://iroh.computer/docs/)
+- [Tokio Tutorial](https://tokio.rs/tokio/tutorial)
+- [Rust Book](https://doc.rust-lang.org/book/)
+
+### 13.4 Getting Help
+
+- **GitHub Issues**: [github.com/kitplummer/hive/issues](https://github.com/kitplummer/hive/issues)
+- **Documentation**: [docs/INDEX.md](../../INDEX.md)
+- **ADRs**: [docs/adr/](../../adr/)
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: 2025-12-08
+**Maintainer**: HIVE Development Team

--- a/docs/guides/operator/OPERATOR_GUIDE.md
+++ b/docs/guides/operator/OPERATOR_GUIDE.md
@@ -1,0 +1,1279 @@
+# HIVE Operator Guide
+
+> **Version**: 1.0
+> **Last Updated**: 2025-12-08
+> **Audience**: System Administrators, DevOps Engineers, Mission Operators
+
+---
+
+## Table of Contents
+
+1. [Introduction](#1-introduction)
+2. [Quick Start](#2-quick-start)
+3. [Installation](#3-installation)
+4. [Configuration](#4-configuration)
+5. [Deployment Patterns](#5-deployment-patterns)
+6. [Network Configuration](#6-network-configuration)
+7. [Security](#7-security)
+8. [Monitoring & Observability](#8-monitoring--observability)
+9. [TAK/ATAK Integration](#9-takatak-integration)
+10. [Backup & Recovery](#10-backup--recovery)
+11. [Troubleshooting](#11-troubleshooting)
+12. [Reference](#12-reference)
+
+---
+
+## 1. Introduction
+
+### 1.1 What is HIVE?
+
+HIVE (Hierarchical Intelligence for Versatile Entities) is a protocol for scalable coordination of autonomous nodes (100+ nodes) using CRDTs with O(n log n) message complexity. It enables autonomous systems to coordinate without centralized control through:
+
+- **Three-phase protocol**: Discovery → Cell Formation → Hierarchical Operations
+- **CRDT-based state**: Eventual consistency via distributed data structures
+- **Capability composition**: Nodes advertise and combine capabilities dynamically
+- **Differential updates**: 95%+ bandwidth reduction through delta propagation
+
+### 1.2 Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         HIVE Network                            │
+│                                                                 │
+│  ┌──────────┐    ┌──────────┐    ┌──────────┐                  │
+│  │  Zone 1  │    │  Zone 2  │    │  Zone 3  │   Hierarchical   │
+│  │ (Leader) │────│ (Leader) │────│ (Leader) │   Operations     │
+│  └────┬─────┘    └────┬─────┘    └────┬─────┘                  │
+│       │               │               │                         │
+│  ┌────┴────┐     ┌────┴────┐     ┌────┴────┐                   │
+│  │  Cell   │     │  Cell   │     │  Cell   │   Cell Formation  │
+│  │ ┌─┬─┬─┐ │     │ ┌─┬─┬─┐ │     │ ┌─┬─┬─┐ │                   │
+│  │ │N│N│N│ │     │ │N│N│N│ │     │ │N│N│N│ │   Discovery       │
+│  │ └─┴─┴─┘ │     │ └─┴─┴─┘ │     │ └─┴─┴─┘ │                   │
+│  └─────────┘     └─────────┘     └─────────┘                   │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 1.3 Key Components
+
+| Component | Description | Crate |
+|-----------|-------------|-------|
+| **Protocol Core** | Three-phase protocol, capabilities, composition | `hive-protocol` |
+| **Mesh Layer** | P2P mesh topology and beacon management | `hive-mesh` |
+| **Transport** | HTTP/REST API for external integration | `hive-transport` |
+| **Discovery** | Peer discovery (mDNS, static, hybrid) | `hive-discovery` |
+| **Persistence** | Storage abstraction for state | `hive-persistence` |
+| **Simulator** | Network simulation and testing | `hive-sim` |
+| **FFI** | Mobile bindings (Kotlin/Swift) | `hive-ffi` |
+| **Inference** | Edge AI/ML inference pipeline | `hive-inference` |
+
+### 1.4 Supported Platforms
+
+| Platform | Backend | Status |
+|----------|---------|--------|
+| Linux (x86_64) | Ditto, Automerge | Production |
+| Linux (aarch64) | Ditto, Automerge | Production |
+| macOS (x86_64, arm64) | Ditto, Automerge | Production |
+| Android | Automerge only | Beta |
+| Windows | Ditto | Experimental |
+| Jetson (CUDA) | Automerge | Beta |
+
+---
+
+## 2. Quick Start
+
+Get HIVE running in 10 minutes.
+
+### 2.1 Prerequisites
+
+- **Rust**: 1.70 or later
+- **Git**: For cloning the repository
+- **8GB RAM** minimum (16GB recommended for simulation)
+- **Network**: Internet access for dependencies
+
+### 2.2 Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/kitplummer/hive.git
+cd hive
+
+# Build the project (first build takes 5-10 minutes)
+cargo build --release
+```
+
+### 2.3 Run Your First Simulation
+
+```bash
+# Run the network simulator
+cargo run --release --bin hive-sim
+```
+
+Expected output:
+```
+[INFO] HIVE Simulator starting...
+[INFO] Creating 10 nodes with random capabilities
+[INFO] Phase 1: Discovery starting...
+[INFO] Node UAV-001 discovered 9 peers
+[INFO] Phase 2: Cell formation starting...
+[INFO] Cell ALPHA formed with leader UAV-003
+[INFO] Cell BETA formed with leader UGV-002
+[INFO] Phase 3: Hierarchical operations active
+[INFO] Zone coordinator elected: UAV-003
+[INFO] Simulation complete. Press Ctrl+C to exit.
+```
+
+### 2.4 Verify Installation
+
+```bash
+# Run the test suite
+make test-fast
+
+# Check the build
+cargo check --all-features
+```
+
+### 2.5 Next Steps
+
+- [Configuration](#4-configuration) - Customize your deployment
+- [Deployment Patterns](#5-deployment-patterns) - Production deployment options
+- [TAK Integration](#9-takatak-integration) - Connect to ATAK
+
+---
+
+## 3. Installation
+
+### 3.1 System Requirements
+
+#### Minimum Requirements
+
+| Resource | Requirement |
+|----------|-------------|
+| CPU | 2 cores |
+| RAM | 4 GB |
+| Disk | 2 GB free |
+| Network | 100 Mbps |
+| OS | Linux 4.4+, macOS 10.15+, Windows 10+ |
+
+#### Recommended for Production
+
+| Resource | Requirement |
+|----------|-------------|
+| CPU | 4+ cores |
+| RAM | 16 GB |
+| Disk | 20 GB SSD |
+| Network | 1 Gbps |
+| OS | Ubuntu 22.04 LTS, RHEL 8+ |
+
+### 3.2 Install Rust
+
+```bash
+# Install Rust via rustup
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+# Reload shell configuration
+source $HOME/.cargo/env
+
+# Verify installation
+rustc --version   # Should show 1.70.0 or later
+cargo --version
+```
+
+### 3.3 Build from Source
+
+#### Standard Build (Ditto Backend)
+
+```bash
+git clone https://github.com/kitplummer/hive.git
+cd hive
+
+# Build all crates
+cargo build --release
+
+# Binaries located at:
+# - target/release/hive-sim
+# - target/release/hive-commander (if available)
+```
+
+#### Build with Automerge Backend (Pure OSS)
+
+```bash
+# Build with Automerge instead of Ditto
+cargo build --release --no-default-features --features automerge-backend
+```
+
+#### Build for Android
+
+```bash
+# Install Android NDK and configure toolchains
+# See .cargo/config.toml for toolchain configuration
+
+# Build FFI library for Android
+cd hive-ffi
+cargo build --release --target aarch64-linux-android
+```
+
+### 3.4 Pre-built Binaries
+
+Pre-built binaries are available for releases:
+
+```bash
+# Download latest release (example)
+curl -LO https://github.com/kitplummer/hive/releases/latest/download/hive-sim-linux-x86_64.tar.gz
+tar -xzf hive-sim-linux-x86_64.tar.gz
+./hive-sim
+```
+
+### 3.5 Container Deployment
+
+```dockerfile
+# Example Dockerfile
+FROM rust:1.75-slim as builder
+WORKDIR /app
+COPY . .
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/target/release/hive-sim /usr/local/bin/
+ENTRYPOINT ["hive-sim"]
+```
+
+Build and run:
+```bash
+docker build -t hive-sim .
+docker run --rm -it hive-sim
+```
+
+### 3.6 Development Tools (Optional)
+
+```bash
+# Fast test runner
+cargo install cargo-nextest
+
+# File watcher for auto-rebuild
+cargo install cargo-watch
+
+# Performance profiling
+cargo install flamegraph
+
+# Mold linker (faster linking on Linux)
+# Ubuntu/Debian:
+sudo apt install mold
+```
+
+---
+
+## 4. Configuration
+
+### 4.1 Environment Variables
+
+#### Ditto Backend Configuration
+
+| Variable | Description | Default | Required |
+|----------|-------------|---------|----------|
+| `DITTO_APP_ID` | Ditto application identifier | - | Yes (Ditto) |
+| `DITTO_OFFLINE_TOKEN` | Offline authentication token | - | Yes (Ditto) |
+| `DITTO_SHARED_KEY` | Shared key for formation security | - | No |
+| `DITTO_PERSISTENCE_DIR` | Directory for Ditto state | `./ditto_data` | No |
+
+#### General Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `RUST_LOG` | Log level configuration | `info` |
+| `HIVE_NODE_ID` | Unique node identifier | Auto-generated UUID |
+| `HIVE_CELL_SIZE` | Target cell size | `5` |
+| `HIVE_DISCOVERY_TIMEOUT` | Discovery phase timeout (seconds) | `30` |
+| `HIVE_LEADER_ELECTION_TIMEOUT` | Leader election timeout (seconds) | `10` |
+
+#### Network Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `HIVE_BIND_ADDRESS` | Address to bind for incoming connections | `0.0.0.0` |
+| `HIVE_BIND_PORT` | Port for P2P communication | `4040` |
+| `HIVE_HTTP_PORT` | Port for HTTP API | `8080` |
+| `HIVE_DISCOVERY_MODE` | Discovery mode: `mdns`, `static`, `hybrid` | `mdns` |
+
+### 4.2 Configuration File
+
+Create `hive.toml` for file-based configuration:
+
+```toml
+# hive.toml - HIVE Configuration
+
+[node]
+id = "node-001"                    # Optional: auto-generated if not set
+name = "Primary Sensor Node"
+platform_type = "UAV"
+
+[network]
+bind_address = "0.0.0.0"
+p2p_port = 4040
+http_port = 8080
+discovery_mode = "hybrid"          # mdns, static, or hybrid
+
+[discovery]
+timeout_seconds = 30
+mdns_enabled = true
+static_peers = [
+    "192.168.1.10:4040",
+    "192.168.1.11:4040",
+]
+
+[cell]
+target_size = 5
+leader_election_timeout = 10
+heartbeat_interval = 5
+
+[hierarchy]
+zone_size = 25
+aggregation_interval = 10
+
+[security]
+formation_key = "your-formation-key-here"  # Required for secure formation
+encryption_enabled = true
+tls_enabled = true
+
+[storage]
+backend = "ditto"                  # ditto or automerge
+persistence_dir = "/var/lib/hive/data"
+max_state_size_mb = 100
+
+[logging]
+level = "info"                     # trace, debug, info, warn, error
+format = "json"                    # json or pretty
+file = "/var/log/hive/hive.log"   # Optional: log to file
+
+[capabilities]
+# Define node capabilities
+[capabilities.sensor]
+type = "EO_IR"
+range_km = 10.0
+resolution = "4K"
+
+[capabilities.compute]
+type = "EDGE_ML"
+tflops = 5.2
+models = ["yolov8", "detection"]
+```
+
+### 4.3 Static Peer Configuration
+
+For environments without mDNS, configure static peers in `peers.toml`:
+
+```toml
+# peers.toml - Static peer configuration
+
+[[peers]]
+id = "node-alpha"
+address = "192.168.1.10"
+port = 4040
+role = "LEADER"
+
+[[peers]]
+id = "node-beta"
+address = "192.168.1.11"
+port = 4040
+role = "FOLLOWER"
+
+[[peers]]
+id = "node-gamma"
+address = "192.168.1.12"
+port = 4040
+role = "FOLLOWER"
+```
+
+### 4.4 Feature Flags
+
+Enable/disable features at compile time:
+
+| Feature | Description | Default |
+|---------|-------------|---------|
+| `ditto-backend` | Use Ditto CRDT backend | Enabled |
+| `automerge-backend` | Use Automerge/Iroh backend | Disabled |
+| `onnx-inference` | Enable ONNX ML inference | Disabled |
+| `video-capture` | Enable GStreamer video | Disabled |
+| `llm-inference` | Enable LLM via llama.cpp | Disabled |
+
+Build with specific features:
+```bash
+# Ditto only (default)
+cargo build --release
+
+# Automerge only
+cargo build --release --no-default-features --features automerge-backend
+
+# With ML inference
+cargo build --release --features onnx-inference
+```
+
+### 4.5 Logging Configuration
+
+#### Log Levels
+
+```bash
+# All debug logs
+RUST_LOG=debug cargo run --bin hive-sim
+
+# Specific module tracing
+RUST_LOG=hive_protocol::discovery=trace,hive_protocol::cell=debug cargo run
+
+# Production logging (info + warnings/errors)
+RUST_LOG=info cargo run --release
+```
+
+#### JSON Logging for Production
+
+Set `format = "json"` in configuration or:
+```bash
+HIVE_LOG_FORMAT=json cargo run --release
+```
+
+Output example:
+```json
+{"timestamp":"2025-12-08T10:30:00Z","level":"INFO","target":"hive_protocol::cell","message":"Cell formed","cell_id":"alpha","member_count":5}
+```
+
+---
+
+## 5. Deployment Patterns
+
+### 5.1 Development/Single-Node
+
+For development and testing on a single machine:
+
+```bash
+# Start the simulator with default configuration
+cargo run --release --bin hive-sim
+
+# Or with custom node count
+HIVE_NODE_COUNT=20 cargo run --release --bin hive-sim
+```
+
+### 5.2 Multi-Node Production
+
+Deploy across multiple machines for production testing:
+
+#### Node 1 (Seed Node)
+```bash
+# Set as discovery seed
+export HIVE_NODE_ID="seed-001"
+export HIVE_DISCOVERY_MODE="hybrid"
+export HIVE_BIND_ADDRESS="0.0.0.0"
+export HIVE_BIND_PORT="4040"
+
+./hive-sim --seed
+```
+
+#### Nodes 2-N (Joining Nodes)
+```bash
+export HIVE_NODE_ID="node-002"
+export HIVE_STATIC_PEERS="192.168.1.10:4040"
+
+./hive-sim
+```
+
+### 5.3 Edge Device Deployment
+
+For resource-constrained edge devices (Jetson, Raspberry Pi):
+
+```bash
+# Build with minimal features
+cargo build --release \
+    --no-default-features \
+    --features automerge-backend
+
+# Deploy binary
+scp target/release/hive-sim edge-device:/opt/hive/
+
+# Run with reduced resource usage
+ssh edge-device "cd /opt/hive && HIVE_CELL_SIZE=3 ./hive-sim"
+```
+
+### 5.4 Containerized Deployment
+
+#### Docker Compose Example
+
+```yaml
+# docker-compose.yml
+version: '3.8'
+
+services:
+  hive-seed:
+    image: hive-sim:latest
+    environment:
+      - HIVE_NODE_ID=seed-001
+      - HIVE_DISCOVERY_MODE=static
+      - RUST_LOG=info
+    ports:
+      - "4040:4040"
+      - "8080:8080"
+    volumes:
+      - hive-data-seed:/var/lib/hive
+    networks:
+      - hive-net
+
+  hive-node-1:
+    image: hive-sim:latest
+    environment:
+      - HIVE_NODE_ID=node-001
+      - HIVE_STATIC_PEERS=hive-seed:4040
+      - RUST_LOG=info
+    depends_on:
+      - hive-seed
+    volumes:
+      - hive-data-1:/var/lib/hive
+    networks:
+      - hive-net
+
+  hive-node-2:
+    image: hive-sim:latest
+    environment:
+      - HIVE_NODE_ID=node-002
+      - HIVE_STATIC_PEERS=hive-seed:4040
+      - RUST_LOG=info
+    depends_on:
+      - hive-seed
+    volumes:
+      - hive-data-2:/var/lib/hive
+    networks:
+      - hive-net
+
+volumes:
+  hive-data-seed:
+  hive-data-1:
+  hive-data-2:
+
+networks:
+  hive-net:
+    driver: bridge
+```
+
+Start the cluster:
+```bash
+docker-compose up -d
+docker-compose logs -f
+```
+
+### 5.5 Kubernetes Deployment
+
+```yaml
+# hive-deployment.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: hive-node
+spec:
+  serviceName: hive
+  replicas: 5
+  selector:
+    matchLabels:
+      app: hive
+  template:
+    metadata:
+      labels:
+        app: hive
+    spec:
+      containers:
+      - name: hive
+        image: hive-sim:latest
+        ports:
+        - containerPort: 4040
+          name: p2p
+        - containerPort: 8080
+          name: http
+        env:
+        - name: HIVE_NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: HIVE_DISCOVERY_MODE
+          value: "static"
+        - name: HIVE_STATIC_PEERS
+          value: "hive-node-0.hive:4040"
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/hive
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 10Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hive
+spec:
+  clusterIP: None
+  selector:
+    app: hive
+  ports:
+  - port: 4040
+    name: p2p
+  - port: 8080
+    name: http
+```
+
+---
+
+## 6. Network Configuration
+
+### 6.1 Port Requirements
+
+| Port | Protocol | Purpose | Direction |
+|------|----------|---------|-----------|
+| 4040 | UDP/TCP | P2P mesh communication | Bidirectional |
+| 8080 | TCP | HTTP API | Inbound |
+| 5353 | UDP | mDNS discovery | Multicast |
+
+### 6.2 Firewall Rules
+
+#### Linux (iptables)
+```bash
+# Allow P2P traffic
+sudo iptables -A INPUT -p tcp --dport 4040 -j ACCEPT
+sudo iptables -A INPUT -p udp --dport 4040 -j ACCEPT
+
+# Allow HTTP API
+sudo iptables -A INPUT -p tcp --dport 8080 -j ACCEPT
+
+# Allow mDNS (for discovery)
+sudo iptables -A INPUT -p udp --dport 5353 -j ACCEPT
+```
+
+#### Linux (firewalld)
+```bash
+sudo firewall-cmd --permanent --add-port=4040/tcp
+sudo firewall-cmd --permanent --add-port=4040/udp
+sudo firewall-cmd --permanent --add-port=8080/tcp
+sudo firewall-cmd --permanent --add-service=mdns
+sudo firewall-cmd --reload
+```
+
+### 6.3 NAT Traversal
+
+HIVE uses Iroh for NAT traversal when using the Automerge backend:
+
+```toml
+# hive.toml
+[network]
+nat_traversal = true
+relay_servers = [
+    "relay.example.com:3478",
+]
+stun_servers = [
+    "stun.l.google.com:19302",
+]
+```
+
+### 6.4 Bandwidth Considerations
+
+HIVE is designed for constrained networks:
+
+| Profile | Bandwidth | Use Case |
+|---------|-----------|----------|
+| `minimal` | 9.6 Kbps | Tactical radio |
+| `low` | 64 Kbps | Satellite link |
+| `medium` | 256 Kbps | Cellular backup |
+| `standard` | 1 Mbps | WiFi mesh |
+| `high` | 10+ Mbps | Ethernet/5G |
+
+Configure bandwidth limits:
+```toml
+[network]
+bandwidth_limit_kbps = 256
+qos_enabled = true
+```
+
+### 6.5 Network Partition Handling
+
+HIVE automatically handles network partitions:
+
+1. **Detection**: Heartbeat timeout (configurable, default 30s)
+2. **Recovery**: Exponential backoff reconnection (2s, 4s, 8s, 16s...)
+3. **Reconciliation**: CRDT automatic merge on reconnection
+
+Monitor partition status via HTTP API:
+```bash
+curl http://localhost:8080/api/v1/network/partitions
+```
+
+---
+
+## 7. Security
+
+### 7.1 Formation Key
+
+The formation key provides shared-secret authentication for cell formation:
+
+```bash
+# Generate a formation key
+openssl rand -base64 32
+# Example: K7j+3Zp8mN2xYtR5qW1vL9cF4hD6gB0nM8aE2sU7iO4=
+
+# Set in environment
+export HIVE_FORMATION_KEY="K7j+3Zp8mN2xYtR5qW1vL9cF4hD6gB0nM8aE2sU7iO4="
+```
+
+Or in configuration:
+```toml
+[security]
+formation_key = "K7j+3Zp8mN2xYtR5qW1vL9cF4hD6gB0nM8aE2sU7iO4="
+```
+
+### 7.2 PKI Configuration
+
+For production deployments with device certificates:
+
+```toml
+[security.pki]
+enabled = true
+ca_cert = "/etc/hive/certs/ca.crt"
+node_cert = "/etc/hive/certs/node.crt"
+node_key = "/etc/hive/certs/node.key"
+verify_peer = true
+```
+
+Generate certificates:
+```bash
+# Generate CA
+openssl genrsa -out ca.key 4096
+openssl req -new -x509 -days 365 -key ca.key -out ca.crt -subj "/CN=HIVE CA"
+
+# Generate node certificate
+openssl genrsa -out node.key 2048
+openssl req -new -key node.key -out node.csr -subj "/CN=hive-node-001"
+openssl x509 -req -days 365 -in node.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out node.crt
+```
+
+### 7.3 Encryption
+
+HIVE uses ChaCha20-Poly1305 for symmetric encryption:
+
+```toml
+[security]
+encryption_enabled = true
+encryption_algorithm = "chacha20-poly1305"
+```
+
+### 7.4 Authentication
+
+#### Device Authentication
+Devices authenticate using ED25519 signatures:
+```toml
+[security.device_auth]
+enabled = true
+key_file = "/etc/hive/device.key"
+```
+
+#### User Authentication (for HTTP API)
+```toml
+[security.user_auth]
+enabled = true
+method = "totp"  # or "password"
+password_hash_algorithm = "argon2"
+```
+
+### 7.5 Security Best Practices
+
+1. **Always use formation keys** in production
+2. **Enable TLS** for HTTP API endpoints
+3. **Rotate credentials** regularly
+4. **Use PKI** for device authentication in secure environments
+5. **Audit logs** for security events
+6. **Network segmentation** for HIVE traffic
+
+---
+
+## 8. Monitoring & Observability
+
+### 8.1 Health Checks
+
+#### HTTP Health Endpoint
+```bash
+# Liveness check
+curl http://localhost:8080/health
+# Response: {"status": "healthy", "uptime_seconds": 3600}
+
+# Readiness check
+curl http://localhost:8080/ready
+# Response: {"status": "ready", "cell_joined": true, "peers_connected": 4}
+```
+
+### 8.2 Metrics
+
+HIVE exposes Prometheus-compatible metrics:
+
+```bash
+curl http://localhost:8080/metrics
+```
+
+Key metrics:
+| Metric | Description |
+|--------|-------------|
+| `hive_peers_connected` | Number of connected peers |
+| `hive_cell_size` | Current cell membership count |
+| `hive_messages_sent_total` | Total messages sent |
+| `hive_messages_received_total` | Total messages received |
+| `hive_sync_latency_seconds` | CRDT sync latency histogram |
+| `hive_bandwidth_bytes_total` | Bandwidth usage |
+| `hive_leader_elections_total` | Leader election count |
+
+### 8.3 Logging
+
+#### Log Levels
+- `ERROR`: Critical failures requiring immediate attention
+- `WARN`: Degraded operation, potential issues
+- `INFO`: Normal operational events
+- `DEBUG`: Detailed diagnostic information
+- `TRACE`: Very detailed tracing (high volume)
+
+#### Structured Logging
+```bash
+# Enable JSON logging
+HIVE_LOG_FORMAT=json ./hive-sim
+
+# Example output
+{"timestamp":"2025-12-08T10:30:00.123Z","level":"INFO","target":"hive_protocol::cell","fields":{"cell_id":"alpha","event":"member_joined","node_id":"node-005"}}
+```
+
+### 8.4 Distributed Tracing
+
+Enable OpenTelemetry tracing:
+
+```toml
+[telemetry]
+tracing_enabled = true
+otlp_endpoint = "http://jaeger:4317"
+service_name = "hive-node"
+```
+
+### 8.5 Alerting Recommendations
+
+| Condition | Severity | Action |
+|-----------|----------|--------|
+| No peers connected for 5 min | Critical | Check network connectivity |
+| Leader election failed 3x | High | Investigate node health |
+| Sync latency > 10s | Medium | Check bandwidth constraints |
+| Partition detected | High | Monitor for recovery |
+| Memory usage > 80% | Medium | Consider scaling |
+
+---
+
+## 9. TAK/ATAK Integration
+
+### 9.1 Overview
+
+HIVE integrates with Team Awareness Kit (TAK) via Cursor-on-Target (CoT) protocol translation:
+
+```
+┌─────────┐      ┌───────────────┐      ┌──────────┐
+│  HIVE   │ ←──→ │ CoT Translator│ ←──→ │  ATAK    │
+│ Network │      │   (hive-cot)  │      │  Devices │
+└─────────┘      └───────────────┘      └──────────┘
+```
+
+### 9.2 ATAK Plugin Installation
+
+1. Download the HIVE ATAK plugin APK
+2. Install on Android device with ATAK
+3. Configure connection settings
+
+```
+Settings → Tool Preferences → HIVE
+- Server: 192.168.1.100
+- Port: 8087
+- Formation Key: [your-key]
+```
+
+### 9.3 CoT Configuration
+
+```toml
+[cot]
+enabled = true
+bind_address = "0.0.0.0"
+bind_port = 8087
+protocol = "tcp"  # tcp, udp, or multicast
+
+[cot.translation]
+# Map HIVE capabilities to CoT types
+platform_uav = "a-f-A-M-F-Q"      # UAV
+platform_ugv = "a-f-G-U-C"        # UGV
+platform_usv = "a-f-S-X-L"        # USV
+sensor_eo_ir = "b-m-p-s-m"        # Sensor point
+```
+
+### 9.4 CoT Message Examples
+
+HIVE automatically translates to CoT XML:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<event version="2.0" uid="HIVE-UAV-001" type="a-f-A-M-F-Q"
+       time="2025-12-08T10:30:00Z" start="2025-12-08T10:30:00Z"
+       stale="2025-12-08T10:35:00Z" how="m-g">
+  <point lat="38.8977" lon="-77.0365" hae="100" ce="10" le="10"/>
+  <detail>
+    <contact callsign="UAV-001"/>
+    <__group name="Alpha" role="Team Lead"/>
+    <hive:capability type="EO_IR" range="10000"/>
+  </detail>
+</event>
+```
+
+### 9.5 Bidirectional Integration
+
+HIVE receives commands from TAK/ATAK:
+- Position updates from ATAK users
+- Mission waypoints
+- Target designations
+- Chat messages
+
+Configure command reception:
+```toml
+[cot.commands]
+accept_waypoints = true
+accept_targets = true
+accept_chat = true
+command_authority = "C2_ONLY"  # or "ANY_TAK_USER"
+```
+
+---
+
+## 10. Backup & Recovery
+
+### 10.1 State Persistence
+
+HIVE persists state to disk for recovery:
+
+```toml
+[storage]
+persistence_dir = "/var/lib/hive/data"
+snapshot_interval_seconds = 60
+max_snapshots = 10
+```
+
+### 10.2 Backup Procedures
+
+#### Manual Backup
+```bash
+# Stop the node gracefully
+kill -SIGTERM $(pgrep hive-sim)
+
+# Backup state directory
+tar -czf hive-backup-$(date +%Y%m%d).tar.gz /var/lib/hive/data
+
+# Restart the node
+./hive-sim
+```
+
+#### Automated Backup
+```bash
+#!/bin/bash
+# /etc/cron.daily/hive-backup
+BACKUP_DIR=/var/backups/hive
+mkdir -p $BACKUP_DIR
+tar -czf $BACKUP_DIR/hive-$(date +%Y%m%d%H%M).tar.gz /var/lib/hive/data
+# Keep last 7 days
+find $BACKUP_DIR -name "hive-*.tar.gz" -mtime +7 -delete
+```
+
+### 10.3 Recovery Procedures
+
+#### From Backup
+```bash
+# Stop the node
+kill -SIGTERM $(pgrep hive-sim)
+
+# Restore state
+rm -rf /var/lib/hive/data/*
+tar -xzf hive-backup-20251208.tar.gz -C /
+
+# Restart
+./hive-sim
+```
+
+#### From Clean State
+```bash
+# Remove corrupted state
+rm -rf /var/lib/hive/data/*
+
+# Node will rejoin network and sync state from peers
+./hive-sim
+```
+
+### 10.4 Disaster Recovery
+
+In case of complete node loss:
+1. Deploy new node with same configuration
+2. Use same formation key
+3. Node will automatically rejoin and sync
+4. CRDT guarantees eventual consistency
+
+---
+
+## 11. Troubleshooting
+
+### 11.1 Common Issues
+
+#### Issue: Node Not Discovering Peers
+
+**Symptoms**: Node starts but shows 0 peers connected
+
+**Diagnosis**:
+```bash
+# Check mDNS
+avahi-browse -a
+
+# Check network connectivity
+ping other-node-ip
+
+# Check ports
+netstat -tuln | grep 4040
+```
+
+**Solutions**:
+1. Verify firewall allows port 4040
+2. Check mDNS is enabled on network
+3. Use static peer configuration if mDNS unavailable
+4. Verify formation keys match across nodes
+
+#### Issue: Leader Election Failing
+
+**Symptoms**: Repeated "leader election timeout" messages
+
+**Diagnosis**:
+```bash
+# Check node clocks
+date
+ntpq -p
+
+# Check network latency
+ping -c 10 peer-node
+```
+
+**Solutions**:
+1. Synchronize clocks across nodes (NTP)
+2. Increase `leader_election_timeout`
+3. Reduce cell size in high-latency environments
+4. Check for network partitions
+
+#### Issue: High Memory Usage
+
+**Symptoms**: Node consuming excessive RAM
+
+**Diagnosis**:
+```bash
+# Check process memory
+ps aux | grep hive
+top -p $(pgrep hive-sim)
+
+# Check state size
+du -sh /var/lib/hive/data/
+```
+
+**Solutions**:
+1. Enable state pruning with TTL
+2. Reduce `max_state_size_mb`
+3. Check for runaway capability updates
+4. Restart node to clear accumulated state
+
+#### Issue: Sync Latency High
+
+**Symptoms**: Updates taking > 5 seconds to propagate
+
+**Diagnosis**:
+```bash
+# Check bandwidth
+iperf3 -c peer-node
+
+# Check metrics
+curl localhost:8080/metrics | grep sync_latency
+```
+
+**Solutions**:
+1. Enable QoS prioritization
+2. Reduce update frequency
+3. Increase bandwidth allocation
+4. Check for network congestion
+
+#### Issue: Ditto SDK Errors
+
+**Symptoms**: "Ditto authentication failed" or similar errors
+
+**Diagnosis**:
+```bash
+# Verify credentials
+echo $DITTO_APP_ID
+echo $DITTO_OFFLINE_TOKEN
+
+# Check Ditto data directory
+ls -la ./ditto_data/
+```
+
+**Solutions**:
+1. Verify `DITTO_APP_ID` and `DITTO_OFFLINE_TOKEN` are set
+2. Clear Ditto persistence directory and restart
+3. Check Ditto license validity
+4. Use Automerge backend if Ditto unavailable
+
+### 11.2 Diagnostic Commands
+
+```bash
+# System information
+uname -a
+cat /etc/os-release
+
+# Network diagnostics
+ip addr
+netstat -tuln
+ss -tuln
+
+# Process information
+ps aux | grep hive
+lsof -p $(pgrep hive-sim)
+
+# Log analysis
+journalctl -u hive -f
+tail -f /var/log/hive/hive.log | jq .
+
+# API health
+curl -s localhost:8080/health | jq .
+curl -s localhost:8080/api/v1/status | jq .
+```
+
+### 11.3 Debug Mode
+
+Enable verbose logging for debugging:
+
+```bash
+RUST_LOG=trace RUST_BACKTRACE=1 ./hive-sim 2>&1 | tee debug.log
+```
+
+### 11.4 Support Escalation
+
+If issues persist:
+
+1. Collect diagnostic information:
+   ```bash
+   # Create support bundle
+   ./scripts/create-support-bundle.sh
+   ```
+
+2. Include:
+   - HIVE version (`cargo --version`, git commit)
+   - Configuration (sanitized, no keys)
+   - Logs from issue timeframe
+   - Network topology diagram
+   - Steps to reproduce
+
+3. Open GitHub issue with collected information
+
+---
+
+## 12. Reference
+
+### 12.1 CLI Reference
+
+```bash
+# hive-sim options
+hive-sim [OPTIONS]
+
+OPTIONS:
+    --config <FILE>          Configuration file path
+    --seed                   Run as discovery seed node
+    --node-id <ID>           Node identifier
+    --bind <ADDR>            Bind address [default: 0.0.0.0]
+    --port <PORT>            P2P port [default: 4040]
+    --http-port <PORT>       HTTP API port [default: 8080]
+    --peers <PEERS>          Static peer list (comma-separated)
+    --log-level <LEVEL>      Log level [default: info]
+    --help                   Print help information
+    --version                Print version information
+```
+
+### 12.2 HTTP API Reference
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/health` | GET | Health check |
+| `/ready` | GET | Readiness check |
+| `/metrics` | GET | Prometheus metrics |
+| `/api/v1/status` | GET | Node status |
+| `/api/v1/peers` | GET | Connected peers |
+| `/api/v1/cell` | GET | Cell information |
+| `/api/v1/capabilities` | GET | Node capabilities |
+| `/api/v1/network/partitions` | GET | Partition status |
+
+### 12.3 Makefile Targets
+
+```bash
+make help              # Show all targets
+make build             # Build all crates
+make test              # Run all tests
+make test-fast         # Run unit tests only
+make test-e2e          # Run E2E tests
+make check             # Format + lint + test
+make clean             # Clean build artifacts
+make pre-commit        # Pre-commit checks
+```
+
+### 12.4 Related Documentation
+
+- [Developer Guide](../developer/DEVELOPER_GUIDE.md) - For code contributors
+- [Architecture Decisions](../../adr/) - Technical decision rationale
+- [Testing Strategy](../../TESTING_STRATEGY.md) - Testing approach
+- [Protobuf Schema](../../spec/proto/) - Protocol definitions
+
+---
+
+## Appendix A: Quick Reference Card
+
+### Essential Commands
+
+```bash
+# Build
+cargo build --release
+
+# Run
+cargo run --release --bin hive-sim
+
+# Test
+make test-fast
+
+# Logs
+RUST_LOG=debug ./hive-sim
+
+# Health check
+curl localhost:8080/health
+```
+
+### Essential Configuration
+
+```bash
+# Minimum environment
+export DITTO_APP_ID="your-app-id"
+export DITTO_OFFLINE_TOKEN="your-token"
+export HIVE_FORMATION_KEY="your-formation-key"
+```
+
+### Essential Ports
+
+| Port | Purpose |
+|------|---------|
+| 4040 | P2P |
+| 8080 | HTTP API |
+| 5353 | mDNS |
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: 2025-12-08
+**Maintainer**: HIVE Operations Team


### PR DESCRIPTION
This commit introduces production-grade documentation for two primary personas:

## Operator Guide (docs/guides/operator/OPERATOR_GUIDE.md)
- Installation procedures and prerequisites
- Configuration reference (env vars, config files, feature flags)
- Deployment patterns (single-node, multi-node, edge, containerized, K8s)
- Network configuration (ports, firewall, NAT traversal, bandwidth)
- Security setup (formation keys, PKI, encryption)
- Monitoring and observability (metrics, logging, health checks)
- TAK/ATAK integration guide
- Backup and recovery procedures
- Comprehensive troubleshooting runbook

## Developer Guide (docs/guides/developer/DEVELOPER_GUIDE.md)
- Architecture overview with diagrams
- Getting started and dev environment setup
- Core concepts (nodes, cells, zones, capabilities, composition)
- Complete crate reference
- API reference with examples
- Extension patterns (custom capabilities, discovery, composition rules)
- Testing guide (unit, integration, E2E)
- Backend abstraction (Ditto vs Automerge)
- Mobile development (hive-ffi, Android)
- Edge AI integration (hive-inference)
- Contributing guidelines

## Supporting Documents
- DOCUMENTATION_PLAN.md: Requirements, standards, and implementation phases
- DOCUMENTATION_ISSUES.md: GitHub issue templates for tracking work
- Updated INDEX.md with guide navigation and quick links

Total: ~3,700 lines of professional technical documentation