### PR TITLE
feat(schema): Add vignette message schemas (#284, #285, #286)

### DIFF
--- a/hive-schema/build.rs
+++ b/hive-schema/build.rs
@@ -13,6 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/hierarchy.proto",
         "proto/command.proto",
         "proto/security.proto",
+        "proto/track.proto",
     ];
 
     // Configure prost to generate Rust code from .proto files

--- a/hive-schema/proto/capability.proto
+++ b/hive-schema/proto/capability.proto
@@ -59,3 +59,61 @@ message CapabilityResponse {
   // Total count of capabilities
   uint32 total_count = 2;
 }
+
+// ============================================================================
+// Capability Advertisement (Upward Flow)
+// ============================================================================
+
+// Capability advertisement message - flows upward from platforms
+//
+// Platforms periodically advertise their capabilities, allowing the hierarchy
+// to maintain an up-to-date view of available resources. This is a generic
+// advertisement that can include any capability type (sensors, compute, AI
+// models, mobility, etc.)
+message CapabilityAdvertisement {
+  // Platform identifier (e.g., "Alpha-3", "UAV-001")
+  string platform_id = 1;
+
+  // Timestamp of advertisement
+  common.v1.Timestamp advertised_at = 2;
+
+  // List of capabilities available on this platform
+  repeated Capability capabilities = 3;
+
+  // Current resource utilization (optional)
+  ResourceStatus resources = 4;
+
+  // Platform operational status
+  OperationalStatus operational_status = 5;
+}
+
+// Operational status of a platform
+enum OperationalStatus {
+  OPERATIONAL_STATUS_UNSPECIFIED = 0;
+  OPERATIONAL_STATUS_READY = 1;      // Ready to accept tasking
+  OPERATIONAL_STATUS_ACTIVE = 2;     // Currently executing task
+  OPERATIONAL_STATUS_DEGRADED = 3;   // Operating with reduced capability
+  OPERATIONAL_STATUS_OFFLINE = 4;    // Not available
+  OPERATIONAL_STATUS_MAINTENANCE = 5; // Under maintenance
+}
+
+// Resource utilization status
+message ResourceStatus {
+  // Compute utilization (0.0 - 1.0)
+  float compute_utilization = 1;
+
+  // Memory utilization (0.0 - 1.0)
+  float memory_utilization = 2;
+
+  // Power/battery level (0.0 - 1.0)
+  float power_level = 3;
+
+  // Storage utilization (0.0 - 1.0)
+  float storage_utilization = 4;
+
+  // Bandwidth utilization (0.0 - 1.0)
+  float bandwidth_utilization = 5;
+
+  // Additional resource metrics (JSON-encoded for extensibility)
+  string extra_json = 10;
+}

