### PR TITLE
feat(schema): Add model.proto for AI model deployment (#319)

### DIFF
--- a/hive-schema/build.rs
+++ b/hive-schema/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/command.proto",
         "proto/security.proto",
         "proto/track.proto",
+        "proto/model.proto",
     ];
 
     // Configure prost to generate Rust code from .proto files

--- a/hive-schema/proto/model.proto
+++ b/hive-schema/proto/model.proto
@@ -1,0 +1,237 @@
+// AI Model Deployment definitions for CAP Protocol
+// Version: 1.0.0
+//
+// Defines schema for distributing AI models from MLOps registries
+// to edge nodes via the HIVE mesh network.
+
+syntax = "proto3";
+
+package cap.model.v1;
+
+import "common.proto";
+
+// ============================================================================
+// Model Deployment (Downward Flow)
+// ============================================================================
+
+// Model deployment message - flows downward from C2 to platforms
+//
+// Used to distribute AI models from MLOps registries to edge platforms.
+// Supports rolling deployments, hash verification, and rollback.
+message ModelDeployment {
+  // Unique deployment identifier (e.g., "deploy-2025-001")
+  string deployment_id = 1;
+
+  // Model identifier (e.g., "yolov8-poi-v2.1")
+  string model_id = 2;
+
+  // Model version string
+  string model_version = 3;
+
+  // Type of model being deployed
+  ModelType model_type = 4;
+
+  // URL to download the model (HTTPS, S3, or blob reference)
+  string model_url = 5;
+
+  // SHA256 hash of the model file for verification
+  string checksum_sha256 = 6;
+
+  // Size of the model file in bytes
+  uint64 file_size_bytes = 7;
+
+  // Target platform IDs for deployment
+  repeated string target_platforms = 8;
+
+  // Deployment policy
+  DeploymentPolicy deployment_policy = 9;
+
+  // Priority of this deployment
+  DeploymentPriority priority = 10;
+
+  // Timestamp when deployment was initiated
+  common.v1.Timestamp deployed_at = 11;
+
+  // Identity of deployer (e.g., "C2-WebTAK", "MLOps-Pipeline")
+  string deployed_by = 12;
+
+  // Previous model version for rollback support
+  string rollback_model_id = 13;
+
+  // Additional model metadata
+  ModelMetadata metadata = 14;
+}
+
+// Type of AI model
+enum ModelType {
+  MODEL_TYPE_UNSPECIFIED = 0;
+  MODEL_TYPE_DETECTOR = 1;          // Object detection model (e.g., YOLO)
+  MODEL_TYPE_TRACKER = 2;           // Object tracking model (e.g., DeepSORT)
+  MODEL_TYPE_DETECTOR_TRACKER = 3;  // Combined detection + tracking
+  MODEL_TYPE_CLASSIFIER = 4;        // Classification model
+  MODEL_TYPE_SEGMENTATION = 5;      // Segmentation model
+  MODEL_TYPE_POSE = 6;              // Pose estimation model
+  MODEL_TYPE_CUSTOM = 99;           // Custom/other model type
+}
+
+// Deployment policy for rolling updates
+enum DeploymentPolicy {
+  DEPLOYMENT_POLICY_UNSPECIFIED = 0;
+  DEPLOYMENT_POLICY_IMMEDIATE = 1;    // Deploy immediately to all targets
+  DEPLOYMENT_POLICY_ROLLING = 2;      // Rolling deployment (one at a time)
+  DEPLOYMENT_POLICY_CANARY = 3;       // Canary deployment (test on subset first)
+  DEPLOYMENT_POLICY_SCHEDULED = 4;    // Deploy at scheduled time
+}
+
+// Deployment priority level
+enum DeploymentPriority {
+  DEPLOYMENT_PRIORITY_UNSPECIFIED = 0;
+  DEPLOYMENT_PRIORITY_LOW = 1;
+  DEPLOYMENT_PRIORITY_NORMAL = 2;
+  DEPLOYMENT_PRIORITY_HIGH = 3;
+  DEPLOYMENT_PRIORITY_CRITICAL = 4;   // Emergency deployment (e.g., security fix)
+}
+
+// Model metadata
+message ModelMetadata {
+  // Model format (e.g., "onnx", "tflite", "tensorrt")
+  string format = 1;
+
+  // Framework the model was trained with (e.g., "pytorch", "tensorflow")
+  string framework = 2;
+
+  // Input dimensions (e.g., "640x640x3")
+  string input_dimensions = 3;
+
+  // Model classes/labels (for detection/classification)
+  repeated string classes = 4;
+
+  // Minimum inference runtime version required
+  string min_runtime_version = 5;
+
+  // Hardware requirements
+  HardwareRequirements hardware_requirements = 6;
+
+  // Performance metrics from validation
+  ModelPerformanceMetrics performance_metrics = 7;
+
+  // Additional metadata (JSON-encoded for extensibility)
+  string extra_json = 10;
+}
+
+// Hardware requirements for running the model
+message HardwareRequirements {
+  // Minimum GPU memory in MB (0 if CPU-only)
+  uint32 min_gpu_memory_mb = 1;
+
+  // Minimum RAM in MB
+  uint32 min_ram_mb = 2;
+
+  // Minimum storage in MB
+  uint32 min_storage_mb = 3;
+
+  // Required accelerator type
+  AcceleratorType accelerator_type = 4;
+}
+
+// Accelerator type for inference
+enum AcceleratorType {
+  ACCELERATOR_TYPE_UNSPECIFIED = 0;
+  ACCELERATOR_TYPE_CPU = 1;           // CPU-only
+  ACCELERATOR_TYPE_CUDA = 2;          // NVIDIA CUDA GPU
+  ACCELERATOR_TYPE_TENSORRT = 3;      // NVIDIA TensorRT
+  ACCELERATOR_TYPE_JETSON = 4;        // NVIDIA Jetson (Orin, Xavier, etc.)
+  ACCELERATOR_TYPE_CORAL = 5;         // Google Coral TPU
+  ACCELERATOR_TYPE_OPENVINO = 6;      // Intel OpenVINO
+}
+
+// Performance metrics from model validation
+message ModelPerformanceMetrics {
+  // Mean Average Precision (mAP) for detection models
+  float map = 1;
+
+  // Inference time in milliseconds (average)
+  float inference_time_ms = 2;
+
+  // Frames per second on reference hardware
+  float fps = 3;
+
+  // Accuracy (for classification models)
+  float accuracy = 4;
+
+  // Reference hardware used for benchmarks
+  string benchmark_hardware = 5;
+}
+
+// ============================================================================
+// Model Deployment Status (Upward Flow)
+// ============================================================================
+
+// Model deployment status - flows upward from platforms
+//
+// Platforms report deployment progress and status back to C2.
+message ModelDeploymentStatus {
+  // Reference to the deployment
+  string deployment_id = 1;
+
+  // Platform reporting status
+  string platform_id = 2;
+
+  // Current status of deployment on this platform
+  DeploymentState state = 3;
+
+  // Progress percentage (0-100) for downloads
+  uint32 progress_percent = 4;
+
+  // Error message if deployment failed
+  string error_message = 5;
+
+  // Timestamp of this status update
+  common.v1.Timestamp updated_at = 6;
+
+  // Hash of downloaded file (for verification reporting)
+  string downloaded_hash = 7;
+
+  // Previous model version (before update)
+  string previous_version = 8;
+}
+
+// State of deployment on a platform
+enum DeploymentState {
+  DEPLOYMENT_STATE_UNSPECIFIED = 0;
+  DEPLOYMENT_STATE_PENDING = 1;       // Deployment received, not started
+  DEPLOYMENT_STATE_DOWNLOADING = 2;   // Currently downloading model
+  DEPLOYMENT_STATE_VERIFYING = 3;     // Verifying hash/integrity
+  DEPLOYMENT_STATE_INSTALLING = 4;    // Installing/loading model
+  DEPLOYMENT_STATE_COMPLETE = 5;      // Successfully deployed
+  DEPLOYMENT_STATE_FAILED = 6;        // Deployment failed
+  DEPLOYMENT_STATE_ROLLED_BACK = 7;   // Rolled back to previous version
+}
+
+// ============================================================================
+// Model Query and Response
+// ============================================================================
+
+// Query for available models
+message ModelQuery {
+  // Filter by model type
+  ModelType model_type = 1;
+
+  // Filter by platform compatibility
+  string platform_id = 2;
+
+  // Filter by minimum version
+  string min_version = 3;
+
+  // Filter by accelerator type
+  AcceleratorType accelerator_type = 4;
+}
+
+// Response containing available models
+message ModelCatalogResponse {
+  // List of available models
+  repeated ModelDeployment models = 1;
+
+  // Total count
+  uint32 total_count = 2;
+}

