### PR TITLE
feat(schema): Add actuator.proto for platform actuator specifications

### DIFF
--- a/hive-schema/build.rs
+++ b/hive-schema/build.rs
@@ -16,6 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/track.proto",
         "proto/model.proto",
         "proto/sensor.proto",
+        "proto/actuator.proto",
     ];
 
     // Configure prost to generate Rust code from .proto files

--- a/hive-schema/proto/actuator.proto
+++ b/hive-schema/proto/actuator.proto
@@ -1,0 +1,472 @@
+// Actuator definitions for CAP Protocol
+// Version: 1.0.0
+//
+// This module defines actuator specifications for platform control systems.
+// Actuators include linear/rotary motors, grippers, valves, and other
+// controlled mechanisms. Relevant for port operations (gates, barriers, cranes),
+// robotic systems, and weapon/effector interfaces.
+
+syntax = "proto3";
+
+package cap.actuator.v1;
+
+import "common.proto";
+
+// ============================================================================
+// Actuator Types
+// ============================================================================
+
+// Primary classification of actuator mechanism
+enum ActuatorType {
+  ACTUATOR_TYPE_UNSPECIFIED = 0;
+
+  // Linear motion actuator (single axis translation)
+  // Examples: hydraulic cylinders, ball screws, linear motors
+  ACTUATOR_TYPE_LINEAR = 1;
+
+  // Rotary motion actuator (single axis rotation)
+  // Examples: servo motors, stepper motors, hydraulic rotary actuators
+  ACTUATOR_TYPE_ROTARY = 2;
+
+  // Multi-axis articulated system
+  // Examples: robotic arms, crane jibs, manipulators
+  ACTUATOR_TYPE_ARTICULATED = 3;
+
+  // Gripping/clamping mechanism
+  // Examples: robotic grippers, cargo clamps, magnetic lifters
+  ACTUATOR_TYPE_GRIPPER = 4;
+
+  // Valve or flow control
+  // Examples: hydraulic valves, gate valves, ball valves
+  ACTUATOR_TYPE_VALVE = 5;
+
+  // Barrier or gate mechanism
+  // Examples: boom barriers, rolling gates, security doors
+  ACTUATOR_TYPE_BARRIER = 6;
+
+  // Locking mechanism
+  // Examples: electronic locks, latches, deadbolts
+  ACTUATOR_TYPE_LOCK = 7;
+
+  // Winch or cable system
+  // Examples: crane hoists, tow winches, cable reels
+  ACTUATOR_TYPE_WINCH = 8;
+
+  // Continuous track or conveyor
+  // Examples: conveyor belts, tracked vehicles, escalators
+  ACTUATOR_TYPE_CONVEYOR = 9;
+}
+
+// ============================================================================
+// Actuator Mount and Installation
+// ============================================================================
+
+// How the actuator is mounted/installed
+enum ActuatorMount {
+  ACTUATOR_MOUNT_UNSPECIFIED = 0;
+
+  // Permanently fixed to structure or platform
+  ACTUATOR_MOUNT_FIXED = 1;
+
+  // On an articulated base (can be repositioned)
+  ACTUATOR_MOUNT_ARTICULATED = 2;
+
+  // Portable/deployable unit
+  ACTUATOR_MOUNT_PORTABLE = 3;
+
+  // Vehicle-mounted
+  ACTUATOR_MOUNT_VEHICLE = 4;
+}
+
+// Power/drive system type
+enum ActuatorDrive {
+  ACTUATOR_DRIVE_UNSPECIFIED = 0;
+
+  // Electric motor (DC or AC)
+  ACTUATOR_DRIVE_ELECTRIC = 1;
+
+  // Hydraulic (oil pressure)
+  ACTUATOR_DRIVE_HYDRAULIC = 2;
+
+  // Pneumatic (air pressure)
+  ACTUATOR_DRIVE_PNEUMATIC = 3;
+
+  // Manual (human-powered)
+  ACTUATOR_DRIVE_MANUAL = 4;
+
+  // Hybrid (multiple systems)
+  ACTUATOR_DRIVE_HYBRID = 5;
+}
+
+// ============================================================================
+// Motion Limits and Capabilities
+// ============================================================================
+
+// Linear actuator limits (single axis translation)
+message LinearLimits {
+  // Position range (meters from home/retracted position)
+  float position_min_m = 1;
+  float position_max_m = 2;
+
+  // Maximum velocity (meters per second)
+  float velocity_max_mps = 3;
+
+  // Maximum acceleration (meters per second squared)
+  float acceleration_max = 4;
+
+  // Maximum force/thrust (Newtons)
+  float force_max_n = 5;
+}
+
+// Rotary actuator limits (single axis rotation)
+message RotaryLimits {
+  // Angle range (degrees)
+  // Continuous rotation: -180 to +180 or 0 to 360
+  float angle_min_deg = 1;
+  float angle_max_deg = 2;
+
+  // Maximum angular velocity (degrees per second)
+  float velocity_max_dps = 3;
+
+  // Maximum angular acceleration (degrees per second squared)
+  float acceleration_max = 4;
+
+  // Maximum torque (Newton-meters)
+  float torque_max_nm = 5;
+
+  // Whether continuous rotation is supported
+  bool continuous_rotation = 6;
+}
+
+// Gripper limits
+message GripperLimits {
+  // Opening range (meters between grip surfaces)
+  float aperture_min_m = 1;
+  float aperture_max_m = 2;
+
+  // Maximum grip force (Newtons)
+  float grip_force_max_n = 3;
+
+  // Maximum payload weight (kg)
+  float payload_max_kg = 4;
+}
+
+// Valve limits
+message ValveLimits {
+  // Opening range (0.0 = closed, 1.0 = fully open)
+  float position_min = 1;
+  float position_max = 2;
+
+  // Actuation time (seconds for full travel)
+  float full_travel_time_s = 3;
+
+  // Maximum flow rate (application-specific units in metadata)
+  float flow_rate_max = 4;
+
+  // Maximum pressure rating (Pascals or application-specific)
+  float pressure_max_pa = 5;
+}
+
+// Barrier/gate limits
+message BarrierLimits {
+  // Opening range (0.0 = closed, 1.0 = fully open)
+  float position_min = 1;
+  float position_max = 2;
+
+  // Operation time (seconds for full open/close)
+  float full_cycle_time_s = 3;
+
+  // Clear width when open (meters)
+  float clear_width_m = 4;
+
+  // Clear height when open (meters)
+  float clear_height_m = 5;
+}
+
+// Winch limits
+message WinchLimits {
+  // Cable length range (meters)
+  float cable_min_m = 1;
+  float cable_max_m = 2;
+
+  // Maximum line speed (meters per second)
+  float line_speed_max_mps = 3;
+
+  // Maximum line tension (Newtons)
+  float tension_max_n = 4;
+
+  // Maximum payload (kg at max cable length)
+  float payload_max_kg = 5;
+}
+
+// ============================================================================
+// Current State
+// ============================================================================
+
+// Linear actuator state
+message LinearState {
+  // Current position (meters from home)
+  float position_m = 1;
+
+  // Current velocity (meters per second)
+  float velocity_mps = 2;
+
+  // Current force (Newtons, positive = extending)
+  float force_n = 3;
+}
+
+// Rotary actuator state
+message RotaryState {
+  // Current angle (degrees)
+  float angle_deg = 1;
+
+  // Current angular velocity (degrees per second)
+  float velocity_dps = 2;
+
+  // Current torque (Newton-meters)
+  float torque_nm = 3;
+}
+
+// Gripper state
+message GripperState {
+  // Current aperture (meters between grip surfaces)
+  float aperture_m = 1;
+
+  // Current grip force (Newtons)
+  float grip_force_n = 2;
+
+  // Whether object is detected in gripper
+  bool object_detected = 3;
+
+  // Estimated payload weight (kg, if load cell available)
+  float payload_kg = 4;
+}
+
+// Valve state
+message ValveState {
+  // Current position (0.0 = closed, 1.0 = fully open)
+  float position = 1;
+
+  // Current flow rate (application-specific units)
+  float flow_rate = 2;
+
+  // Current pressure (Pascals)
+  float pressure_pa = 3;
+}
+
+// Barrier/gate state
+message BarrierState {
+  // Current position (0.0 = closed, 1.0 = fully open)
+  float position = 1;
+
+  // Whether fully closed
+  bool is_closed = 2;
+
+  // Whether fully open
+  bool is_open = 3;
+
+  // Whether obstruction detected
+  bool obstruction_detected = 4;
+}
+
+// Winch state
+message WinchState {
+  // Current cable out (meters)
+  float cable_out_m = 1;
+
+  // Current line speed (meters per second, positive = paying out)
+  float line_speed_mps = 2;
+
+  // Current line tension (Newtons)
+  float tension_n = 3;
+
+  // Estimated payload (kg)
+  float payload_kg = 4;
+}
+
+// Lock state
+message LockState {
+  // Whether lock is engaged
+  bool is_locked = 1;
+
+  // Whether bolt is fully extended
+  bool bolt_extended = 2;
+
+  // Last unlock time
+  common.v1.Timestamp last_unlock_time = 3;
+
+  // Last lock time
+  common.v1.Timestamp last_lock_time = 4;
+}
+
+// ============================================================================
+// Complete Actuator Specification
+// ============================================================================
+
+// Complete actuator specification
+message ActuatorSpec {
+  // Unique actuator identifier within the platform
+  // Format: lowercase alphanumeric with hyphens, e.g., "gate-main", "crane-hoist"
+  string actuator_id = 1;
+
+  // Human-readable name
+  // e.g., "Main Entry Gate", "Container Crane Hoist", "Forward Lock"
+  string name = 2;
+
+  // Primary actuator type
+  ActuatorType actuator_type = 3;
+
+  // Mount/installation type
+  ActuatorMount mount = 4;
+
+  // Drive system type
+  ActuatorDrive drive = 5;
+
+  // Type-specific limits (one of)
+  oneof limits {
+    LinearLimits linear_limits = 10;
+    RotaryLimits rotary_limits = 11;
+    GripperLimits gripper_limits = 12;
+    ValveLimits valve_limits = 13;
+    BarrierLimits barrier_limits = 14;
+    WinchLimits winch_limits = 15;
+  }
+
+  // Type-specific current state (one of)
+  oneof state {
+    LinearState linear_state = 20;
+    RotaryState rotary_state = 21;
+    GripperState gripper_state = 22;
+    ValveState valve_state = 23;
+    BarrierState barrier_state = 24;
+    WinchState winch_state = 25;
+    LockState lock_state = 26;
+  }
+
+  // Timestamp of last state update
+  common.v1.Timestamp updated_at = 30;
+
+  // Additional metadata (JSON format for extensibility)
+  // Can include manufacturer info, maintenance schedules, etc.
+  string metadata_json = 31;
+}
+
+// ============================================================================
+// Actuator Status and Events
+// ============================================================================
+
+// Operational status of actuator
+enum ActuatorStatus {
+  ACTUATOR_STATUS_UNSPECIFIED = 0;
+  ACTUATOR_STATUS_OPERATIONAL = 1;    // Normal operation
+  ACTUATOR_STATUS_MOVING = 2;         // Currently in motion
+  ACTUATOR_STATUS_HOLDING = 3;        // Holding position under load
+  ACTUATOR_STATUS_STALLED = 4;        // Motion blocked/overloaded
+  ACTUATOR_STATUS_FAULT = 5;          // Error condition
+  ACTUATOR_STATUS_EMERGENCY_STOP = 6; // E-stop activated
+  ACTUATOR_STATUS_DISABLED = 7;       // Disabled by operator
+  ACTUATOR_STATUS_CALIBRATING = 8;    // Calibration in progress
+  ACTUATOR_STATUS_OFFLINE = 9;        // Not available
+}
+
+// Actuator state update message (flows upward with capability advertisements)
+message ActuatorStateUpdate {
+  // Platform this actuator belongs to
+  string platform_id = 1;
+
+  // Actuator specification with current state
+  ActuatorSpec actuator = 2;
+
+  // Current operational status
+  ActuatorStatus status = 3;
+
+  // Timestamp of this update
+  common.v1.Timestamp timestamp = 4;
+}
+
+// ============================================================================
+// Actuator Commands
+// ============================================================================
+
+// Command type for actuator control
+enum ActuatorCommandType {
+  ACTUATOR_COMMAND_UNSPECIFIED = 0;
+
+  // Move to target position
+  ACTUATOR_COMMAND_MOVE_TO = 1;
+
+  // Move at specified velocity
+  ACTUATOR_COMMAND_MOVE_VELOCITY = 2;
+
+  // Stop motion (controlled deceleration)
+  ACTUATOR_COMMAND_STOP = 3;
+
+  // Emergency stop (immediate halt)
+  ACTUATOR_COMMAND_EMERGENCY_STOP = 4;
+
+  // Return to home/default position
+  ACTUATOR_COMMAND_HOME = 5;
+
+  // Engage/close (for grippers, locks, barriers)
+  ACTUATOR_COMMAND_ENGAGE = 6;
+
+  // Disengage/open (for grippers, locks, barriers)
+  ACTUATOR_COMMAND_DISENGAGE = 7;
+
+  // Hold current position
+  ACTUATOR_COMMAND_HOLD = 8;
+
+  // Release/free motion (disable holding)
+  ACTUATOR_COMMAND_RELEASE = 9;
+}
+
+// Command message for actuator control (flows downward from C2)
+message ActuatorCommand {
+  // Command identifier
+  string command_id = 1;
+
+  // Target platform
+  string platform_id = 2;
+
+  // Target actuator
+  string actuator_id = 3;
+
+  // Command type
+  ActuatorCommandType command_type = 4;
+
+  // Target position (for MOVE_TO, type-specific interpretation)
+  float target_position = 5;
+
+  // Target velocity (for MOVE_VELOCITY, type-specific interpretation)
+  float target_velocity = 6;
+
+  // Priority level (higher = more urgent)
+  int32 priority = 7;
+
+  // Command originator
+  string issued_by = 8;
+
+  // Timestamp when command was issued
+  common.v1.Timestamp issued_at = 9;
+
+  // Optional expiry time (command ignored if received after)
+  common.v1.Timestamp expires_at = 10;
+}
+
+// Command acknowledgment
+message ActuatorCommandAck {
+  // Original command ID
+  string command_id = 1;
+
+  // Whether command was accepted
+  bool accepted = 2;
+
+  // Reason if rejected
+  string rejection_reason = 3;
+
+  // Estimated completion time (if accepted)
+  common.v1.Timestamp estimated_completion = 4;
+
+  // Timestamp of acknowledgment
+  common.v1.Timestamp acknowledged_at = 5;
+}