--- a/hive-schema/proto/track.proto
+++ b/hive-schema/proto/track.proto
@@ -1,0 +1,198 @@
+// Track definitions for CAP Protocol
+// Version: 1.0.0
+//
+// Tracks represent observed entities in the environment (ISR products).
+// These are the outputs of sensors, AI models, and human observers.
+// Tracks flow upward through the hierarchy for aggregation and fusion.
+
+syntax = "proto3";
+
+package cap.track.v1;
+
+import "common.proto";
+
+// ============================================================================
+// Track (ISR Product)
+// ============================================================================
+
+// Track represents an observed entity in the environment
+//
+// This is a generic ISR product that can represent anything being tracked:
+// persons, vehicles, aircraft, vessels, etc. The source can be any sensor,
+// AI model, or human observer.
+message Track {
+  // Unique track identifier (e.g., "TRK-001")
+  string track_id = 1;
+
+  // Classification of the tracked entity
+  string classification = 2;
+
+  // Confidence in the classification (0.0 - 1.0)
+  float confidence = 3;
+
+  // Current position estimate
+  TrackPosition position = 4;
+
+  // Velocity estimate (optional)
+  Velocity velocity = 5;
+
+  // Track state
+  TrackState state = 6;
+
+  // Source information
+  TrackSource source = 7;
+
+  // Additional attributes (JSON-encoded for extensibility)
+  // e.g., {"color": "red", "size": "large", "armed": true}
+  string attributes_json = 8;
+
+  // First observation timestamp
+  common.v1.Timestamp first_seen = 9;
+
+  // Most recent observation timestamp
+  common.v1.Timestamp last_seen = 10;
+
+  // Number of observations contributing to this track
+  uint32 observation_count = 11;
+}
+
+// Track position with uncertainty
+message TrackPosition {
+  // Latitude in degrees
+  double latitude = 1;
+
+  // Longitude in degrees
+  double longitude = 2;
+
+  // Altitude/elevation in meters (optional)
+  float altitude = 3;
+
+  // Circular Error Probable in meters (horizontal accuracy)
+  float cep_m = 4;
+
+  // Vertical error in meters (optional)
+  float vertical_error_m = 5;
+}
+
+// Velocity vector
+message Velocity {
+  // Bearing/heading in degrees (0-360, 0 = North)
+  float bearing = 1;
+
+  // Speed in meters per second
+  float speed_mps = 2;
+
+  // Vertical speed in m/s (positive = ascending)
+  float vertical_speed_mps = 3;
+}
+
+// Track state
+enum TrackState {
+  TRACK_STATE_UNSPECIFIED = 0;
+  TRACK_STATE_TENTATIVE = 1;    // New track, not yet confirmed
+  TRACK_STATE_CONFIRMED = 2;    // Track confirmed with multiple observations
+  TRACK_STATE_LOST = 3;         // Track lost (no recent observations)
+  TRACK_STATE_DROPPED = 4;      // Track dropped (stale, no longer tracked)
+}
+
+// Track source information
+message TrackSource {
+  // Platform that produced this track
+  string platform_id = 1;
+
+  // Sensor or capability that detected the entity
+  string sensor_id = 2;
+
+  // Model/algorithm version (for AI sources)
+  string model_version = 3;
+
+  // Source type
+  SourceType source_type = 4;
+}
+
+// Type of track source
+enum SourceType {
+  SOURCE_TYPE_UNSPECIFIED = 0;
+  SOURCE_TYPE_SENSOR = 1;       // Raw sensor (radar, camera, etc.)
+  SOURCE_TYPE_AI_MODEL = 2;     // AI/ML model processing
+  SOURCE_TYPE_HUMAN = 3;        // Human observer
+  SOURCE_TYPE_FUSED = 4;        // Fused from multiple sources
+}
+
+// ============================================================================
+// Track Update (Upward Flow Message)
+// ============================================================================
+
+// Track update message - flows upward from platforms
+//
+// Used to report new tracks, update existing tracks, or report track drops.
+// This is the primary ISR product message.
+message TrackUpdate {
+  // Update type
+  UpdateType update_type = 1;
+
+  // The track being reported/updated
+  Track track = 2;
+
+  // Previous track ID (for track merges)
+  string previous_track_id = 3;
+
+  // Timestamp of this update
+  common.v1.Timestamp timestamp = 4;
+}
+
+// Type of track update
+enum UpdateType {
+  UPDATE_TYPE_UNSPECIFIED = 0;
+  UPDATE_TYPE_NEW = 1;          // New track detected
+  UPDATE_TYPE_UPDATE = 2;       // Existing track updated
+  UPDATE_TYPE_DROP = 3;         // Track dropped
+  UPDATE_TYPE_MERGE = 4;        // Tracks merged (previous_track_id -> track_id)
+  UPDATE_TYPE_SPLIT = 5;        // Track split (track_id spawned from previous_track_id)
+}
+
+// ============================================================================
+// Track Query
+// ============================================================================
+
+// Query for tracks
+message TrackQuery {
+  // Filter by classification
+  repeated string classifications = 1;
+
+  // Filter by minimum confidence
+  float min_confidence = 2;
+
+  // Filter by geographic area (bounding box)
+  BoundingBox area = 3;
+
+  // Filter by state
+  repeated TrackState states = 4;
+
+  // Filter by source platform
+  repeated string source_platforms = 5;
+
+  // Maximum age in seconds (tracks older than this are excluded)
+  uint32 max_age_seconds = 6;
+}
+
+// Geographic bounding box
+message BoundingBox {
+  // Southwest corner
+  common.v1.Position southwest = 1;
+
+  // Northeast corner
+  common.v1.Position northeast = 2;
+}
+
+// Track query response
+message TrackResponse {
+  // Matching tracks
+  repeated Track tracks = 1;
+
+  // Total count
+  uint32 total_count = 2;
+
+  // Query timestamp
+  common.v1.Timestamp as_of = 3;
+}

--- a/hive-schema/src/lib.rs
+++ b/hive-schema/src/lib.rs
@@ -119,6 +119,12 @@ pub mod cap {
             include!(concat!(env!("OUT_DIR"), "/cap.security.v1.rs"));
         }
     }
+
+    pub mod track {
+        pub mod v1 {
+            include!(concat!(env!("OUT_DIR"), "/cap.track.v1.rs"));
+        }
+    }
 }
 
 // Re-export for convenience
