### PR TITLE
feat(tak-bridge): Add HIVE-TAK Bridge service (#311)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2675,6 +2675,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hive-tak-bridge"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "clap",
+ "hex",
+ "hive-protocol",
+ "hive-transport",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "hive-transport"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "hive-ffi",
     "hive-commander",
     "hive-inference",
+    "hive-tak-bridge",
 ]
 
 [workspace.package]

--- a/docs/contracts/CONTRACT_CORE_ATAK_TAK_BRIDGE.md
+++ b/docs/contracts/CONTRACT_CORE_ATAK_TAK_BRIDGE.md
@@ -236,6 +236,146 @@ This contract defines the bidirectional interface between the Core protocol and 
 
 ---
 
+## Interface 3: Capability Advertisement (HIVE → CoT)
+
+### HIVE Schema: CapabilityAdvertisement (from capability.proto)
+
+```protobuf
+message CapabilityAdvertisement {
+  string platform_id = 1;                    // "Alpha-3"
+  Timestamp advertised_at = 2;               // Unix timestamp
+  repeated Capability capabilities = 3;      // List of capabilities
+  ResourceStatus resources = 4;              // Optional resource utilization
+  OperationalStatus operational_status = 5;  // READY, ACTIVE, DEGRADED, etc.
+}
+
+message Capability {
+  string id = 1;                    // "object_tracker"
+  string name = 2;                  // "Object Tracker Model"
+  CapabilityType capability_type = 3;  // COMPUTE, SENSOR, etc.
+  float confidence = 4;             // 0.0-1.0
+  string metadata_json = 5;         // AI model details
+}
+```
+
+### CoT Mapping: Platform Registration
+
+| HIVE Field | CoT Element/Attribute | Notes |
+|------------|----------------------|-------|
+| `platform_id` | `event@uid` | Direct mapping |
+| N/A | `event@type` | `a-f-G-U-C` (friendly ground unit, combat) |
+| `advertised_at` | `event@time`, `event@start` | ISO 8601 |
+| N/A | `event@stale` | `advertised_at + 60 seconds` (heartbeat) |
+| N/A | `event@how` | `m-g` (machine-generated) |
+| `operational_status` | `detail/status@readiness` | See status mapping |
+| `capabilities[].name` | `detail/remarks` | Comma-separated list |
+| `resources.compute_utilization` | `detail/_hive_@cpu` | Percentage (×100) |
+| `resources.memory_utilization` | `detail/_hive_@mem` | Percentage (×100) |
+| `resources.power_level` | `detail/_hive_@battery` | Percentage (×100) |
+| `capabilities[].metadata_json` | `detail/_hive_@models` | JSON array of model info |
+
+### Operational Status → CoT Mapping
+
+| HIVE OperationalStatus | CoT status@readiness | Description |
+|------------------------|---------------------|-------------|
+| `READY` | `true` | Platform ready for tasking |
+| `ACTIVE` | `true` | Platform executing task |
+| `DEGRADED` | `partial` | Reduced capability |
+| `OFFLINE` | `false` | Not available |
+| `MAINTENANCE` | `false` | Under maintenance |
+
+### Example Transformation
+
+**HIVE Input (CapabilityAdvertisement):**
+```json
+{
+  "platform_id": "Alpha-3",
+  "advertised_at": { "seconds": 1733670600, "nanos": 0 },
+  "capabilities": [
+    {
+      "id": "object_tracker",
+      "name": "Object Tracker v1.2",
+      "capability_type": "COMPUTE",
+      "confidence": 0.95,
+      "metadata_json": "{\"model_type\":\"detector_tracker\",\"fps\":15}"
+    }
+  ],
+  "resources": {
+    "compute_utilization": 0.65,
+    "memory_utilization": 0.50,
+    "power_level": 0.90
+  },
+  "operational_status": "READY"
+}
+```
+
+**CoT Output (Platform Registration):**
+```xml
+<event uid="Alpha-3" type="a-f-G-U-C" time="2025-12-08T14:30:00Z"
+       start="2025-12-08T14:30:00Z" stale="2025-12-08T14:31:00Z" how="m-g">
+  <point lat="0" lon="0" hae="0" ce="9999999" le="9999999"/>
+  <detail>
+    <status readiness="true"/>
+    <remarks>Capabilities: Object Tracker v1.2 (95%)</remarks>
+    <_hive_ cpu="65" mem="50" battery="90"
+            models="[{\"id\":\"object_tracker\",\"type\":\"detector_tracker\",\"fps\":15}]"/>
+  </detail>
+</event>
+```
+
+*Note: Position is placeholder (0,0) until actual GPS fix. Platform position comes from separate TrackUpdate or SA message.*
+
+---
+
+## Interface 4: Protobuf ↔ JSON Field Reference
+
+For implementation, here are the exact protobuf field mappings:
+
+### TrackUpdate (track.proto) → JSON
+
+| Protobuf Field | JSON Path | Type |
+|----------------|-----------|------|
+| `track.track_id` | `track_id` | string |
+| `track.classification` | `classification` | string |
+| `track.confidence` | `confidence` | float |
+| `track.position.latitude` | `position.lat` | double |
+| `track.position.longitude` | `position.lon` | double |
+| `track.position.altitude` | `position.hae` | float |
+| `track.position.cep_m` | `position.cep_m` | float |
+| `track.velocity.bearing` | `velocity.bearing` | float |
+| `track.velocity.speed_mps` | `velocity.speed_mps` | float |
+| `track.source.platform_id` | `source_platform` | string |
+| `track.source.sensor_id` | `source_model` | string |
+| `track.source.model_version` | `model_version` | string |
+| `track.attributes_json` | `attributes` | object (parsed) |
+| `timestamp.seconds` | `timestamp` | ISO 8601 |
+| `update_type` | N/A | Internal use |
+
+### HierarchicalCommand (command.proto) ← CoT Mission
+
+| CoT Element | Protobuf Field | Notes |
+|-------------|----------------|-------|
+| `event@uid` | `command_id` | Direct mapping |
+| `event@time` | `issued_at.seconds` | Parse ISO 8601 |
+| `event@stale` | `expires_at.seconds` | Parse ISO 8601 |
+| `detail/mission@type` | `mission_order.mission_type` | See enum mapping |
+| `detail/target@description` | `mission_order.description` | Target description |
+| `point@lat` | `mission_order.objective_location.latitude` | Target position |
+| `point@lon` | `mission_order.objective_location.longitude` | Target position |
+| N/A | `originator_id` | Set to TAK Server UID |
+| N/A | `target.scope` | Default to SQUAD |
+
+### Mission Type Mapping
+
+| CoT mission@type | HierarchicalCommand MissionType |
+|------------------|--------------------------------|
+| `TRACK_TARGET` | `ISR` (1) |
+| `SEARCH_AREA` | `ISR` (1) |
+| `MONITOR_ZONE` | `DEFENSIVE` (5) |
+| `ABORT` | N/A (cancel command) |
+
+---
+
 ## Core Team Responsibilities
 
 - [ ] Define HIVE schemas (TrackUpdate, MissionTask, etc.)

