### PR TITLE
test(inference): Add TAK integration E2E tests (Issue #330)

### DIFF
--- a/hive-inference/tests/tak_integration.rs
+++ b/hive-inference/tests/tak_integration.rs
@@ -239,6 +239,7 @@ async fn test_capability_sync_between_nodes() {
 async fn test_detection_to_track_flow() {
     use hive_inference::inference::BoundingBox;
     use hive_inference::inference::GroundTruthObject;
+    use hive_inference::inference::SimulatedDetectorConfig;
 
     let _ = tracing_subscriber::fmt()
         .with_env_filter("info")
@@ -248,7 +249,13 @@ async fn test_detection_to_track_flow() {
     println!("=== Test: Detection → Track Flow ===");
 
     // Create inference pipeline with simulated detector/tracker
-    let mut detector = SimulatedDetector::default_config();
+    // Use high recall config to ensure deterministic detection
+    let detector_config = SimulatedDetectorConfig {
+        recall: 1.0,              // Always detect (deterministic for test)
+        false_positive_rate: 0.0, // No false positives
+        ..Default::default()
+    };
+    let mut detector = SimulatedDetector::new(detector_config);
 
     // Add ground truth objects for the detector to find
     // GroundTruthObject::new(id, bbox, class_label, class_id)


### PR DESCRIPTION
## Summary
- Add comprehensive end-to-end integration tests for the Jetson → HIVE → TAK pipeline
- 9 tests covering all major integration points:
  1. **Capability Advertisement Flow** - Beacon generates and syncs capability advertisements
  2. **Capability Sync Between Nodes** - CRDT sync verification between Jetson and Bridge
  3. **Detection → Track Flow** - Simulated detector/tracker pipeline processing
  4. **Track Sync to C2** - Track updates sync from edge to command
  5. **Chipout Extraction** - Detection-triggered image extraction
  6. **Mission Tasking (TAK → Jetson)** - C2 mission tasks flow to edge nodes
  7. **Model Deployment** - C2 deployment directives via OrchestrationService
  8. **Model Deployment with Sync** - Full sync flow for deployment directives
  9. **Performance Metrics** - FPS and latency validation

## Test Coverage
Tests validate:
- Full CRDT sync between Jetson and C2/Bridge nodes
- Track update format and latency requirements (<500ms publish, <5s E2E)
- Model deployment via OrchestrationService with simulated adapters
- Performance metrics collection and reporting

All tests use simulated components but exercise the full message flow and sync protocol.

## Test plan
- [x] All 9 tak_integration tests pass
- [x] Existing hive-inference tests still pass (195 unit + 9 E2E)
- [x] clippy passes
- [x] Code formatted

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)