@@ -155,5 +161,74 @@ mod tests {
         // If we got here, all packages are accessible
         assert_eq!(CapabilityType::Sensor as i32, 1);
         assert_eq!(Phase::Discovery as i32, 1);
+    }
+
+    #[test]
+    fn test_capability_advertisement_accessible() {
+        // Verify CapabilityAdvertisement is accessible from capability.v1
+        use capability::v1::{CapabilityAdvertisement, OperationalStatus, ResourceStatus};
+
+        let _cap_ad = CapabilityAdvertisement {
+            platform_id: "Alpha-3".to_string(),
+            advertised_at: None,
+            capabilities: vec![],
+            resources: None,
+            operational_status: OperationalStatus::Ready as i32,
+        };
+
+        let _resources = ResourceStatus {
+            compute_utilization: 0.5,
+            memory_utilization: 0.3,
+            power_level: 0.9,
+            storage_utilization: 0.2,
+            bandwidth_utilization: 0.1,
+            extra_json: String::new(),
+        };
+
+        assert_eq!(OperationalStatus::Ready as i32, 1);
+    }
+
+    #[test]
+    fn test_track_types_accessible() {
+        // Verify Track types are accessible from track.v1
+        use track::v1::{
+            SourceType, Track, TrackPosition, TrackSource, TrackState, TrackUpdate, UpdateType,
+        };
+
+        let _track = Track {
+            track_id: "TRK-001".to_string(),
+            classification: "person".to_string(),
+            confidence: 0.95,
+            position: Some(TrackPosition {
+                latitude: 38.0,
+                longitude: -122.0,
+                altitude: 0.0,
+                cep_m: 5.0,
+                vertical_error_m: 0.0,
+            }),
+            velocity: None,
+            state: TrackState::Confirmed as i32,
+            source: Some(TrackSource {
+                platform_id: "Alpha-3".to_string(),
+                sensor_id: "camera-1".to_string(),
+                model_version: "1.0.0".to_string(),
+                source_type: SourceType::AiModel as i32,
+            }),
+            attributes_json: r#"{"color":"red"}"#.to_string(),
+            first_seen: None,
+            last_seen: None,
+            observation_count: 5,
+        };
+
+        let _update = TrackUpdate {
+            update_type: UpdateType::New as i32,
+            track: Some(_track),
+            previous_track_id: String::new(),
+            timestamp: None,
+        };
+
+        assert_eq!(TrackState::Confirmed as i32, 2);
+        assert_eq!(SourceType::AiModel as i32, 2);
+        assert_eq!(UpdateType::New as i32, 1);
     }
 }


### PR DESCRIPTION
## Summary

Adds **generic protocol primitives** to `hive-schema` for capability advertisement and track reporting.

### ⚠️ Revised Approach

This PR was revised from vignette-specific schemas to **generic primitives** based on feedback:

> "There should only be a generic 'Capability' advertisement schema... these are primitives that we need to define carefully so that they can be utilized or extended by various application implementations."

## Changes

### Extended `capability.proto`
- `CapabilityAdvertisement` - Platform advertising its capabilities
- `OperationalStatus` - Platform operational status enum
- `ResourceStatus` - Resource utilization metrics

### New `track.proto`
- `Track` - Generic ISR product (observed entity)
- `TrackUpdate` - Track update message for upward flow
- `TrackPosition`, `Velocity` - Position and motion
- `TrackSource` - Source attribution (sensor, AI, human, fused)
- `TrackState` - Track lifecycle management
- `TrackQuery`/`TrackResponse` - Query interface

### Removed
- `vignette.proto` - Was too use-case-specific
- `MissionTask` - Redundant with existing `command.proto::HierarchicalCommand`

## Design Principles

| Principle | Application |
|-----------|-------------|
| Generic over specific | Schemas work for any application |
| Extend existing | `CapabilityAdvertisement` extends `capability.proto` |
| Don't duplicate | Use existing `command.proto` for tasking |
| Metadata for specialization | AI-specific fields go in `metadata_json` |

## For AI Team (Issue #308)

Use `Capability` with `type=COMPUTE` for AI models. Put AI-specific fields in `metadata_json`:
- Model hash, version, type
- Performance metrics (precision, recall, fps)
- Framework, quantization

## Test plan

- [x] Proto compiles successfully
- [x] All hive-schema tests pass (14 tests)
- [x] `capability::v1::CapabilityAdvertisement` accessible
- [x] `track::v1::Track` and `TrackUpdate` accessible
- [x] Pre-commit checks pass

Closes #284, #285, #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)