--- a/hive-schema/src/lib.rs
+++ b/hive-schema/src/lib.rs
@@ -25,6 +25,7 @@
 //! ### Protocol Schemas
 //! - **`beacon.v1`**: Discovery phase beacons and queries
 //! - **`composition.v1`**: Capability composition rules (additive, emergent, redundant, constraint)
+//! - **`model.v1`**: AI model deployment and distribution
 //!
 //! ## Three-Tier Hierarchy
 //!
@@ -123,6 +124,12 @@ pub mod cap {
     pub mod track {
         pub mod v1 {
             include!(concat!(env!("OUT_DIR"), "/cap.track.v1.rs"));
+        }
+    }
+
+    pub mod model {
+        pub mod v1 {
+            include!(concat!(env!("OUT_DIR"), "/cap.model.v1.rs"));
         }
     }
 }

--- a/hive-schema/src/validation.rs
+++ b/hive-schema/src/validation.rs
@@ -11,6 +11,10 @@ use crate::capability::v1::{
 };
 use crate::cell::v1::{CellConfig, CellState};
 use crate::command::v1::HierarchicalCommand;
+use crate::model::v1::{
+    DeploymentPolicy, DeploymentPriority, DeploymentState, ModelDeployment, ModelDeploymentStatus,
+    ModelType,
+};
 use crate::node::v1::{NodeConfig, NodeState};
 use crate::track::v1::{Track, TrackPosition, TrackUpdate, UpdateType};
 
