### PR TITLE
feat(atak): Add track display on ATAK map (#320)

### DIFF
--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
@@ -176,8 +176,9 @@ class HiveDropDownReceiver(
         container.addView(createSpacer(24))
 
         // Tracks section
+        val mapMarkerCount = mapComponent.getMapMarkerCount()
         val tracksTitle = TextView(pluginContext).apply {
-            text = "Tracks (${mapComponent.tracks.size})"
+            text = "Tracks (${mapComponent.tracks.size}) • Map: $mapMarkerCount"
             textSize = 16f
             setTextColor(Color.WHITE)
         }

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
@@ -2,6 +2,8 @@ package com.revolveteam.atak.hive
 
 import android.content.Context
 import android.content.Intent
+import android.os.Handler
+import android.os.Looper
 import com.atakmap.android.dropdown.DropDownMapComponent
 import com.atakmap.android.ipc.AtakBroadcast.DocumentedIntentFilter
 import com.atakmap.android.maps.MapView
@@ -9,6 +11,7 @@ import com.atakmap.coremap.log.Log
 import com.revolveteam.atak.hive.model.HiveCell
 import com.revolveteam.atak.hive.model.HivePlatform
 import com.revolveteam.atak.hive.model.HiveTrack
+import com.revolveteam.atak.hive.overlay.HiveTrackOverlay
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -25,10 +28,15 @@ class HiveMapComponent : DropDownMapComponent() {
 
     companion object {
         private const val TAG = "HiveMapComponent"
+        private const val REFRESH_INTERVAL_MS = 2000L // Refresh every 2 seconds
     }
 
     private lateinit var pluginContext: Context
+    private lateinit var mapView: MapView
     private var dropDownReceiver: HiveDropDownReceiver? = null
+    private var trackOverlay: HiveTrackOverlay? = null
+    private val refreshHandler = Handler(Looper.getMainLooper())
+    private var isRefreshing = false
 
     // Simple state management without coroutines
     private val _cells = mutableListOf<HiveCell>()
@@ -50,7 +58,12 @@ class HiveMapComponent : DropDownMapComponent() {
         super.onCreate(context, intent, view)
 
         pluginContext = context
+        mapView = view
         Log.d(TAG, "HiveMapComponent onCreate")
+
+        // Create track overlay for map markers
+        trackOverlay = HiveTrackOverlay(view)
+        Log.d(TAG, "Track overlay created")
 
         // Create dropdown receiver
         dropDownReceiver = HiveDropDownReceiver(view, context, this)
@@ -63,12 +76,56 @@ class HiveMapComponent : DropDownMapComponent() {
         // Update connection status based on HIVE node availability
         updateConnectionStatus()
 
+        // Start periodic refresh for map markers
+        startPeriodicRefresh()
+
         Log.d(TAG, "HiveMapComponent initialized")
     }
 
     override fun onDestroyImpl(context: Context, view: MapView) {
         Log.d(TAG, "HiveMapComponent onDestroy")
+        stopPeriodicRefresh()
+        trackOverlay?.dispose()
+        trackOverlay = null
         super.onDestroyImpl(context, view)
+    }
+
+    /**
+     * Start periodic refresh of track data and map markers
+     */
+    private fun startPeriodicRefresh() {
+        if (isRefreshing) return
+        isRefreshing = true
+        Log.i(TAG, "Starting periodic refresh (${REFRESH_INTERVAL_MS}ms interval)")
+        refreshHandler.post(refreshRunnable)
+    }
+
+    /**
+     * Stop periodic refresh
+     */
+    private fun stopPeriodicRefresh() {
+        isRefreshing = false
+        refreshHandler.removeCallbacks(refreshRunnable)
+        Log.i(TAG, "Stopped periodic refresh")
+    }
+
+    private val refreshRunnable = object : Runnable {
+        override fun run() {
+            if (!isRefreshing) return
+
+            try {
+                refreshData()
+                // Update map markers
+                trackOverlay?.updateTracks(_tracks)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error in periodic refresh: ${e.message}", e)
+            }
+
+            // Schedule next refresh
+            if (isRefreshing) {
+                refreshHandler.postDelayed(this, REFRESH_INTERVAL_MS)
+            }
+        }
     }
 
     /**
@@ -321,6 +378,18 @@ class HiveMapComponent : DropDownMapComponent() {
      * Get the node manager - returns null in this simplified version
      */
     fun getNodeManager(): Any? = null
+
+    /**
+     * Get the number of track markers currently on the map
+     */
+    fun getMapMarkerCount(): Int = trackOverlay?.getMarkerCount() ?: 0
+
+    /**
+     * Force update of track markers on the map
+     */
+    fun updateMapMarkers() {
+        trackOverlay?.updateTracks(_tracks)
+    }
 
     /**
      * Connection status enumeration

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/overlay/HiveTrackOverlay.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/overlay/HiveTrackOverlay.kt
@@ -1,0 +1,228 @@
+package com.revolveteam.atak.hive.overlay
+
+import android.graphics.Color
+import com.atakmap.android.maps.MapGroup
+import com.atakmap.android.maps.MapItem
+import com.atakmap.android.maps.MapView
+import com.atakmap.android.maps.Marker
+import com.atakmap.android.maps.PointMapItem
+import com.atakmap.coremap.log.Log
+import com.atakmap.coremap.maps.coords.GeoPoint
+import com.revolveteam.atak.hive.model.HiveTrack
+
+/**
+ * Manages HIVE track markers on the ATAK map.
+ *
+ * Tracks are displayed as markers with:
+ * - Icon based on classification (person, vehicle, etc.)
+ * - Color based on affiliation (hostile=red, friendly=green, unknown=yellow)
+ * - Label showing track ID and confidence
+ * - Automatic removal when stale (no update > 5 minutes)
+ */
+class HiveTrackOverlay(private val mapView: MapView) {
+
+    companion object {
+        private const val TAG = "HiveTrackOverlay"
+        private const val GROUP_NAME = "HIVE Tracks"
+        private const val STALE_THRESHOLD_MS = 5 * 60 * 1000L // 5 minutes
+    }
+
+    private var mapGroup: MapGroup? = null
+    private val trackMarkers = mutableMapOf<String, Marker>()
+
+    init {
+        initMapGroup()
+    }
+
+    private fun initMapGroup() {
+        val rootGroup = mapView.rootGroup
+        if (rootGroup == null) {
+            Log.e(TAG, "Root map group is null")
+            return
+        }
+
+        // Find or create HIVE Tracks group
+        mapGroup = rootGroup.findMapGroup(GROUP_NAME)
+        if (mapGroup == null) {
+            mapGroup = rootGroup.addGroup(GROUP_NAME)
+            Log.i(TAG, "Created HIVE Tracks map group")
+        } else {
+            Log.d(TAG, "Found existing HIVE Tracks map group")
+        }
+    }
+
+    /**
+     * Update all track markers from the provided list.
+     * Adds new markers, updates existing ones, removes stale ones.
+     */
+    fun updateTracks(tracks: List<HiveTrack>) {
+        val group = mapGroup ?: run {
+            Log.w(TAG, "Map group not initialized")
+            return
+        }
+
+        val currentTrackIds = tracks.map { it.id }.toSet()
+        val now = System.currentTimeMillis()
+
+        // Remove markers for tracks no longer in the list or stale
+        val toRemove = trackMarkers.keys.filter { trackId ->
+            trackId !in currentTrackIds
+        }
+        toRemove.forEach { trackId ->
+            removeMarker(trackId)
+        }
+
+        // Add or update markers for current tracks
+        tracks.forEach { track ->
+            // Skip stale tracks
+            if (track.isStale(STALE_THRESHOLD_MS)) {
+                Log.d(TAG, "Skipping stale track: ${track.id}")
+                removeMarker(track.id)
+                return@forEach
+            }
+
+            val existingMarker = trackMarkers[track.id]
+            if (existingMarker != null) {
+                updateMarker(existingMarker, track)
+            } else {
+                createMarker(track)
+            }
+        }
+
+        Log.d(TAG, "Updated ${trackMarkers.size} track markers")
+    }
+
+    /**
+     * Create a new marker for a track.
+     */
+    private fun createMarker(track: HiveTrack) {
+        val group = mapGroup ?: return
+
+        try {
+            val uid = track.toCotUid()
+            val point = GeoPoint(track.lat, track.lon, track.hae ?: 0.0)
+
+            val marker = Marker(point, uid)
+            marker.type = track.toCotType()
+            marker.title = "Track ${track.id.takeLast(6)}"
+
+            // Set marker style based on classification
+            applyMarkerStyle(marker, track)
+
+            // Add metadata for tap-to-view details
+            marker.setMetaString("hiveTackId", track.id)
+            marker.setMetaString("sourcePlatform", track.sourcePlatform)
+            marker.setMetaDouble("confidence", track.confidence)
+            marker.setMetaString("category", track.category.name)
+            marker.setMetaString("classification", track.classification)
+
+            // Add attributes as metadata
+            track.attributes.forEach { (key, value) ->
+                marker.setMetaString("attr_$key", value)
+            }
+
+            group.addItem(marker)
+            trackMarkers[track.id] = marker
+            Log.d(TAG, "Created marker for track: ${track.id}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to create marker for track ${track.id}: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Update an existing marker with new track data.
+     */
+    private fun updateMarker(marker: Marker, track: HiveTrack) {
+        try {
+            val point = GeoPoint(track.lat, track.lon, track.hae ?: 0.0)
+            marker.point = point
+
+            // Update title with confidence
+            marker.title = "Track ${track.id.takeLast(6)} (${(track.confidence * 100).toInt()}%)"
+
+            // Update style if classification changed
+            applyMarkerStyle(marker, track)
+
+            // Update metadata
+            marker.setMetaDouble("confidence", track.confidence)
+            marker.setMetaString("category", track.category.name)
+
+            Log.v(TAG, "Updated marker for track: ${track.id}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to update marker for track ${track.id}: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Apply visual style to marker based on track classification.
+     */
+    private fun applyMarkerStyle(marker: Marker, track: HiveTrack) {
+        // Color based on affiliation in classification
+        val color = when {
+            track.classification.contains("-h-") -> Color.RED      // Hostile
+            track.classification.contains("-f-") -> Color.GREEN    // Friendly
+            track.classification.contains("-n-") -> Color.CYAN     // Neutral
+            else -> Color.YELLOW                                    // Unknown
+        }
+
+        marker.setMetaInteger("color", color)
+
+        // Icon type based on category
+        val iconUri = when (track.category) {
+            HiveTrack.Category.PERSON -> "asset://icons/person.png"
+            HiveTrack.Category.VEHICLE -> "asset://icons/vehicle.png"
+            HiveTrack.Category.AIRCRAFT -> "asset://icons/aircraft.png"
+            HiveTrack.Category.VESSEL -> "asset://icons/vessel.png"
+            else -> "asset://icons/unknown.png"
+        }
+
+        // Set track/course if available (store as metadata)
+        track.heading?.let { heading ->
+            marker.setMetaDouble("course", heading)
+        }
+
+        track.speed?.let { speed ->
+            marker.setMetaDouble("speed", speed)
+        }
+    }
+
+    /**
+     * Remove a marker by track ID.
+     */
+    private fun removeMarker(trackId: String) {
+        trackMarkers.remove(trackId)?.let { marker ->
+            mapGroup?.removeItem(marker)
+            marker.dispose()
+            Log.d(TAG, "Removed marker for track: $trackId")
+        }
+    }
+
+    /**
+     * Remove all track markers.
+     */
+    fun clearAll() {
+        trackMarkers.values.forEach { marker ->
+            mapGroup?.removeItem(marker)
+            marker.dispose()
+        }
+        trackMarkers.clear()
+        Log.i(TAG, "Cleared all track markers")
+    }
+
+    /**
+     * Get the number of active track markers.
+     */
+    fun getMarkerCount(): Int = trackMarkers.size
+
+    /**
+     * Dispose of the overlay and clean up resources.
+     */
+    fun dispose() {
+        clearAll()
+        mapGroup?.let { group ->
+            mapView.rootGroup?.removeGroup(group)
+        }
+        mapGroup = null
+        Log.i(TAG, "HiveTrackOverlay disposed")
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HiveTrackOverlay` class to display HIVE tracks as markers on the ATAK map
- Integrate periodic refresh (2s) for real-time track updates
- Implement stale track removal (5 min timeout)
- Show map marker count in dropdown UI

## Changes
- **NEW**: `atak-plugin/app/src/main/java/com/revolveteam/atak/hive/overlay/HiveTrackOverlay.kt`
  - Creates/updates/removes ATAK map markers for tracks
  - Color-coded by affiliation (red=hostile, green=friendly, yellow=unknown)
  - Track ID and confidence shown in marker title
  - Metadata stored for tap-to-view details
- **MODIFIED**: `HiveMapComponent.kt`
  - Added periodic refresh handler
  - Integrates track overlay
  - Added `getMapMarkerCount()` and `updateMapMarkers()` methods
- **MODIFIED**: `HiveDropDownReceiver.kt`
  - Shows map marker count in tracks section

## Test plan
- [ ] Build ATAK plugin: `./gradlew assembleCivDebug`
- [ ] Install on device with ATAK
- [ ] Verify tracks appear on map when HIVE mesh has track data
- [ ] Verify stale tracks disappear after 5 minutes
- [ ] Verify marker colors match track affiliation

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)