--- a/hive-schema/src/lib.rs
+++ b/hive-schema/src/lib.rs
@@ -27,6 +27,7 @@
 //! - **`composition.v1`**: Capability composition rules (additive, emergent, redundant, constraint)
 //! - **`model.v1`**: AI model deployment and distribution
 //! - **`sensor.v1`**: Sensor specifications (mount types, orientation, FOV, gimbal state)
+//! - **`actuator.v1`**: Actuator specifications (linear, rotary, gripper, barrier, winch)
 //!
 //! ## Three-Tier Hierarchy
 //!
@@ -137,6 +138,13 @@ pub mod cap {
     pub mod sensor {
         pub mod v1 {
             include!(concat!(env!("OUT_DIR"), "/cap.sensor.v1.rs"));
+        }
+    }
+
+    #[allow(clippy::enum_variant_names)]
+    pub mod actuator {
+        pub mod v1 {
+            include!(concat!(env!("OUT_DIR"), "/cap.actuator.v1.rs"));
         }
     }
 }

--- a/hive-schema/src/validation.rs
+++ b/hive-schema/src/validation.rs
@@ -6,6 +6,12 @@
 //! - Semantic constraints are satisfied
 //! - CRDT invariants are maintained
 
+use crate::actuator::v1::{
+    ActuatorCommand, ActuatorCommandType, ActuatorMount, ActuatorSpec, ActuatorStateUpdate,
+    ActuatorStatus, ActuatorType, BarrierLimits, BarrierState, GripperLimits, GripperState,
+    LinearLimits, LinearState, LockState, RotaryLimits, RotaryState, ValveLimits, ValveState,
+    WinchLimits, WinchState,
+};
 use crate::capability::v1::{
     Capability, CapabilityAdvertisement, OperationalStatus, ResourceStatus,
 };