@@ -406,6 +410,202 @@ pub fn validate_hierarchical_command(cmd: &HierarchicalCommand) -> ValidationRes
     Ok(())
 }
 
+// ============================================================================
+// Model Deployment Validators (Issue #319)
+// ============================================================================
+
+/// Validate a ModelDeployment message
+///
+/// Validates:
+/// - deployment_id is present
+/// - model_id is present
+/// - model_version is present
+/// - model_type is specified (not unspecified)
+/// - model_url is present and well-formed
+/// - checksum_sha256 is present and valid length
+/// - file_size_bytes is non-zero
+/// - At least one target_platform is specified
+/// - deployment_policy is specified
+/// - priority is specified
+/// - deployed_at timestamp is present
+/// - deployed_by is present
+pub fn validate_model_deployment(deployment: &ModelDeployment) -> ValidationResult<()> {
+    // Check required string fields
+    if deployment.deployment_id.is_empty() {
+        return Err(ValidationError::MissingField("deployment_id".to_string()));
+    }
+
+    if deployment.model_id.is_empty() {
+        return Err(ValidationError::MissingField("model_id".to_string()));
+    }
+
+    if deployment.model_version.is_empty() {
+        return Err(ValidationError::MissingField("model_version".to_string()));
+    }
+
+    // Model type must be specified
+    if deployment.model_type == ModelType::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "model_type must be specified".to_string(),
+        ));
+    }
+
+    // Model URL must be present
+    if deployment.model_url.is_empty() {
+        return Err(ValidationError::MissingField("model_url".to_string()));
+    }
+
+    // Validate URL scheme (basic check for https://, s3://, or similar)
+    if !deployment.model_url.contains("://") {
+        return Err(ValidationError::InvalidValue(
+            "model_url must be a valid URL with scheme".to_string(),
+        ));
+    }
+
+    // Checksum must be present and 64 characters (SHA256 hex)
+    if deployment.checksum_sha256.is_empty() {
+        return Err(ValidationError::MissingField("checksum_sha256".to_string()));
+    }
+
+    if deployment.checksum_sha256.len() != 64 {
+        return Err(ValidationError::InvalidValue(format!(
+            "checksum_sha256 must be 64 hex characters, got {}",
+            deployment.checksum_sha256.len()
+        )));
+    }
+
+    // Validate checksum is valid hex
+    if !deployment
+        .checksum_sha256
+        .chars()
+        .all(|c| c.is_ascii_hexdigit())
+    {
+        return Err(ValidationError::InvalidValue(
+            "checksum_sha256 must contain only hex characters".to_string(),
+        ));
+    }
+
+    // File size must be non-zero
+    if deployment.file_size_bytes == 0 {
+        return Err(ValidationError::InvalidValue(
+            "file_size_bytes must be non-zero".to_string(),
+        ));
+    }
+
+    // At least one target platform is required
+    if deployment.target_platforms.is_empty() {
+        return Err(ValidationError::MissingField(
+            "target_platforms (at least one required)".to_string(),
+        ));
+    }
+
+    // Deployment policy must be specified
+    if deployment.deployment_policy == DeploymentPolicy::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "deployment_policy must be specified".to_string(),
+        ));
+    }
+
+    // Priority must be specified
+    if deployment.priority == DeploymentPriority::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "priority must be specified".to_string(),
+        ));
+    }
+
+    // deployed_at timestamp is required
+    if deployment.deployed_at.is_none() {
+        return Err(ValidationError::MissingField("deployed_at".to_string()));
+    }
+
+    // deployed_by is required
+    if deployment.deployed_by.is_empty() {
+        return Err(ValidationError::MissingField("deployed_by".to_string()));
+    }
+
+    Ok(())
+}
+
+/// Validate a ModelDeploymentStatus message
+///
+/// Validates:
+/// - deployment_id is present
+/// - platform_id is present
+/// - state is specified (not unspecified)
+/// - progress_percent is in valid range (0-100)
+/// - updated_at timestamp is present
+/// - If state is FAILED, error_message is present
+/// - If state is COMPLETE or VERIFYING, downloaded_hash is present and valid
+pub fn validate_model_deployment_status(status: &ModelDeploymentStatus) -> ValidationResult<()> {
+    // Check required fields
+    if status.deployment_id.is_empty() {
+        return Err(ValidationError::MissingField("deployment_id".to_string()));
+    }
+
+    if status.platform_id.is_empty() {
+        return Err(ValidationError::MissingField("platform_id".to_string()));
+    }
+
+    // State must be specified
+    if status.state == DeploymentState::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "state must be specified".to_string(),
+        ));
+    }
+
+    // Progress must be 0-100
+    if status.progress_percent > 100 {
+        return Err(ValidationError::InvalidValue(format!(
+            "progress_percent {} must be between 0 and 100",
+            status.progress_percent
+        )));
+    }
+
+    // updated_at is required
+    if status.updated_at.is_none() {
+        return Err(ValidationError::MissingField("updated_at".to_string()));
+    }
+
+    // If state is FAILED, error_message must be present
+    if status.state == DeploymentState::Failed as i32 && status.error_message.is_empty() {
+        return Err(ValidationError::MissingField(
+            "error_message (required when state is FAILED)".to_string(),
+        ));
+    }
+
+    // If state is COMPLETE or VERIFYING, downloaded_hash should be present
+    if (status.state == DeploymentState::Complete as i32
+        || status.state == DeploymentState::Verifying as i32)
+        && status.downloaded_hash.is_empty()
+    {
+        return Err(ValidationError::MissingField(
+            "downloaded_hash (required for COMPLETE or VERIFYING state)".to_string(),
+        ));
+    }
+
+    // Validate downloaded_hash format if present
+    if !status.downloaded_hash.is_empty() {
+        if status.downloaded_hash.len() != 64 {
+            return Err(ValidationError::InvalidValue(format!(
+                "downloaded_hash must be 64 hex characters, got {}",
+                status.downloaded_hash.len()
+            )));
+        }
+
+        if !status
+            .downloaded_hash
+            .chars()
+            .all(|c| c.is_ascii_hexdigit())
+        {
+            return Err(ValidationError::InvalidValue(
+                "downloaded_hash must contain only hex characters".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -753,6 +953,222 @@ mod tests {
             cmd.command_type = None;
             let err = validate_hierarchical_command(&cmd).unwrap_err();
             assert!(matches!(err, ValidationError::MissingField(f) if f == "command_type"));
+        }
+    }
+
+    mod model_deployment_tests {
+        use super::*;
+        use crate::common::v1::Timestamp;
+
+        fn valid_model_deployment() -> ModelDeployment {
+            ModelDeployment {
+                deployment_id: "deploy-2025-001".to_string(),
+                model_id: "yolov8-poi-v2.1".to_string(),
+                model_version: "2.1.0".to_string(),
+                model_type: ModelType::Detector as i32,
+                model_url: "https://models.example.com/yolov8-poi-v2.1.onnx".to_string(),
+                checksum_sha256: "a".repeat(64), // Valid SHA256 hex
+                file_size_bytes: 45_000_000,
+                target_platforms: vec!["Alpha-3".to_string(), "Bravo-1".to_string()],
+                deployment_policy: DeploymentPolicy::Rolling as i32,
+                priority: DeploymentPriority::Normal as i32,
+                deployed_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                deployed_by: "MLOps-Pipeline".to_string(),
+                rollback_model_id: String::new(),
+                metadata: None,
+            }
+        }
+
+        #[test]
+        fn test_valid_model_deployment() {
+            let deployment = valid_model_deployment();
+            assert!(validate_model_deployment(&deployment).is_ok());
+        }
+
+        #[test]
+        fn test_missing_deployment_id() {
+            let mut deployment = valid_model_deployment();
+            deployment.deployment_id = String::new();
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "deployment_id"));
+        }
+
+        #[test]
+        fn test_missing_model_id() {
+            let mut deployment = valid_model_deployment();
+            deployment.model_id = String::new();
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "model_id"));
+        }
+
+        #[test]
+        fn test_unspecified_model_type() {
+            let mut deployment = valid_model_deployment();
+            deployment.model_type = ModelType::Unspecified as i32;
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_invalid_model_url() {
+            let mut deployment = valid_model_deployment();
+            deployment.model_url = "not-a-valid-url".to_string();
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_invalid_checksum_length() {
+            let mut deployment = valid_model_deployment();
+            deployment.checksum_sha256 = "abc123".to_string(); // Too short
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_invalid_checksum_chars() {
+            let mut deployment = valid_model_deployment();
+            deployment.checksum_sha256 = "g".repeat(64); // 'g' is not hex
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_zero_file_size() {
+            let mut deployment = valid_model_deployment();
+            deployment.file_size_bytes = 0;
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_empty_target_platforms() {
+            let mut deployment = valid_model_deployment();
+            deployment.target_platforms = vec![];
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(_)));
+        }
+
+        #[test]
+        fn test_unspecified_deployment_policy() {
+            let mut deployment = valid_model_deployment();
+            deployment.deployment_policy = DeploymentPolicy::Unspecified as i32;
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_missing_deployed_at() {
+            let mut deployment = valid_model_deployment();
+            deployment.deployed_at = None;
+            let err = validate_model_deployment(&deployment).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "deployed_at"));
+        }
+    }
+
+    mod model_deployment_status_tests {
+        use super::*;
+        use crate::common::v1::Timestamp;
+
+        fn valid_deployment_status() -> ModelDeploymentStatus {
+            ModelDeploymentStatus {
+                deployment_id: "deploy-2025-001".to_string(),
+                platform_id: "Alpha-3".to_string(),
+                state: DeploymentState::Downloading as i32,
+                progress_percent: 45,
+                error_message: String::new(),
+                updated_at: Some(Timestamp {
+                    seconds: 1702000100,
+                    nanos: 0,
+                }),
+                downloaded_hash: String::new(),
+                previous_version: "2.0.0".to_string(),
+            }
+        }
+
+        #[test]
+        fn test_valid_deployment_status() {
+            let status = valid_deployment_status();
+            assert!(validate_model_deployment_status(&status).is_ok());
+        }
+
+        #[test]
+        fn test_missing_deployment_id() {
+            let mut status = valid_deployment_status();
+            status.deployment_id = String::new();
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "deployment_id"));
+        }
+
+        #[test]
+        fn test_missing_platform_id() {
+            let mut status = valid_deployment_status();
+            status.platform_id = String::new();
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "platform_id"));
+        }
+
+        #[test]
+        fn test_unspecified_state() {
+            let mut status = valid_deployment_status();
+            status.state = DeploymentState::Unspecified as i32;
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_invalid_progress_percent() {
+            let mut status = valid_deployment_status();
+            status.progress_percent = 150; // > 100
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_missing_updated_at() {
+            let mut status = valid_deployment_status();
+            status.updated_at = None;
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "updated_at"));
+        }
+
+        #[test]
+        fn test_failed_state_requires_error_message() {
+            let mut status = valid_deployment_status();
+            status.state = DeploymentState::Failed as i32;
+            status.error_message = String::new();
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(_)));
+        }
+
+        #[test]
+        fn test_complete_state_requires_hash() {
+            let mut status = valid_deployment_status();
+            status.state = DeploymentState::Complete as i32;
+            status.downloaded_hash = String::new();
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(_)));
+        }
+
+        #[test]
+        fn test_valid_complete_status() {
+            let mut status = valid_deployment_status();
+            status.state = DeploymentState::Complete as i32;
+            status.downloaded_hash = "a".repeat(64);
+            status.progress_percent = 100;
+            assert!(validate_model_deployment_status(&status).is_ok());
+        }
+
+        #[test]
+        fn test_invalid_downloaded_hash_length() {
+            let mut status = valid_deployment_status();
+            status.state = DeploymentState::Complete as i32;
+            status.downloaded_hash = "abc123".to_string(); // Too short
+            let err = validate_model_deployment_status(&status).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds the ModelDeployment protobuf schema to the core HIVE schema, making AI model deployment part of the open standard
- Implements comprehensive validation functions for model deployment messages
- Adds 21 unit tests for validation coverage

## Motivation

Issue #319 was closed when the ModelFetcher was implemented in hive-inference, but that implementation only added Rust structs in the client code. The HIVE Protocol is designed as an **open standard**, so the schema must be in the core protobuf definitions in `hive-schema`, not just client implementations.

This enables:
- Multi-language code generation (Rust, Python, Java, C++, JavaScript)
- Multi-transport support (HTTP, gRPC, ROS2, WebSocket, MQTT)
- Interoperability between different HIVE implementations

## Changes

### Proto Schema (`hive-schema/proto/model.proto`)
- **ModelDeployment**: Downward flow from C2 to edge platforms
  - Model identification (ID, version, type, URL, checksum)
  - Deployment configuration (policy, priority, target platforms)
  - Model metadata (format, framework, hardware requirements, performance metrics)
- **ModelDeploymentStatus**: Upward flow from platforms to C2
  - State tracking (pending→downloading→verifying→installing→complete/failed)
  - Progress reporting, hash verification, error messages
- **ModelQuery/ModelCatalogResponse**: Query available models

### Validation (`hive-schema/src/validation.rs`)
- `validate_model_deployment()`: Required fields, URL format, SHA256 checksum format
- `validate_model_deployment_status()`: State-specific requirements, progress range

## Test plan

- [x] `cargo build --package hive-schema` compiles successfully
- [x] `cargo test --package hive-schema` - 54 tests pass (21 new)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)