--- a/hive-tak-bridge/Cargo.toml
+++ b/hive-tak-bridge/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "hive-tak-bridge"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "HIVE-TAK Bridge service - connects HIVE mesh to TAK Server"
+
+[[bin]]
+name = "hive-tak-bridge"
+path = "src/main.rs"
+
+[dependencies]
+# Workspace crates
+hive-protocol = { path = "../hive-protocol", default-features = false, features = ["automerge-backend"] }
+hive-transport = { path = "../hive-transport" }
+
+# Async runtime
+tokio = { workspace = true }
+async-trait = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Utilities
+uuid = { workspace = true }
+thiserror = { workspace = true }
+anyhow = { workspace = true }
+chrono = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
+# Encoding
+hex = "0.4"

--- a/hive-tak-bridge/docker-compose.yaml
+++ b/hive-tak-bridge/docker-compose.yaml
@@ -1,0 +1,49 @@
+# HIVE-TAK Bridge Testing Environment
+# Spins up FreeTAKServer + UI for integration testing
+#
+# Usage:
+#   docker compose up -d        # Start FreeTAKServer + UI
+#   cargo run --package hive-tak-bridge -- --demo --verbose
+#   docker compose down         # Stop all
+#
+# Access:
+#   - WebTAK UI: http://localhost:5000
+#   - REST API: http://localhost:19023
+
+services:
+  freetakserver:
+    image: ghcr.io/freetakteam/freetakserver:latest
+    container_name: freetakserver
+    restart: unless-stopped
+    ports:
+      - "8080:8080"   # FTS Web
+      - "8087:8087"   # CoT TCP (plain)
+      - "8089:8089"   # CoT SSL
+      - "8443:8443"   # Web SSL
+      - "19023:19023" # REST API
+    environment:
+      FTS_DP_ADDRESS: "0.0.0.0"
+      FTS_COT_PORT: "8087"
+      FTS_SSLCOT_PORT: "8089"
+      FTS_SAVE_COT_TO_DB: "True"
+    volumes:
+      - fts_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  ui:
+    image: ghcr.io/freetakteam/ui:latest
+    container_name: freetakserver-ui
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      FTS_IP: "127.0.0.1"
+      FTS_API_PORT: "19023"
+      FTS_COT_PORT: "8087"
+
+volumes:
+  fts_data:

--- a/hive-tak-bridge/src/main.rs
+++ b/hive-tak-bridge/src/main.rs
@@ -1,0 +1,505 @@
+//! HIVE-TAK Bridge Service
+//!
+//! Connects HIVE mesh network to TAK Server for C2 visibility.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! HIVE Mesh (Automerge/Iroh)
+//!     │
+//!     │ Document subscriptions
+//!     ▼
+//! HiveTakBridge (filtering, aggregation, encoding)
+//!     │
+//!     │ CoT/TCP
+//!     ▼
+//! TAK Server (FreeTAKServer / official)
+//!     │
+//!     ▼
+//! WebTAK / ATAK (C2 visibility)
+//! ```
+
+use anyhow::Result;
+use clap::Parser;
+use hive_protocol::cot::{
+    types::CapabilityInfo, CapabilityAdvertisement, OperationalStatus, Position, TrackUpdate,
+};
+use hive_protocol::network::IrohTransport;
+use hive_protocol::storage::{AutomergeBackend, AutomergeStore, StorageBackend};
+use hive_transport::tak::bridge::{BridgeConfig, HiveMessage, HiveTakBridge, PublishResult};
+use hive_transport::tak::server::TakServerTransport;
+use hive_transport::tak::{TakProtocolVersion, TakTransport, TakTransportConfig, TakTransportMode};
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tracing::{debug, error, info, warn};
+
+/// HIVE-TAK Bridge Service
+///
+/// Bridges HIVE mesh network to TAK Server for C2 visibility.
+#[derive(Parser, Debug)]
+#[command(name = "hive-tak-bridge")]
+#[command(about = "HIVE-TAK Bridge - connects HIVE mesh to TAK Server")]
+struct Args {
+    /// TAK Server address (host:port)
+    #[arg(long, env = "TAK_SERVER", default_value = "127.0.0.1:8087")]
+    tak_server: SocketAddr,
+
+    /// Use TLS for TAK Server connection
+    #[arg(long, env = "TAK_USE_TLS", default_value = "false")]
+    tak_use_tls: bool,
+
+    /// Path to client certificate (PEM format) for TAK Server TLS
+    #[arg(long, env = "TAK_CLIENT_CERT")]
+    tak_client_cert: Option<PathBuf>,
+
+    /// Path to client private key (PEM format) for TAK Server TLS
+    #[arg(long, env = "TAK_CLIENT_KEY")]
+    tak_client_key: Option<PathBuf>,
+
+    /// Path to CA certificate (PEM format) for TAK Server TLS
+    #[arg(long, env = "TAK_CA_CERT")]
+    tak_ca_cert: Option<PathBuf>,
+
+    /// TAK protocol version: raw (FreeTAKServer), xml (legacy), protobuf (official TAK Server)
+    #[arg(long, env = "TAK_PROTOCOL", default_value = "raw")]
+    tak_protocol: String,
+
+    /// Bridge callsign (shown in TAK)
+    #[arg(long, env = "BRIDGE_CALLSIGN", default_value = "HIVE-BRIDGE")]
+    callsign: String,
+
+    /// HIVE app ID for mesh authentication
+    #[arg(long, env = "HIVE_APP_ID", default_value = "hive-demo")]
+    hive_app_id: String,
+
+    /// HIVE shared key (base64) - required for mesh authentication
+    #[arg(long, env = "HIVE_SHARED_KEY")]
+    hive_shared_key: Option<String>,
+
+    /// HIVE storage path for Automerge documents
+    #[arg(long, env = "HIVE_STORAGE", default_value = "/tmp/hive-bridge")]
+    hive_storage: PathBuf,
+
+    /// HIVE peer to connect to (format: node_id@address)
+    #[arg(long, env = "HIVE_PEER")]
+    hive_peer: Vec<String>,
+
+    /// Document collections to subscribe to (comma-separated)
+    #[arg(long, default_value = "tracks,capabilities")]
+    collections: String,
+
+    /// Run in demo mode (simulated messages, no HIVE connection)
+    #[arg(long)]
+    demo: bool,
+
+    /// Enable verbose logging
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+
+    // Initialize logging
+    let filter = if args.verbose {
+        "hive_tak_bridge=debug,hive_transport=debug,hive_protocol=debug"
+    } else {
+        "hive_tak_bridge=info,hive_transport=info"
+    };
+    tracing_subscriber::fmt().with_env_filter(filter).init();
+
+    info!("HIVE-TAK Bridge starting");
+    info!("TAK Server: {}", args.tak_server);
+    info!("Callsign: {}", args.callsign);
+
+    // Parse protocol version
+    let protocol_version = match args.tak_protocol.to_lowercase().as_str() {
+        "raw" | "rawxml" => TakProtocolVersion::RawXml,
+        "xml" | "xmltcp" => TakProtocolVersion::XmlTcp,
+        "protobuf" | "proto" | "v1" => TakProtocolVersion::ProtobufV1,
+        _ => {
+            warn!(
+                "Unknown protocol '{}', defaulting to raw XML",
+                args.tak_protocol
+            );
+            TakProtocolVersion::RawXml
+        }
+    };
+    info!("Protocol: {:?}", protocol_version);
+
+    // Create TAK transport configuration
+    let mut tak_config = TakTransportConfig {
+        mode: TakTransportMode::TakServer {
+            address: args.tak_server,
+            use_tls: args.tak_use_tls,
+        },
+        identity: Some(hive_transport::tak::TakIdentity {
+            callsign: args.callsign.clone(),
+            client_cert: args.tak_client_cert.clone().unwrap_or_default(),
+            client_key: args.tak_client_key.clone().unwrap_or_default(),
+            ca_cert: args.tak_ca_cert.clone(),
+            credentials: None,
+        }),
+        ..Default::default()
+    };
+    tak_config.protocol.version = protocol_version;
+
+    // Log TLS configuration
+    if args.tak_use_tls {
+        info!("TLS enabled");
+        if let Some(ref cert) = args.tak_client_cert {
+            info!("Client cert: {:?}", cert);
+        }
+        if let Some(ref ca) = args.tak_ca_cert {
+            info!("CA cert: {:?}", ca);
+        }
+    }
+
+    // Create TAK transport
+    let mut tak_transport = TakServerTransport::new(tak_config)?;
+
+    // Connect to TAK Server
+    info!("Connecting to TAK Server...");
+    match tak_transport.connect().await {
+        Ok(()) => info!("Connected to TAK Server"),
+        Err(e) => {
+            error!("Failed to connect to TAK Server: {}", e);
+            return Err(e.into());
+        }
+    }
+
+    // Create bridge
+    let bridge_config = BridgeConfig::default();
+    let bridge = Arc::new(HiveTakBridge::new(tak_transport, bridge_config));
+
+    info!("Bridge initialized, ready to relay messages");
+
+    // Parse collections to subscribe to
+    let collections: Vec<String> = args.collections.split(',').map(|s| s.to_string()).collect();
+    info!("Subscribing to collections: {:?}", collections);
+
+    if args.demo {
+        // Demo mode - simulated messages
+        info!("Running in DEMO mode (simulated messages)");
+        let bridge_clone = Arc::clone(&bridge);
+        let demo_task = tokio::spawn(async move {
+            demo_messages(bridge_clone).await;
+        });
+
+        tokio::signal::ctrl_c().await?;
+        demo_task.abort();
+    } else {
+        // Production mode - connect to HIVE mesh
+        info!("Connecting to HIVE mesh...");
+        info!("App ID: {}", args.hive_app_id);
+        info!("Storage: {:?}", args.hive_storage);
+
+        // Create storage directory
+        std::fs::create_dir_all(&args.hive_storage)?;
+
+        // Create Automerge store
+        let store = Arc::new(AutomergeStore::open(&args.hive_storage)?);
+
+        // Create Iroh transport for P2P connectivity
+        let seed = format!("{}/bridge", args.hive_app_id);
+        let transport = Arc::new(IrohTransport::from_seed(&seed).await?);
+        info!(
+            "HIVE Node ID: {}",
+            hex::encode(transport.endpoint_id().as_bytes())
+        );
+
+        // Create storage backend with transport
+        let backend = AutomergeBackend::with_transport(Arc::clone(&store), Arc::clone(&transport));
+
+        // Connect to specified peers
+        for peer_str in &args.hive_peer {
+            if let Some((node_id, addr)) = peer_str.split_once('@') {
+                info!("Connecting to peer {} at {}", node_id, addr);
+                let peer_info = hive_protocol::network::PeerInfo {
+                    name: "peer".to_string(),
+                    node_id: node_id.to_string(),
+                    addresses: vec![addr.to_string()],
+                    relay_url: None,
+                };
+                if let Err(e) = transport.connect_peer(&peer_info).await {
+                    warn!("Failed to connect to peer {}: {}", node_id, e);
+                }
+            } else {
+                warn!(
+                    "Invalid peer format: {} (expected node_id@address)",
+                    peer_str
+                );
+            }
+        }
+
+        // Subscribe to document changes
+        let change_rx = store.subscribe_to_changes();
+        info!("Subscribed to document changes");
+
+        // Spawn the bridge relay task
+        let bridge_clone = Arc::clone(&bridge);
+        let collections_clone = collections.clone();
+        let relay_task = tokio::spawn(async move {
+            relay_hive_to_tak(change_rx, backend, bridge_clone, collections_clone).await;
+        });
+
+        // Wait for shutdown
+        info!("Bridge running. Press Ctrl+C to stop.");
+        tokio::signal::ctrl_c().await?;
+        relay_task.abort();
+    }
+
+    info!("HIVE-TAK Bridge stopped");
+    Ok(())
+}
+
+/// Relay HIVE document changes to TAK Server
+async fn relay_hive_to_tak(
+    mut change_rx: broadcast::Receiver<String>,
+    backend: AutomergeBackend,
+    bridge: Arc<HiveTakBridge<TakServerTransport>>,
+    collections: Vec<String>,
+) {
+    info!("Starting HIVE→TAK relay loop");
+
+    loop {
+        match change_rx.recv().await {
+            Ok(doc_key) => {
+                debug!("Document changed: {}", doc_key);
+
+                // Parse collection:doc_id format
+                let (collection, doc_id) = match doc_key.split_once(':') {
+                    Some((c, d)) => (c, d),
+                    None => {
+                        debug!("Skipping key without collection prefix: {}", doc_key);
+                        continue;
+                    }
+                };
+
+                // Check if we're subscribed to this collection
+                if !collections.iter().any(|c| c == collection) {
+                    debug!("Skipping unsubscribed collection: {}", collection);
+                    continue;
+                }
+
+                // Fetch the document
+                let coll = backend.collection(collection);
+                let doc_data = match coll.get(doc_id) {
+                    Ok(Some(data)) => data,
+                    Ok(None) => {
+                        debug!("Document {} not found", doc_key);
+                        continue;
+                    }
+                    Err(e) => {
+                        warn!("Failed to fetch document {}: {}", doc_key, e);
+                        continue;
+                    }
+                };
+
+                // Parse and convert to HiveMessage
+                let message = match collection {
+                    "tracks" => parse_track_document(&doc_data, doc_id),
+                    "capabilities" => parse_capability_document(&doc_data, doc_id),
+                    _ => {
+                        debug!("Unknown collection type: {}", collection);
+                        None
+                    }
+                };
+
+                // Publish to TAK
+                if let Some(msg) = message {
+                    match bridge.publish_to_tak(msg).await {
+                        PublishResult::Published => {
+                            info!("Relayed {} to TAK", doc_key);
+                        }
+                        PublishResult::Filtered(reason) => {
+                            debug!("Filtered {}: {}", doc_key, reason);
+                        }
+                        PublishResult::TransportError(e) => {
+                            error!("Failed to relay {}: {}", doc_key, e);
+                        }
+                        other => {
+                            debug!("Relay result for {}: {:?}", doc_key, other);
+                        }
+                    }
+                }
+            }
+            Err(broadcast::error::RecvError::Lagged(n)) => {
+                warn!("Subscription lagged {} messages", n);
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                info!("Document change channel closed");
+                break;
+            }
+        }
+    }
+}
+
+/// Parse a track document from JSON
+fn parse_track_document(data: &[u8], doc_id: &str) -> Option<HiveMessage> {
+    let json_str = match std::str::from_utf8(data) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Invalid UTF-8 in track document {}: {}", doc_id, e);
+            return None;
+        }
+    };
+
+    // Try to parse as TrackUpdate JSON
+    match serde_json::from_str::<serde_json::Value>(json_str) {
+        Ok(json) => {
+            // Extract fields from JSON
+            let track = TrackUpdate {
+                track_id: json["track_id"].as_str().unwrap_or(doc_id).to_string(),
+                source_platform: json["source_platform"]
+                    .as_str()
+                    .unwrap_or("unknown")
+                    .to_string(),
+                source_model: json["source_model"]
+                    .as_str()
+                    .unwrap_or("unknown")
+                    .to_string(),
+                model_version: json["model_version"].as_str().unwrap_or("1.0").to_string(),
+                cell_id: json["cell_id"].as_str().map(|s| s.to_string()),
+                formation_id: json["formation_id"].as_str().map(|s| s.to_string()),
+                timestamp: chrono::Utc::now(),
+                position: Position {
+                    lat: json["position"]["lat"].as_f64().unwrap_or(0.0),
+                    lon: json["position"]["lon"].as_f64().unwrap_or(0.0),
+                    hae: json["position"]["hae"].as_f64(),
+                    cep_m: json["position"]["cep_m"].as_f64(),
+                },
+                velocity: None,
+                classification: json["classification"]
+                    .as_str()
+                    .unwrap_or("a-u-G")
+                    .to_string(),
+                confidence: json["confidence"].as_f64().unwrap_or(0.5),
+                attributes: Default::default(),
+            };
+            Some(HiveMessage::Track(track))
+        }
+        Err(e) => {
+            warn!("Failed to parse track JSON for {}: {}", doc_id, e);
+            None
+        }
+    }
+}
+
+/// Parse a capability document from JSON
+fn parse_capability_document(data: &[u8], doc_id: &str) -> Option<HiveMessage> {
+    let json_str = match std::str::from_utf8(data) {
+        Ok(s) => s,
+        Err(e) => {
+            warn!("Invalid UTF-8 in capability document {}: {}", doc_id, e);
+            return None;
+        }
+    };
+
+    match serde_json::from_str::<serde_json::Value>(json_str) {
+        Ok(json) => {
+            // Parse operational status
+            let status = match json["status"].as_str().unwrap_or("READY") {
+                "ACTIVE" => OperationalStatus::Active,
+                "DEGRADED" => OperationalStatus::Degraded,
+                "OFFLINE" => OperationalStatus::Offline,
+                "LOADING" => OperationalStatus::Loading,
+                _ => OperationalStatus::Ready,
+            };
+
+            // Parse capabilities array
+            let capabilities: Vec<CapabilityInfo> = json["capabilities"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|c| {
+                            Some(CapabilityInfo {
+                                capability_type: c["type"].as_str()?.to_string(),
+                                model_name: c["model"].as_str().unwrap_or("unknown").to_string(),
+                                version: c["version"].as_str().unwrap_or("1.0").to_string(),
+                                precision: c["precision"].as_f64().unwrap_or(0.9),
+                                status: OperationalStatus::Ready,
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let cap = CapabilityAdvertisement {
+                platform_id: json["platform_id"].as_str().unwrap_or(doc_id).to_string(),
+                platform_type: json["platform_type"].as_str().unwrap_or("UGV").to_string(),
+                position: Position {
+                    lat: json["position"]["lat"].as_f64().unwrap_or(0.0),
+                    lon: json["position"]["lon"].as_f64().unwrap_or(0.0),
+                    hae: json["position"]["hae"].as_f64(),
+                    cep_m: None,
+                },
+                status,
+                readiness: json["readiness"].as_f64().unwrap_or(1.0),
+                capabilities,
+                cell_id: json["cell_id"].as_str().map(|s| s.to_string()),
+                formation_id: json["formation_id"].as_str().map(|s| s.to_string()),
+                timestamp: chrono::Utc::now(),
+            };
+            Some(HiveMessage::Capability(cap))
+        }
+        Err(e) => {
+            warn!("Failed to parse capability JSON for {}: {}", doc_id, e);
+            None
+        }
+    }
+}
+
+/// Demo function that sends simulated messages
+async fn demo_messages(bridge: Arc<HiveTakBridge<TakServerTransport>>) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+    let mut track_num = 0;
+
+    loop {
+        interval.tick().await;
+
+        track_num += 1;
+        let track_id = format!("TRACK-{:04}", track_num);
+
+        // Create a simulated track update
+        let track = TrackUpdate {
+            track_id: track_id.clone(),
+            source_platform: "Alpha-3".to_string(),
+            source_model: "YOLOv8".to_string(),
+            model_version: "1.3.0".to_string(),
+            cell_id: Some("Alpha".to_string()),
+            formation_id: Some("Demo-Formation".to_string()),
+            timestamp: chrono::Utc::now(),
+            position: Position {
+                lat: 38.8977 + (track_num as f64 * 0.001),
+                lon: -77.0365 + (track_num as f64 * 0.001),
+                hae: Some(10.0),
+                cep_m: Some(5.0),
+            },
+            velocity: None,
+            classification: "a-f-G-U-C".to_string(),
+            confidence: 0.92,
+            attributes: Default::default(),
+        };
+
+        let message = HiveMessage::Track(track);
+
+        match bridge.publish_to_tak(message).await {
+            PublishResult::Published => {
+                info!("Published track {} to TAK", track_id);
+            }
+            PublishResult::Filtered(reason) => {
+                warn!("Track {} filtered: {}", track_id, reason);
+            }
+            PublishResult::TransportError(e) => {
+                error!("Failed to publish track {}: {}", track_id, e);
+            }
+            other => {
+                info!("Track {} result: {:?}", track_id, other);
+            }
+        }
+    }
+}

--- a/hive-transport/src/tak/config.rs
+++ b/hive-transport/src/tak/config.rs
@@ -136,6 +136,11 @@ impl Default for ProtocolConfig {
 /// TAK Protocol version selection
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum TakProtocolVersion {
+    /// Raw XML over TCP (no framing)
+    /// Payload: <xml_payload>
+    /// Use for: FreeTAKServer, simple integrations
+    RawXml,
+
     /// CoT XML over TCP (legacy, Version 0)
     /// Header: 0xbf 0x00 0xbf <xml_payload>
     /// Use for: debugging, legacy TAK Server compatibility

--- a/hive-transport/src/tak/mesh.rs
+++ b/hive-transport/src/tak/mesh.rs
@@ -164,6 +164,10 @@ impl MeshSaTransport {
     /// Format: [0xBF][0x01][0xBF][varint_len][payload] for Protobuf
     fn frame_mesh_sa(&self, payload: &[u8]) -> Vec<u8> {
         match self.config.protocol.version {
+            TakProtocolVersion::RawXml => {
+                // Raw XML, no framing
+                payload.to_vec()
+            }
             TakProtocolVersion::XmlTcp => {
                 // XML framing
                 let mut frame = Vec::with_capacity(3 + payload.len());

--- a/hive-transport/src/tak/server.rs
+++ b/hive-transport/src/tak/server.rs
@@ -1,7 +1,7 @@
 //! TAK Server TCP/SSL transport implementation
 
 use async_trait::async_trait;
-use hive_protocol::cot::{CotEncoder, CotEvent, CotEventBuilder, CotType};
+use hive_protocol::cot::{CotEncoder, CotEvent, CotEventBuilder, CotPoint, CotType};
 use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -102,10 +102,13 @@ impl TakServerTransport {
             .unwrap_or("HIVE-BRIDGE");
 
         let uid = format!("HIVE-{}", uuid::Uuid::new_v4());
+        // Default position at 0,0 for presence announcement
+        // Real position would come from configuration or GPS
         let presence = CotEventBuilder::new()
             .uid(&uid)
             .cot_type(CotType::new("a-f-G-U-C"))
             .how("m-g")
+            .point(CotPoint::new(0.0, 0.0))
             .build()
             .map_err(|e| {
                 TakError::EncodingError(format!("Failed to build presence event: {}", e))
@@ -128,6 +131,10 @@ impl TakServerTransport {
 
         // Frame the message based on protocol version
         let frame = match self.config.protocol.version {
+            TakProtocolVersion::RawXml => {
+                // Raw XML, no framing - for FreeTAKServer
+                payload.to_vec()
+            }
             TakProtocolVersion::XmlTcp => {
                 // XML framing: [0xBF][0x00][0xBF][payload]
                 let mut frame = Vec::with_capacity(3 + payload.len());


### PR DESCRIPTION
## Summary
- New `hive-tak-bridge` binary crate connecting HIVE mesh to TAK Server for C2 visibility
- Added `TakProtocolVersion::RawXml` for FreeTAKServer compatibility (no magic byte framing)
- Added TLS certificate and protocol configuration options
- Updated CoT-HIVE mapping contract documentation

## Changes
- **hive-tak-bridge/**: New binary crate with CLI, Docker Compose setup
- **hive-transport/src/tak/**: Added RawXml protocol, fixed presence CotPoint
- **docs/contracts/**: Added Interface 3 & 4 mappings

## Test plan
- [x] Build passes with `cargo build --package hive-tak-bridge`
- [x] Demo mode tested: `cargo run --package hive-tak-bridge -- --demo`
- [x] FreeTAKServer receives client connections (verified via logs)
- [ ] End-to-end WebTAK visualization (blocked on Linux deployment)

## Configuration
```bash
# FreeTAKServer (raw XML, default)
cargo run --package hive-tak-bridge -- --demo --tak-server 127.0.0.1:8087

# Official TAK Server (protobuf + TLS)
cargo run --package hive-tak-bridge -- --tak-protocol protobuf --tak-use-tls \
  --tak-client-cert cert.pem --tak-client-key key.pem
```

Closes #311
Related: #290, #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)