@@ -884,6 +890,519 @@ pub fn validate_sensor_state_update(update: &SensorStateUpdate) -> ValidationRes
     Ok(())
 }
 
+// ============================================================================
+// Actuator Validators
+// ============================================================================
+
+/// Validate linear actuator limits
+///
+/// Validates:
+/// - position_min <= position_max
+/// - velocity_max is non-negative
+/// - force_max is non-negative
+pub fn validate_linear_limits(limits: &LinearLimits) -> ValidationResult<()> {
+    if limits.position_min_m > limits.position_max_m {
+        return Err(ValidationError::ConstraintViolation(
+            "position_min_m must be <= position_max_m".to_string(),
+        ));
+    }
+
+    if limits.velocity_max_mps < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "velocity_max_mps must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.force_max_n < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "force_max_n must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate rotary actuator limits
+///
+/// Validates:
+/// - angle_min <= angle_max
+/// - velocity_max is non-negative
+/// - torque_max is non-negative
+pub fn validate_rotary_limits(limits: &RotaryLimits) -> ValidationResult<()> {
+    // For continuous rotation, min/max might be equal (e.g., both 0 for unlimited)
+    if !limits.continuous_rotation && limits.angle_min_deg > limits.angle_max_deg {
+        return Err(ValidationError::ConstraintViolation(
+            "angle_min_deg must be <= angle_max_deg for non-continuous rotation".to_string(),
+        ));
+    }
+
+    if limits.velocity_max_dps < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "velocity_max_dps must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.torque_max_nm < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "torque_max_nm must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate gripper limits
+///
+/// Validates:
+/// - aperture_min <= aperture_max
+/// - aperture values are non-negative
+/// - grip_force_max is non-negative
+/// - payload_max is non-negative
+pub fn validate_gripper_limits(limits: &GripperLimits) -> ValidationResult<()> {
+    if limits.aperture_min_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "aperture_min_m must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.aperture_min_m > limits.aperture_max_m {
+        return Err(ValidationError::ConstraintViolation(
+            "aperture_min_m must be <= aperture_max_m".to_string(),
+        ));
+    }
+
+    if limits.grip_force_max_n < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "grip_force_max_n must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.payload_max_kg < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "payload_max_kg must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate valve limits
+///
+/// Validates:
+/// - position values are in [0.0, 1.0]
+/// - position_min <= position_max
+/// - travel time is positive
+pub fn validate_valve_limits(limits: &ValveLimits) -> ValidationResult<()> {
+    if limits.position_min < 0.0 || limits.position_min > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "position_min {} must be in range [0.0, 1.0]",
+            limits.position_min
+        )));
+    }
+
+    if limits.position_max < 0.0 || limits.position_max > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "position_max {} must be in range [0.0, 1.0]",
+            limits.position_max
+        )));
+    }
+
+    if limits.position_min > limits.position_max {
+        return Err(ValidationError::ConstraintViolation(
+            "position_min must be <= position_max".to_string(),
+        ));
+    }
+
+    if limits.full_travel_time_s <= 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "full_travel_time_s must be positive".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate barrier/gate limits
+///
+/// Validates:
+/// - position values are in [0.0, 1.0]
+/// - cycle time is positive
+/// - dimensions are non-negative
+pub fn validate_barrier_limits(limits: &BarrierLimits) -> ValidationResult<()> {
+    if limits.position_min < 0.0 || limits.position_min > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "position_min {} must be in range [0.0, 1.0]",
+            limits.position_min
+        )));
+    }
+
+    if limits.position_max < 0.0 || limits.position_max > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "position_max {} must be in range [0.0, 1.0]",
+            limits.position_max
+        )));
+    }
+
+    if limits.full_cycle_time_s <= 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "full_cycle_time_s must be positive".to_string(),
+        ));
+    }
+
+    if limits.clear_width_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "clear_width_m must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.clear_height_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "clear_height_m must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate winch limits
+///
+/// Validates:
+/// - cable_min <= cable_max
+/// - cable values are non-negative
+/// - speed and tension are non-negative
+pub fn validate_winch_limits(limits: &WinchLimits) -> ValidationResult<()> {
+    if limits.cable_min_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "cable_min_m must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.cable_min_m > limits.cable_max_m {
+        return Err(ValidationError::ConstraintViolation(
+            "cable_min_m must be <= cable_max_m".to_string(),
+        ));
+    }
+
+    if limits.line_speed_max_mps < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "line_speed_max_mps must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.tension_max_n < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "tension_max_n must be non-negative".to_string(),
+        ));
+    }
+
+    if limits.payload_max_kg < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "payload_max_kg must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate linear actuator state against limits
+pub fn validate_linear_state(
+    state: &LinearState,
+    limits: Option<&LinearLimits>,
+) -> ValidationResult<()> {
+    if let Some(limits) = limits {
+        if state.position_m < limits.position_min_m || state.position_m > limits.position_max_m {
+            return Err(ValidationError::ConstraintViolation(format!(
+                "position_m {} must be within limits [{}, {}]",
+                state.position_m, limits.position_min_m, limits.position_max_m
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate rotary actuator state against limits
+pub fn validate_rotary_state(
+    state: &RotaryState,
+    limits: Option<&RotaryLimits>,
+) -> ValidationResult<()> {
+    if let Some(limits) = limits {
+        if !limits.continuous_rotation
+            && (state.angle_deg < limits.angle_min_deg || state.angle_deg > limits.angle_max_deg)
+        {
+            return Err(ValidationError::ConstraintViolation(format!(
+                "angle_deg {} must be within limits [{}, {}]",
+                state.angle_deg, limits.angle_min_deg, limits.angle_max_deg
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate gripper state against limits
+pub fn validate_gripper_state(
+    state: &GripperState,
+    limits: Option<&GripperLimits>,
+) -> ValidationResult<()> {
+    if state.aperture_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "aperture_m must be non-negative".to_string(),
+        ));
+    }
+
+    if let Some(limits) = limits {
+        if state.aperture_m < limits.aperture_min_m || state.aperture_m > limits.aperture_max_m {
+            return Err(ValidationError::ConstraintViolation(format!(
+                "aperture_m {} must be within limits [{}, {}]",
+                state.aperture_m, limits.aperture_min_m, limits.aperture_max_m
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate valve state
+pub fn validate_valve_state(state: &ValveState) -> ValidationResult<()> {
+    if state.position < 0.0 || state.position > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "position {} must be in range [0.0, 1.0]",
+            state.position
+        )));
+    }
+    Ok(())
+}
+
+/// Validate barrier/gate state
+pub fn validate_barrier_state(state: &BarrierState) -> ValidationResult<()> {
+    if state.position < 0.0 || state.position > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "position {} must be in range [0.0, 1.0]",
+            state.position
+        )));
+    }
+
+    // Consistency checks
+    if state.is_closed && state.position > 0.01 {
+        return Err(ValidationError::ConstraintViolation(
+            "is_closed should not be true when position > 0".to_string(),
+        ));
+    }
+
+    if state.is_open && state.position < 0.99 {
+        return Err(ValidationError::ConstraintViolation(
+            "is_open should not be true when position < 1".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate winch state against limits
+pub fn validate_winch_state(
+    state: &WinchState,
+    limits: Option<&WinchLimits>,
+) -> ValidationResult<()> {
+    if state.cable_out_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "cable_out_m must be non-negative".to_string(),
+        ));
+    }
+
+    if let Some(limits) = limits {
+        if state.cable_out_m > limits.cable_max_m {
+            return Err(ValidationError::ConstraintViolation(format!(
+                "cable_out_m {} exceeds max {}",
+                state.cable_out_m, limits.cable_max_m
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate lock state (basic validation - locks have minimal numeric constraints)
+pub fn validate_lock_state(_state: &LockState) -> ValidationResult<()> {
+    // Lock state is mostly boolean - no numeric constraints to validate
+    // Could validate timestamps if needed
+    Ok(())
+}
+
+/// Validate a complete actuator specification
+///
+/// Validates:
+/// - actuator_id is present
+/// - name is present
+/// - actuator_type is specified
+/// - mount is specified
+/// - Type-specific limits are valid if present
+/// - Type-specific state is valid if present
+pub fn validate_actuator_spec(spec: &ActuatorSpec) -> ValidationResult<()> {
+    // Check required fields
+    if spec.actuator_id.is_empty() {
+        return Err(ValidationError::MissingField("actuator_id".to_string()));
+    }
+
+    if spec.name.is_empty() {
+        return Err(ValidationError::MissingField("name".to_string()));
+    }
+
+    // Type must be specified
+    if spec.actuator_type == ActuatorType::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "actuator_type must be specified".to_string(),
+        ));
+    }
+
+    // Mount must be specified
+    if spec.mount == ActuatorMount::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "mount must be specified".to_string(),
+        ));
+    }
+
+    // Validate type-specific limits if present
+    if let Some(ref limits) = spec.limits {
+        use crate::actuator::v1::actuator_spec::Limits;
+        match limits {
+            Limits::LinearLimits(l) => validate_linear_limits(l)?,
+            Limits::RotaryLimits(l) => validate_rotary_limits(l)?,
+            Limits::GripperLimits(l) => validate_gripper_limits(l)?,
+            Limits::ValveLimits(l) => validate_valve_limits(l)?,
+            Limits::BarrierLimits(l) => validate_barrier_limits(l)?,
+            Limits::WinchLimits(l) => validate_winch_limits(l)?,
+        }
+    }
+
+    // Validate type-specific state if present
+    if let Some(ref state) = spec.state {
+        use crate::actuator::v1::actuator_spec::State;
+        match state {
+            State::LinearState(s) => {
+                let limits = spec.limits.as_ref().and_then(|l| {
+                    if let crate::actuator::v1::actuator_spec::Limits::LinearLimits(ll) = l {
+                        Some(ll)
+                    } else {
+                        None
+                    }
+                });
+                validate_linear_state(s, limits)?;
+            }
+            State::RotaryState(s) => {
+                let limits = spec.limits.as_ref().and_then(|l| {
+                    if let crate::actuator::v1::actuator_spec::Limits::RotaryLimits(rl) = l {
+                        Some(rl)
+                    } else {
+                        None
+                    }
+                });
+                validate_rotary_state(s, limits)?;
+            }
+            State::GripperState(s) => {
+                let limits = spec.limits.as_ref().and_then(|l| {
+                    if let crate::actuator::v1::actuator_spec::Limits::GripperLimits(gl) = l {
+                        Some(gl)
+                    } else {
+                        None
+                    }
+                });
+                validate_gripper_state(s, limits)?;
+            }
+            State::ValveState(s) => validate_valve_state(s)?,
+            State::BarrierState(s) => validate_barrier_state(s)?,
+            State::WinchState(s) => {
+                let limits = spec.limits.as_ref().and_then(|l| {
+                    if let crate::actuator::v1::actuator_spec::Limits::WinchLimits(wl) = l {
+                        Some(wl)
+                    } else {
+                        None
+                    }
+                });
+                validate_winch_state(s, limits)?;
+            }
+            State::LockState(s) => validate_lock_state(s)?,
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate an actuator state update message
+///
+/// Validates:
+/// - platform_id is present
+/// - actuator spec is valid
+/// - status is specified
+/// - timestamp is present
+pub fn validate_actuator_state_update(update: &ActuatorStateUpdate) -> ValidationResult<()> {
+    if update.platform_id.is_empty() {
+        return Err(ValidationError::MissingField("platform_id".to_string()));
+    }
+
+    // Actuator spec is required
+    let actuator = update
+        .actuator
+        .as_ref()
+        .ok_or_else(|| ValidationError::MissingField("actuator".to_string()))?;
+    validate_actuator_spec(actuator)?;
+
+    // Status must be specified
+    if update.status == ActuatorStatus::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "status must be specified".to_string(),
+        ));
+    }
+
+    // Timestamp is required
+    if update.timestamp.is_none() {
+        return Err(ValidationError::MissingField("timestamp".to_string()));
+    }
+
+    Ok(())
+}
+
+/// Validate an actuator command
+///
+/// Validates:
+/// - command_id is present
+/// - platform_id is present
+/// - actuator_id is present
+/// - command_type is specified
+/// - issued_at is present
+pub fn validate_actuator_command(cmd: &ActuatorCommand) -> ValidationResult<()> {
+    if cmd.command_id.is_empty() {
+        return Err(ValidationError::MissingField("command_id".to_string()));
+    }
+
+    if cmd.platform_id.is_empty() {
+        return Err(ValidationError::MissingField("platform_id".to_string()));
+    }
+
+    if cmd.actuator_id.is_empty() {
+        return Err(ValidationError::MissingField("actuator_id".to_string()));
+    }
+
+    if cmd.command_type == ActuatorCommandType::ActuatorCommandUnspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "command_type must be specified".to_string(),
+        ));
+    }
+
+    if cmd.issued_at.is_none() {
+        return Err(ValidationError::MissingField("issued_at".to_string()));
+    }
+
+    // If expires_at is set, validate it comes after issued_at
+    if let (Some(issued), Some(expires)) = (&cmd.issued_at, &cmd.expires_at) {
+        if expires.seconds < issued.seconds
+            || (expires.seconds == issued.seconds && expires.nanos < issued.nanos)
+        {
+            return Err(ValidationError::ConstraintViolation(
+                "expires_at must be after issued_at".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1690,6 +2209,310 @@ mod tests {
             };
             let err = validate_sensor_state_update(&update).unwrap_err();
             assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+    }
+
+    mod actuator_spec_tests {
+        use super::*;
+        use crate::actuator::v1::{actuator_spec::Limits, actuator_spec::State, ActuatorDrive};
+        use crate::common::v1::Timestamp;
+
+        fn valid_barrier_actuator() -> ActuatorSpec {
+            ActuatorSpec {
+                actuator_id: "gate-main".to_string(),
+                name: "Main Entry Gate".to_string(),
+                actuator_type: ActuatorType::Barrier as i32,
+                mount: ActuatorMount::Fixed as i32,
+                drive: ActuatorDrive::Electric as i32,
+                limits: Some(Limits::BarrierLimits(BarrierLimits {
+                    position_min: 0.0,
+                    position_max: 1.0,
+                    full_cycle_time_s: 8.0,
+                    clear_width_m: 4.0,
+                    clear_height_m: 2.5,
+                })),
+                state: Some(State::BarrierState(BarrierState {
+                    position: 0.0,
+                    is_closed: true,
+                    is_open: false,
+                    obstruction_detected: false,
+                })),
+                updated_at: None,
+                metadata_json: String::new(),
+            }
+        }
+
+        fn valid_linear_actuator() -> ActuatorSpec {
+            ActuatorSpec {
+                actuator_id: "lift-main".to_string(),
+                name: "Cargo Lift".to_string(),
+                actuator_type: ActuatorType::Linear as i32,
+                mount: ActuatorMount::Fixed as i32,
+                drive: ActuatorDrive::Hydraulic as i32,
+                limits: Some(Limits::LinearLimits(LinearLimits {
+                    position_min_m: 0.0,
+                    position_max_m: 3.0,
+                    velocity_max_mps: 0.5,
+                    acceleration_max: 0.2,
+                    force_max_n: 50000.0,
+                })),
+                state: Some(State::LinearState(LinearState {
+                    position_m: 1.5,
+                    velocity_mps: 0.0,
+                    force_n: 0.0,
+                })),
+                updated_at: None,
+                metadata_json: String::new(),
+            }
+        }
+
+        fn valid_winch_actuator() -> ActuatorSpec {
+            ActuatorSpec {
+                actuator_id: "crane-hoist".to_string(),
+                name: "Container Crane Hoist".to_string(),
+                actuator_type: ActuatorType::Winch as i32,
+                mount: ActuatorMount::Fixed as i32,
+                drive: ActuatorDrive::Electric as i32,
+                limits: Some(Limits::WinchLimits(WinchLimits {
+                    cable_min_m: 0.0,
+                    cable_max_m: 50.0,
+                    line_speed_max_mps: 2.0,
+                    tension_max_n: 500000.0,
+                    payload_max_kg: 40000.0,
+                })),
+                state: Some(State::WinchState(WinchState {
+                    cable_out_m: 25.0,
+                    line_speed_mps: 0.0,
+                    tension_n: 150000.0,
+                    payload_kg: 15000.0,
+                })),
+                updated_at: None,
+                metadata_json: String::new(),
+            }
+        }
+
+        #[test]
+        fn test_valid_barrier_actuator() {
+            let actuator = valid_barrier_actuator();
+            assert!(validate_actuator_spec(&actuator).is_ok());
+        }
+
+        #[test]
+        fn test_valid_linear_actuator() {
+            let actuator = valid_linear_actuator();
+            assert!(validate_actuator_spec(&actuator).is_ok());
+        }
+
+        #[test]
+        fn test_valid_winch_actuator() {
+            let actuator = valid_winch_actuator();
+            assert!(validate_actuator_spec(&actuator).is_ok());
+        }
+
+        #[test]
+        fn test_missing_actuator_id() {
+            let mut actuator = valid_barrier_actuator();
+            actuator.actuator_id = String::new();
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "actuator_id"));
+        }
+
+        #[test]
+        fn test_missing_name() {
+            let mut actuator = valid_barrier_actuator();
+            actuator.name = String::new();
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "name"));
+        }
+
+        #[test]
+        fn test_unspecified_actuator_type() {
+            let mut actuator = valid_barrier_actuator();
+            actuator.actuator_type = ActuatorType::Unspecified as i32;
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_unspecified_mount() {
+            let mut actuator = valid_barrier_actuator();
+            actuator.mount = ActuatorMount::Unspecified as i32;
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_invalid_barrier_position() {
+            let mut actuator = valid_barrier_actuator();
+            actuator.state = Some(State::BarrierState(BarrierState {
+                position: 1.5, // Invalid: > 1.0
+                is_closed: false,
+                is_open: false,
+                obstruction_detected: false,
+            }));
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_barrier_state_consistency() {
+            let mut actuator = valid_barrier_actuator();
+            actuator.state = Some(State::BarrierState(BarrierState {
+                position: 0.5,   // Half open
+                is_closed: true, // Invalid: closed but position > 0
+                is_open: false,
+                obstruction_detected: false,
+            }));
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+
+        #[test]
+        fn test_linear_state_outside_limits() {
+            let mut actuator = valid_linear_actuator();
+            actuator.state = Some(State::LinearState(LinearState {
+                position_m: 5.0, // Outside limits [0, 3]
+                velocity_mps: 0.0,
+                force_n: 0.0,
+            }));
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+
+        #[test]
+        fn test_invalid_linear_limits() {
+            let mut actuator = valid_linear_actuator();
+            actuator.limits = Some(Limits::LinearLimits(LinearLimits {
+                position_min_m: 5.0, // Invalid: min > max
+                position_max_m: 3.0,
+                velocity_max_mps: 0.5,
+                acceleration_max: 0.2,
+                force_max_n: 50000.0,
+            }));
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+
+        #[test]
+        fn test_winch_cable_exceeds_max() {
+            let mut actuator = valid_winch_actuator();
+            actuator.state = Some(State::WinchState(WinchState {
+                cable_out_m: 100.0, // Exceeds max of 50m
+                line_speed_mps: 0.0,
+                tension_n: 0.0,
+                payload_kg: 0.0,
+            }));
+            let err = validate_actuator_spec(&actuator).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+
+        #[test]
+        fn test_valid_actuator_state_update() {
+            let update = ActuatorStateUpdate {
+                platform_id: "PORT-GATE-1".to_string(),
+                actuator: Some(valid_barrier_actuator()),
+                status: ActuatorStatus::Operational as i32,
+                timestamp: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+            };
+            assert!(validate_actuator_state_update(&update).is_ok());
+        }
+
+        #[test]
+        fn test_actuator_update_missing_platform_id() {
+            let update = ActuatorStateUpdate {
+                platform_id: String::new(),
+                actuator: Some(valid_barrier_actuator()),
+                status: ActuatorStatus::Operational as i32,
+                timestamp: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+            };
+            let err = validate_actuator_state_update(&update).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "platform_id"));
+        }
+
+        #[test]
+        fn test_actuator_update_unspecified_status() {
+            let update = ActuatorStateUpdate {
+                platform_id: "PORT-GATE-1".to_string(),
+                actuator: Some(valid_barrier_actuator()),
+                status: ActuatorStatus::Unspecified as i32,
+                timestamp: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+            };
+            let err = validate_actuator_state_update(&update).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_valid_actuator_command() {
+            let cmd = ActuatorCommand {
+                command_id: "CMD-001".to_string(),
+                platform_id: "PORT-GATE-1".to_string(),
+                actuator_id: "gate-main".to_string(),
+                command_type: ActuatorCommandType::ActuatorCommandDisengage as i32,
+                target_position: 1.0,
+                target_velocity: 0.0,
+                priority: 1,
+                issued_by: "operator-1".to_string(),
+                issued_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                expires_at: None,
+            };
+            assert!(validate_actuator_command(&cmd).is_ok());
+        }
+
+        #[test]
+        fn test_command_missing_command_id() {
+            let cmd = ActuatorCommand {
+                command_id: String::new(),
+                platform_id: "PORT-GATE-1".to_string(),
+                actuator_id: "gate-main".to_string(),
+                command_type: ActuatorCommandType::ActuatorCommandDisengage as i32,
+                target_position: 1.0,
+                target_velocity: 0.0,
+                priority: 1,
+                issued_by: "operator-1".to_string(),
+                issued_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                expires_at: None,
+            };
+            let err = validate_actuator_command(&cmd).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "command_id"));
+        }
+
+        #[test]
+        fn test_command_expires_before_issued() {
+            let cmd = ActuatorCommand {
+                command_id: "CMD-001".to_string(),
+                platform_id: "PORT-GATE-1".to_string(),
+                actuator_id: "gate-main".to_string(),
+                command_type: ActuatorCommandType::ActuatorCommandDisengage as i32,
+                target_position: 1.0,
+                target_velocity: 0.0,
+                priority: 1,
+                issued_by: "operator-1".to_string(),
+                issued_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                expires_at: Some(Timestamp {
+                    seconds: 1701000000, // Before issued_at
+                    nanos: 0,
+                }),
+            };
+            let err = validate_actuator_command(&cmd).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds comprehensive actuator schema for port operations and robotic systems
- Supports 9 actuator types: LINEAR, ROTARY, ARTICULATED, GRIPPER, VALVE, BARRIER, LOCK, WINCH, CONVEYOR
- Includes type-specific limits, state, and command messages
- 18 validation functions with 17 tests (83 total tests passing)

## Actuator Types
| Type | Examples |
|------|----------|
| LINEAR | Hydraulic cylinders, ball screws, linear motors |
| ROTARY | Servo motors, stepper motors |
| ARTICULATED | Robotic arms, crane jibs |
| GRIPPER | Robotic grippers, cargo clamps |
| VALVE | Hydraulic/pneumatic valves |
| BARRIER | Boom barriers, rolling gates |
| LOCK | Electronic locks, latches |
| WINCH | Crane hoists, cable reels |
| CONVEYOR | Conveyor belts, tracked systems |

## Key Messages
- `ActuatorSpec`: Complete specification with limits and current state
- `ActuatorStateUpdate`: For capability advertisement updates
- `ActuatorCommand`: Downward command flow (MOVE_TO, ENGAGE, DISENGAGE, etc.)
- `ActuatorCommandAck`: Command acknowledgment

## Port Operations Use Cases
- Gate/barrier control for port access
- Crane hoist control for cargo handling
- Lock management for secure areas
- Valve control for fuel/cargo systems

## Test Plan
- [x] `cargo build --package hive-schema` passes
- [x] `cargo test --package hive-schema` - 83 tests pass
- [x] `cargo clippy --package hive-schema` - no errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)