### PR TITLE
feat(schema): Add effector.proto for weapon/countermeasure specifications

### DIFF
--- a/hive-schema/build.rs
+++ b/hive-schema/build.rs
@@ -17,6 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "proto/model.proto",
         "proto/sensor.proto",
         "proto/actuator.proto",
+        "proto/effector.proto",
     ];
 
     // Configure prost to generate Rust code from .proto files

--- a/hive-schema/proto/effector.proto
+++ b/hive-schema/proto/effector.proto
@@ -1,0 +1,591 @@
+// Effector definitions for CAP Protocol
+// Version: 1.0.0
+//
+// This module defines effector specifications for weapon systems and
+// countermeasures. Effectors represent systems that produce effects on
+// targets, including kinetic weapons, directed energy, electronic warfare,
+// and countermeasures. Effectors contain safety states, authorization
+// chains, ammunition tracking, and ROE compliance.
+//
+// IMPORTANT: This schema is for capability modeling and C2 coordination.
+// Actual weapon control systems require additional safety interlocks
+// and hardened implementations beyond this schema.
+
+syntax = "proto3";
+
+package cap.effector.v1;
+
+import "common.proto";
+
+// ============================================================================
+// Effector Types
+// ============================================================================
+
+// Primary classification of effector system
+enum EffectorType {
+  EFFECTOR_TYPE_UNSPECIFIED = 0;
+
+  // Kinetic weapons - projectile-based
+  // Examples: machine guns, cannons, missiles, rockets
+  EFFECTOR_TYPE_KINETIC = 1;
+
+  // Directed energy weapons
+  // Examples: lasers, high-power microwave (HPM)
+  EFFECTOR_TYPE_DIRECTED_ENERGY = 2;
+
+  // Electronic warfare - jamming/spoofing
+  // Examples: GPS jammers, comm jammers, radar jammers
+  EFFECTOR_TYPE_ELECTRONIC = 3;
+
+  // Obscurants and decoys
+  // Examples: smoke grenades, chaff, flares, decoys
+  EFFECTOR_TYPE_OBSCURANT = 4;
+
+  // Acoustic devices
+  // Examples: LRAD, warning sirens, acoustic hailing
+  EFFECTOR_TYPE_ACOUSTIC = 5;
+
+  // Non-lethal systems
+  // Examples: tasers, flashbang, rubber rounds, dazzlers
+  EFFECTOR_TYPE_NON_LETHAL = 6;
+
+  // Chemical/biological defense (dispensers, not agents)
+  // Examples: riot control dispensers, marker dye
+  EFFECTOR_TYPE_DISPENSER = 7;
+}
+
+// Effector category for ROE and authorization purposes
+enum EffectorCategory {
+  EFFECTOR_CATEGORY_UNSPECIFIED = 0;
+  EFFECTOR_CATEGORY_LETHAL = 1;           // Designed to cause casualties
+  EFFECTOR_CATEGORY_NON_LETHAL = 2;       // Designed to incapacitate
+  EFFECTOR_CATEGORY_DEFENSIVE = 3;        // Countermeasures, self-defense
+  EFFECTOR_CATEGORY_WARNING = 4;          // Warning/deterrent only
+  EFFECTOR_CATEGORY_OBSCURANT = 5;        // Concealment only
+}
+
+// ============================================================================
+// Safety and Arming States
+// ============================================================================
+
+// Weapon safety state - strict state machine
+enum SafetyState {
+  SAFETY_STATE_UNSPECIFIED = 0;
+
+  // Safe - cannot fire, all interlocks engaged
+  // Transition: SAFE -> ARMED requires authorization
+  SAFETY_STATE_SAFE = 1;
+
+  // Armed - ready to engage, safety interlocks disengaged
+  // Transition: ARMED -> READY when firing solution valid
+  SAFETY_STATE_ARMED = 2;
+
+  // Ready - firing solution valid, authorized to engage
+  // Transition: READY -> FIRING on trigger
+  SAFETY_STATE_READY = 3;
+
+  // Firing - currently engaging target
+  // Transition: FIRING -> READY or COOLDOWN after engagement
+  SAFETY_STATE_FIRING = 4;
+
+  // Cooldown - post-firing cooldown period
+  // Transition: COOLDOWN -> ARMED after cooldown complete
+  SAFETY_STATE_COOLDOWN = 5;
+
+  // Fault - safety interlock tripped, requires manual reset
+  // Transition: FAULT -> SAFE requires maintenance action
+  SAFETY_STATE_FAULT = 6;
+
+  // Maintenance - system under maintenance, cannot arm
+  SAFETY_STATE_MAINTENANCE = 7;
+}
+
+// Interlock status for safety systems
+message SafetyInterlocks {
+  // Master arm switch status
+  bool master_arm_enabled = 1;
+
+  // Firing circuit continuity
+  bool firing_circuit_ready = 2;
+
+  // Barrel/muzzle clear
+  bool muzzle_clear = 3;
+
+  // Ammunition feed ready
+  bool feed_ready = 4;
+
+  // Thermal limits OK (for DEW)
+  bool thermal_ok = 5;
+
+  // Authorization received
+  bool authorization_valid = 6;
+
+  // ROE compliance verified
+  bool roe_compliant = 7;
+
+  // Target in valid engagement zone
+  bool engagement_zone_valid = 8;
+
+  // No friendly fire risk detected
+  bool friendly_clear = 9;
+
+  // Human-in-the-loop confirmation received (if required)
+  bool human_confirmed = 10;
+}
+
+// ============================================================================
+// Ammunition and Capacity
+// ============================================================================
+
+// Ammunition/capacity status for kinetic weapons
+message AmmunitionStatus {
+  // Current rounds in ready magazine
+  uint32 rounds_ready = 1;
+
+  // Total rounds available (all magazines)
+  uint32 rounds_total = 2;
+
+  // Magazine capacity
+  uint32 magazine_capacity = 3;
+
+  // Number of full magazines available
+  uint32 magazines_available = 4;
+
+  // Ammunition type loaded (e.g., "7.62 NATO", "APFSDS")
+  string ammunition_type = 5;
+
+  // Reload in progress
+  bool reloading = 6;
+
+  // Estimated time to reload complete (seconds)
+  float reload_time_remaining_s = 7;
+
+  // Jam/malfunction detected
+  bool malfunction = 8;
+
+  // Malfunction description
+  string malfunction_detail = 9;
+}
+
+// Capacity status for directed energy weapons
+message EnergyCapacity {
+  // Current charge level (0.0 - 1.0)
+  float charge_level = 1;
+
+  // Maximum capacity (joules or application-specific)
+  float max_capacity = 2;
+
+  // Current power output capability
+  float power_available_kw = 3;
+
+  // Thermal state (0.0 = cool, 1.0 = thermal limit)
+  float thermal_level = 4;
+
+  // Charging in progress
+  bool charging = 5;
+
+  // Time to full charge (seconds)
+  float charge_time_remaining_s = 6;
+
+  // Shots remaining at current power setting
+  uint32 shots_remaining = 7;
+}
+
+// Capacity status for dispensers (smoke, chaff, flares)
+message DispenserCapacity {
+  // Canisters/units remaining
+  uint32 units_remaining = 1;
+
+  // Total capacity
+  uint32 total_capacity = 2;
+
+  // Unit type (e.g., "M18 Smoke", "MJU-7 Flare")
+  string unit_type = 3;
+
+  // Dispenser ready
+  bool ready = 4;
+}
+
+// ============================================================================
+// Engagement and Targeting
+// ============================================================================
+
+// Current engagement state
+enum EngagementState {
+  ENGAGEMENT_STATE_UNSPECIFIED = 0;
+  ENGAGEMENT_STATE_IDLE = 1;              // No engagement
+  ENGAGEMENT_STATE_TRACKING = 2;          // Tracking target
+  ENGAGEMENT_STATE_SOLUTION_VALID = 3;    // Firing solution computed
+  ENGAGEMENT_STATE_ENGAGING = 4;          // Actively engaging
+  ENGAGEMENT_STATE_ASSESSING = 5;         // Battle damage assessment
+  ENGAGEMENT_STATE_COMPLETE = 6;          // Engagement complete
+}
+
+// Target designation for engagement
+message TargetDesignation {
+  // Target track ID (from track.proto)
+  string target_track_id = 1;
+
+  // Target classification
+  string target_classification = 2;
+
+  // Target position
+  common.v1.Position target_position = 3;
+
+  // Target velocity (if tracking)
+  float target_velocity_mps = 4;
+
+  // Target bearing from effector (degrees)
+  float bearing_deg = 5;
+
+  // Target range (meters)
+  float range_m = 6;
+
+  // Designation source (e.g., "SENSOR-01", "OPERATOR", "C2")
+  string designation_source = 7;
+
+  // Designation timestamp
+  common.v1.Timestamp designated_at = 8;
+}
+
+// Firing solution status
+message FiringSolution {
+  // Solution valid
+  bool valid = 1;
+
+  // Solution quality (0.0 - 1.0)
+  float quality = 2;
+
+  // Predicted hit probability (0.0 - 1.0)
+  float hit_probability = 3;
+
+  // Lead angle computed (degrees)
+  float lead_angle_deg = 4;
+
+  // Elevation adjustment (degrees)
+  float elevation_deg = 5;
+
+  // Time to impact (seconds)
+  float time_to_impact_s = 6;
+
+  // Solution computed at
+  common.v1.Timestamp computed_at = 7;
+
+  // Solution stale after (requires recompute)
+  common.v1.Timestamp valid_until = 8;
+}
+
+// ============================================================================
+// Authorization and ROE
+// ============================================================================
+
+// Authorization level required for engagement
+enum AuthorizationLevel {
+  AUTHORIZATION_LEVEL_UNSPECIFIED = 0;
+
+  // Autonomous - system can engage without human approval
+  // Typically for defensive countermeasures only
+  AUTHORIZATION_LEVEL_AUTONOMOUS = 1;
+
+  // Operator - requires operator confirmation
+  AUTHORIZATION_LEVEL_OPERATOR = 2;
+
+  // Commander - requires cell/squad commander approval
+  AUTHORIZATION_LEVEL_COMMANDER = 3;
+
+  // Higher authority - requires zone/theater approval
+  AUTHORIZATION_LEVEL_HIGHER = 4;
+
+  // Weapons hold - no engagement authorized
+  AUTHORIZATION_LEVEL_HOLD = 5;
+}
+
+// Authorization chain record
+message Authorization {
+  // Authorization ID
+  string authorization_id = 1;
+
+  // Who authorized (operator/commander ID)
+  string authorized_by = 2;
+
+  // Authorization level granted
+  AuthorizationLevel level = 3;
+
+  // When authorized
+  common.v1.Timestamp authorized_at = 4;
+
+  // Authorization expires at
+  common.v1.Timestamp expires_at = 5;
+
+  // Target class authorized (e.g., "hostile_vehicle", "all_hostile")
+  repeated string authorized_target_classes = 6;
+
+  // Geographic constraints (if any)
+  string engagement_zone_id = 7;
+
+  // ROE reference (e.g., "ROE-ALPHA-3")
+  string roe_reference = 8;
+
+  // Special instructions
+  string special_instructions = 9;
+}
+
+// Rules of Engagement status
+message RoeStatus {
+  // Current ROE in effect
+  string roe_id = 1;
+
+  // ROE description
+  string roe_description = 2;
+
+  // Weapons status (FREE, TIGHT, HOLD)
+  string weapons_status = 3;
+
+  // Current engagement authorized
+  bool engagement_authorized = 4;
+
+  // Reason if not authorized
+  string denial_reason = 5;
+
+  // ROE last updated
+  common.v1.Timestamp updated_at = 6;
+}
+
+// ============================================================================
+// Complete Effector Specification
+// ============================================================================
+
+// Complete effector specification
+message EffectorSpec {
+  // Unique effector identifier within the platform
+  // Format: lowercase alphanumeric with hyphens, e.g., "m240-coax", "smoke-l"
+  string effector_id = 1;
+
+  // Human-readable name
+  // e.g., "M240 Coaxial Machine Gun", "Left Smoke Dispenser"
+  string name = 2;
+
+  // Effector type
+  EffectorType effector_type = 3;
+
+  // Effector category for ROE
+  EffectorCategory category = 4;
+
+  // Caliber/type for kinetic (e.g., "7.62x51mm NATO")
+  // Wavelength for DEW (e.g., "1064nm")
+  // Frequency for EW (e.g., "GPS L1")
+  string effector_class = 5;
+
+  // Maximum effective range (meters)
+  float max_range_m = 6;
+
+  // Minimum safe range (meters)
+  float min_range_m = 7;
+
+  // Rate of fire (rounds/min for kinetic, shots/min for DEW)
+  float rate_of_fire = 8;
+
+  // Current safety state
+  SafetyState safety_state = 9;
+
+  // Safety interlock status
+  SafetyInterlocks interlocks = 10;
+
+  // Ammunition/capacity (one of)
+  oneof capacity {
+    AmmunitionStatus ammunition = 15;
+    EnergyCapacity energy = 16;
+    DispenserCapacity dispenser = 17;
+  }
+
+  // Current engagement state
+  EngagementState engagement_state = 20;
+
+  // Current target (if tracking/engaging)
+  TargetDesignation current_target = 21;
+
+  // Current firing solution (if computed)
+  FiringSolution firing_solution = 22;
+
+  // Authorization level required
+  AuthorizationLevel required_authorization = 25;
+
+  // Current authorization (if any)
+  Authorization current_authorization = 26;
+
+  // Current ROE status
+  RoeStatus roe_status = 27;
+
+  // Mount/actuator reference (links to actuator.proto)
+  // e.g., "turret-main" for the turret actuator controlling this effector
+  string mount_actuator_id = 30;
+
+  // Timestamp of last state update
+  common.v1.Timestamp updated_at = 31;
+
+  // Additional metadata (JSON)
+  string metadata_json = 32;
+}
+
+// ============================================================================
+// Effector Status and Events
+// ============================================================================
+
+// Operational status of effector
+enum EffectorStatus {
+  EFFECTOR_STATUS_UNSPECIFIED = 0;
+  EFFECTOR_STATUS_OPERATIONAL = 1;     // Fully operational
+  EFFECTOR_STATUS_DEGRADED = 2;        // Reduced capability
+  EFFECTOR_STATUS_MALFUNCTION = 3;     // Malfunction detected
+  EFFECTOR_STATUS_DEPLETED = 4;        // Out of ammunition/capacity
+  EFFECTOR_STATUS_OFFLINE = 5;         // Not available
+  EFFECTOR_STATUS_MAINTENANCE = 6;     // Under maintenance
+}
+
+// Effector state update message (flows upward with capability advertisements)
+message EffectorStateUpdate {
+  // Platform this effector belongs to
+  string platform_id = 1;
+
+  // Effector specification with current state
+  EffectorSpec effector = 2;
+
+  // Current operational status
+  EffectorStatus status = 3;
+
+  // Timestamp of this update
+  common.v1.Timestamp timestamp = 4;
+}
+
+// ============================================================================
+// Effector Commands (C2 → Platform)
+// ============================================================================
+
+// Command type for effector control
+enum EffectorCommandType {
+  EFFECTOR_COMMAND_UNSPECIFIED = 0;
+
+  // Set to safe (cannot fire)
+  EFFECTOR_COMMAND_SAFE = 1;
+
+  // Arm weapon (enable firing)
+  EFFECTOR_COMMAND_ARM = 2;
+
+  // Designate target
+  EFFECTOR_COMMAND_DESIGNATE = 3;
+
+  // Clear target designation
+  EFFECTOR_COMMAND_CLEAR_TARGET = 4;
+
+  // Engage designated target
+  EFFECTOR_COMMAND_ENGAGE = 5;
+
+  // Cease fire
+  EFFECTOR_COMMAND_CEASE_FIRE = 6;
+
+  // Reload/recharge
+  EFFECTOR_COMMAND_RELOAD = 7;
+
+  // Fire warning (for non-lethal/acoustic)
+  EFFECTOR_COMMAND_WARNING = 8;
+
+  // Deploy countermeasure
+  EFFECTOR_COMMAND_DEPLOY = 9;
+}
+
+// Command message for effector control (flows downward from C2)
+message EffectorCommand {
+  // Command identifier
+  string command_id = 1;
+
+  // Target platform
+  string platform_id = 2;
+
+  // Target effector
+  string effector_id = 3;
+
+  // Command type
+  EffectorCommandType command_type = 4;
+
+  // Target designation (for DESIGNATE/ENGAGE commands)
+  TargetDesignation target = 5;
+
+  // Authorization record (required for ARM/ENGAGE)
+  Authorization authorization = 6;
+
+  // Number of rounds/shots (for ENGAGE)
+  uint32 rounds_authorized = 7;
+
+  // Command originator
+  string issued_by = 8;
+
+  // Priority level
+  int32 priority = 9;
+
+  // Timestamp when command was issued
+  common.v1.Timestamp issued_at = 10;
+
+  // Optional expiry time
+  common.v1.Timestamp expires_at = 11;
+}
+
+// Command acknowledgment
+message EffectorCommandAck {
+  // Original command ID
+  string command_id = 1;
+
+  // Whether command was accepted
+  bool accepted = 2;
+
+  // Reason if rejected
+  string rejection_reason = 3;
+
+  // Current safety state after command
+  SafetyState resulting_state = 4;
+
+  // Timestamp of acknowledgment
+  common.v1.Timestamp acknowledged_at = 5;
+}
+
+// ============================================================================
+// Engagement Record (for audit/logging)
+// ============================================================================
+
+// Record of an engagement (for logging/audit)
+message EngagementRecord {
+  // Unique engagement ID
+  string engagement_id = 1;
+
+  // Platform that engaged
+  string platform_id = 2;
+
+  // Effector used
+  string effector_id = 3;
+
+  // Target information
+  TargetDesignation target = 4;
+
+  // Authorization for this engagement
+  Authorization authorization = 5;
+
+  // Rounds/shots expended
+  uint32 rounds_expended = 6;
+
+  // Engagement start time
+  common.v1.Timestamp started_at = 7;
+
+  // Engagement end time
+  common.v1.Timestamp ended_at = 8;
+
+  // Outcome assessment
+  string outcome = 9;
+
+  // Battle damage assessment
+  string bda = 10;
+
+  // Position at time of engagement
+  common.v1.Position engagement_position = 11;
+
+  // Recording reference (if recorded)
+  string recording_id = 12;
+}

--- a/hive-schema/src/lib.rs
+++ b/hive-schema/src/lib.rs
@@ -28,6 +28,7 @@
 //! - **`model.v1`**: AI model deployment and distribution
 //! - **`sensor.v1`**: Sensor specifications (mount types, orientation, FOV, gimbal state)
 //! - **`actuator.v1`**: Actuator specifications (linear, rotary, gripper, barrier, winch)
+//! - **`effector.v1`**: Effector specifications (weapons, countermeasures, safety, authorization)
 //!
 //! ## Three-Tier Hierarchy
 //!
@@ -145,6 +146,13 @@ pub mod cap {
     pub mod actuator {
         pub mod v1 {
             include!(concat!(env!("OUT_DIR"), "/cap.actuator.v1.rs"));
+        }
+    }
+
+    #[allow(clippy::enum_variant_names)]
+    pub mod effector {
+        pub mod v1 {
+            include!(concat!(env!("OUT_DIR"), "/cap.effector.v1.rs"));
         }
     }
 }

--- a/hive-schema/src/validation.rs
+++ b/hive-schema/src/validation.rs
@@ -17,6 +17,11 @@ use crate::capability::v1::{
 };
 use crate::cell::v1::{CellConfig, CellState};
 use crate::command::v1::HierarchicalCommand;
+use crate::effector::v1::{
+    AmmunitionStatus, Authorization, AuthorizationLevel, EffectorCategory, EffectorCommand,
+    EffectorCommandType, EffectorSpec, EffectorStateUpdate, EffectorStatus, EffectorType,
+    FiringSolution, SafetyInterlocks, TargetDesignation,
+};
 use crate::model::v1::{
     DeploymentPolicy, DeploymentPriority, DeploymentState, ModelDeployment, ModelDeploymentStatus,
     ModelType,
@@ -1403,6 +1408,349 @@ pub fn validate_actuator_command(cmd: &ActuatorCommand) -> ValidationResult<()> 
     Ok(())
 }
 
+// ============================================================================
+// Effector Validators
+// ============================================================================
+
+/// Validate safety interlocks
+///
+/// Validates the safety interlock structure is present and properly formed.
+/// This is a basic validation - actual safety verification requires
+/// hardware-level checks beyond schema validation.
+pub fn validate_safety_interlocks(_interlocks: &SafetyInterlocks) -> ValidationResult<()> {
+    // Safety interlocks are boolean flags - no numeric constraints
+    // The semantic validation (are all required interlocks true for firing?) is
+    // application-level logic, not schema validation
+    Ok(())
+}
+
+/// Validate ammunition status
+///
+/// Validates:
+/// - rounds_ready <= rounds_total
+/// - magazine_capacity > 0 if magazines are used
+/// - reload_time_remaining is non-negative
+pub fn validate_ammunition_status(status: &AmmunitionStatus) -> ValidationResult<()> {
+    if status.rounds_ready > status.rounds_total {
+        return Err(ValidationError::ConstraintViolation(
+            "rounds_ready cannot exceed rounds_total".to_string(),
+        ));
+    }
+
+    if status.magazine_capacity == 0 && status.magazines_available > 0 {
+        return Err(ValidationError::InvalidValue(
+            "magazine_capacity must be > 0 if magazines_available > 0".to_string(),
+        ));
+    }
+
+    if status.reload_time_remaining_s < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "reload_time_remaining_s must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate firing solution
+///
+/// Validates:
+/// - quality is in [0.0, 1.0]
+/// - hit_probability is in [0.0, 1.0]
+/// - time_to_impact is non-negative
+pub fn validate_firing_solution(solution: &FiringSolution) -> ValidationResult<()> {
+    if solution.quality < 0.0 || solution.quality > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "quality {} must be in range [0.0, 1.0]",
+            solution.quality
+        )));
+    }
+
+    if solution.hit_probability < 0.0 || solution.hit_probability > 1.0 {
+        return Err(ValidationError::InvalidValue(format!(
+            "hit_probability {} must be in range [0.0, 1.0]",
+            solution.hit_probability
+        )));
+    }
+
+    if solution.time_to_impact_s < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "time_to_impact_s must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate target designation
+///
+/// Validates:
+/// - target_track_id is present
+/// - range is non-negative
+pub fn validate_target_designation(target: &TargetDesignation) -> ValidationResult<()> {
+    if target.target_track_id.is_empty() {
+        return Err(ValidationError::MissingField("target_track_id".to_string()));
+    }
+
+    if target.range_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "range_m must be non-negative".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Validate authorization record
+///
+/// Validates:
+/// - authorization_id is present
+/// - authorized_by is present
+/// - level is specified
+/// - authorized_at is present
+pub fn validate_authorization(auth: &Authorization) -> ValidationResult<()> {
+    if auth.authorization_id.is_empty() {
+        return Err(ValidationError::MissingField(
+            "authorization_id".to_string(),
+        ));
+    }
+
+    if auth.authorized_by.is_empty() {
+        return Err(ValidationError::MissingField("authorized_by".to_string()));
+    }
+
+    if auth.level == AuthorizationLevel::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "authorization level must be specified".to_string(),
+        ));
+    }
+
+    if auth.authorized_at.is_none() {
+        return Err(ValidationError::MissingField("authorized_at".to_string()));
+    }
+
+    // If expires_at is set, it must be after authorized_at
+    if let (Some(authorized), Some(expires)) = (&auth.authorized_at, &auth.expires_at) {
+        if expires.seconds < authorized.seconds
+            || (expires.seconds == authorized.seconds && expires.nanos < authorized.nanos)
+        {
+            return Err(ValidationError::ConstraintViolation(
+                "expires_at must be after authorized_at".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate a complete effector specification
+///
+/// Validates:
+/// - effector_id is present
+/// - name is present
+/// - effector_type is specified
+/// - category is specified
+/// - max_range >= min_range
+/// - Type-specific capacity is valid if present
+/// - Safety interlocks are present
+pub fn validate_effector_spec(spec: &EffectorSpec) -> ValidationResult<()> {
+    // Check required fields
+    if spec.effector_id.is_empty() {
+        return Err(ValidationError::MissingField("effector_id".to_string()));
+    }
+
+    if spec.name.is_empty() {
+        return Err(ValidationError::MissingField("name".to_string()));
+    }
+
+    // Type must be specified
+    if spec.effector_type == EffectorType::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "effector_type must be specified".to_string(),
+        ));
+    }
+
+    // Category must be specified
+    if spec.category == EffectorCategory::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "category must be specified".to_string(),
+        ));
+    }
+
+    // Range constraints
+    if spec.min_range_m < 0.0 {
+        return Err(ValidationError::InvalidValue(
+            "min_range_m must be non-negative".to_string(),
+        ));
+    }
+
+    if spec.max_range_m < spec.min_range_m {
+        return Err(ValidationError::ConstraintViolation(
+            "max_range_m must be >= min_range_m".to_string(),
+        ));
+    }
+
+    // Validate safety interlocks if present
+    if let Some(ref interlocks) = spec.interlocks {
+        validate_safety_interlocks(interlocks)?;
+    }
+
+    // Validate type-specific capacity
+    if let Some(ref capacity) = spec.capacity {
+        use crate::effector::v1::effector_spec::Capacity;
+        match capacity {
+            Capacity::Ammunition(ammo) => validate_ammunition_status(ammo)?,
+            Capacity::Energy(energy) => {
+                // Energy capacity validation
+                if energy.charge_level < 0.0 || energy.charge_level > 1.0 {
+                    return Err(ValidationError::InvalidValue(format!(
+                        "charge_level {} must be in range [0.0, 1.0]",
+                        energy.charge_level
+                    )));
+                }
+                if energy.thermal_level < 0.0 || energy.thermal_level > 1.0 {
+                    return Err(ValidationError::InvalidValue(format!(
+                        "thermal_level {} must be in range [0.0, 1.0]",
+                        energy.thermal_level
+                    )));
+                }
+            }
+            Capacity::Dispenser(dispenser) => {
+                // Dispenser capacity validation
+                if dispenser.units_remaining > dispenser.total_capacity {
+                    return Err(ValidationError::ConstraintViolation(
+                        "units_remaining cannot exceed total_capacity".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Validate current target if present
+    if let Some(ref target) = spec.current_target {
+        validate_target_designation(target)?;
+    }
+
+    // Validate firing solution if present
+    if let Some(ref solution) = spec.firing_solution {
+        validate_firing_solution(solution)?;
+    }
+
+    // Validate authorization if present
+    if let Some(ref auth) = spec.current_authorization {
+        validate_authorization(auth)?;
+    }
+
+    Ok(())
+}
+
+/// Validate an effector state update message
+///
+/// Validates:
+/// - platform_id is present
+/// - effector spec is valid
+/// - status is specified
+/// - timestamp is present
+pub fn validate_effector_state_update(update: &EffectorStateUpdate) -> ValidationResult<()> {
+    if update.platform_id.is_empty() {
+        return Err(ValidationError::MissingField("platform_id".to_string()));
+    }
+
+    // Effector spec is required
+    let effector = update
+        .effector
+        .as_ref()
+        .ok_or_else(|| ValidationError::MissingField("effector".to_string()))?;
+    validate_effector_spec(effector)?;
+
+    // Status must be specified
+    if update.status == EffectorStatus::Unspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "status must be specified".to_string(),
+        ));
+    }
+
+    // Timestamp is required
+    if update.timestamp.is_none() {
+        return Err(ValidationError::MissingField("timestamp".to_string()));
+    }
+
+    Ok(())
+}
+
+/// Validate an effector command
+///
+/// Validates:
+/// - command_id is present
+/// - platform_id is present
+/// - effector_id is present
+/// - command_type is specified
+/// - issued_at is present
+/// - ARM/ENGAGE commands require authorization
+pub fn validate_effector_command(cmd: &EffectorCommand) -> ValidationResult<()> {
+    if cmd.command_id.is_empty() {
+        return Err(ValidationError::MissingField("command_id".to_string()));
+    }
+
+    if cmd.platform_id.is_empty() {
+        return Err(ValidationError::MissingField("platform_id".to_string()));
+    }
+
+    if cmd.effector_id.is_empty() {
+        return Err(ValidationError::MissingField("effector_id".to_string()));
+    }
+
+    if cmd.command_type == EffectorCommandType::EffectorCommandUnspecified as i32 {
+        return Err(ValidationError::InvalidValue(
+            "command_type must be specified".to_string(),
+        ));
+    }
+
+    if cmd.issued_at.is_none() {
+        return Err(ValidationError::MissingField("issued_at".to_string()));
+    }
+
+    // If expires_at is set, validate it comes after issued_at
+    if let (Some(issued), Some(expires)) = (&cmd.issued_at, &cmd.expires_at) {
+        if expires.seconds < issued.seconds
+            || (expires.seconds == issued.seconds && expires.nanos < issued.nanos)
+        {
+            return Err(ValidationError::ConstraintViolation(
+                "expires_at must be after issued_at".to_string(),
+            ));
+        }
+    }
+
+    // ARM and ENGAGE commands require authorization
+    let requires_auth = cmd.command_type == EffectorCommandType::EffectorCommandArm as i32
+        || cmd.command_type == EffectorCommandType::EffectorCommandEngage as i32;
+
+    if requires_auth && cmd.authorization.is_none() {
+        return Err(ValidationError::MissingField(
+            "authorization (required for ARM/ENGAGE commands)".to_string(),
+        ));
+    }
+
+    // Validate authorization if present
+    if let Some(ref auth) = cmd.authorization {
+        validate_authorization(auth)?;
+    }
+
+    // ENGAGE commands require target designation
+    if cmd.command_type == EffectorCommandType::EffectorCommandEngage as i32 {
+        if cmd.target.is_none() {
+            return Err(ValidationError::MissingField(
+                "target (required for ENGAGE command)".to_string(),
+            ));
+        }
+        if let Some(ref target) = cmd.target {
+            validate_target_designation(target)?;
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2512,6 +2860,345 @@ mod tests {
                 }),
             };
             let err = validate_actuator_command(&cmd).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+    }
+
+    mod effector_spec_tests {
+        use super::*;
+        use crate::common::v1::Timestamp;
+        use crate::effector::v1::{
+            effector_spec::Capacity, DispenserCapacity, EnergyCapacity, EngagementState, RoeStatus,
+            SafetyState,
+        };
+
+        fn valid_kinetic_effector() -> EffectorSpec {
+            EffectorSpec {
+                effector_id: "m240-coax".to_string(),
+                name: "M240 Coaxial Machine Gun".to_string(),
+                effector_type: EffectorType::Kinetic as i32,
+                category: EffectorCategory::Lethal as i32,
+                effector_class: "7.62x51mm NATO".to_string(),
+                max_range_m: 1800.0,
+                min_range_m: 0.0,
+                rate_of_fire: 650.0,
+                safety_state: SafetyState::Safe as i32,
+                interlocks: Some(SafetyInterlocks {
+                    master_arm_enabled: false,
+                    firing_circuit_ready: true,
+                    muzzle_clear: true,
+                    feed_ready: true,
+                    thermal_ok: true,
+                    authorization_valid: false,
+                    roe_compliant: true,
+                    engagement_zone_valid: false,
+                    friendly_clear: true,
+                    human_confirmed: false,
+                }),
+                capacity: Some(Capacity::Ammunition(AmmunitionStatus {
+                    rounds_ready: 200,
+                    rounds_total: 1000,
+                    magazine_capacity: 200,
+                    magazines_available: 5,
+                    ammunition_type: "7.62 NATO Ball".to_string(),
+                    reloading: false,
+                    reload_time_remaining_s: 0.0,
+                    malfunction: false,
+                    malfunction_detail: String::new(),
+                })),
+                engagement_state: EngagementState::Idle as i32,
+                current_target: None,
+                firing_solution: None,
+                required_authorization: AuthorizationLevel::Commander as i32,
+                current_authorization: None,
+                roe_status: Some(RoeStatus {
+                    roe_id: "ROE-ALPHA-3".to_string(),
+                    roe_description: "Weapons tight".to_string(),
+                    weapons_status: "TIGHT".to_string(),
+                    engagement_authorized: false,
+                    denial_reason: String::new(),
+                    updated_at: None,
+                }),
+                mount_actuator_id: "turret-main".to_string(),
+                updated_at: None,
+                metadata_json: String::new(),
+            }
+        }
+
+        fn valid_countermeasure_effector() -> EffectorSpec {
+            EffectorSpec {
+                effector_id: "smoke-l".to_string(),
+                name: "Left Smoke Dispenser".to_string(),
+                effector_type: EffectorType::Obscurant as i32,
+                category: EffectorCategory::Defensive as i32,
+                effector_class: "M18 Smoke".to_string(),
+                max_range_m: 50.0,
+                min_range_m: 5.0,
+                rate_of_fire: 0.0,
+                safety_state: SafetyState::Safe as i32,
+                interlocks: None,
+                capacity: Some(Capacity::Dispenser(DispenserCapacity {
+                    units_remaining: 4,
+                    total_capacity: 4,
+                    unit_type: "M18 Smoke Grenade".to_string(),
+                    ready: true,
+                })),
+                engagement_state: EngagementState::Idle as i32,
+                current_target: None,
+                firing_solution: None,
+                required_authorization: AuthorizationLevel::Operator as i32,
+                current_authorization: None,
+                roe_status: None,
+                mount_actuator_id: String::new(),
+                updated_at: None,
+                metadata_json: String::new(),
+            }
+        }
+
+        #[test]
+        fn test_valid_kinetic_effector() {
+            let effector = valid_kinetic_effector();
+            assert!(validate_effector_spec(&effector).is_ok());
+        }
+
+        #[test]
+        fn test_valid_countermeasure_effector() {
+            let effector = valid_countermeasure_effector();
+            assert!(validate_effector_spec(&effector).is_ok());
+        }
+
+        #[test]
+        fn test_missing_effector_id() {
+            let mut effector = valid_kinetic_effector();
+            effector.effector_id = String::new();
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "effector_id"));
+        }
+
+        #[test]
+        fn test_missing_name() {
+            let mut effector = valid_kinetic_effector();
+            effector.name = String::new();
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "name"));
+        }
+
+        #[test]
+        fn test_unspecified_effector_type() {
+            let mut effector = valid_kinetic_effector();
+            effector.effector_type = EffectorType::Unspecified as i32;
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_unspecified_category() {
+            let mut effector = valid_kinetic_effector();
+            effector.category = EffectorCategory::Unspecified as i32;
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_invalid_range_constraint() {
+            let mut effector = valid_kinetic_effector();
+            effector.min_range_m = 1000.0;
+            effector.max_range_m = 500.0; // max < min
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+
+        #[test]
+        fn test_invalid_ammunition_rounds() {
+            let mut effector = valid_kinetic_effector();
+            effector.capacity = Some(Capacity::Ammunition(AmmunitionStatus {
+                rounds_ready: 500, // > rounds_total
+                rounds_total: 200,
+                magazine_capacity: 100,
+                magazines_available: 2,
+                ammunition_type: "7.62 NATO".to_string(),
+                reloading: false,
+                reload_time_remaining_s: 0.0,
+                malfunction: false,
+                malfunction_detail: String::new(),
+            }));
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+
+        #[test]
+        fn test_invalid_energy_charge_level() {
+            let mut effector = valid_kinetic_effector();
+            effector.capacity = Some(Capacity::Energy(EnergyCapacity {
+                charge_level: 1.5, // > 1.0
+                max_capacity: 1000.0,
+                power_available_kw: 50.0,
+                thermal_level: 0.3,
+                charging: false,
+                charge_time_remaining_s: 0.0,
+                shots_remaining: 10,
+            }));
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_invalid_dispenser_units() {
+            let mut effector = valid_countermeasure_effector();
+            effector.capacity = Some(Capacity::Dispenser(DispenserCapacity {
+                units_remaining: 10, // > total_capacity
+                total_capacity: 4,
+                unit_type: "M18 Smoke".to_string(),
+                ready: true,
+            }));
+            let err = validate_effector_spec(&effector).unwrap_err();
+            assert!(matches!(err, ValidationError::ConstraintViolation(_)));
+        }
+
+        #[test]
+        fn test_valid_effector_state_update() {
+            let update = EffectorStateUpdate {
+                platform_id: "IFV-Alpha-1".to_string(),
+                effector: Some(valid_kinetic_effector()),
+                status: EffectorStatus::Operational as i32,
+                timestamp: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+            };
+            assert!(validate_effector_state_update(&update).is_ok());
+        }
+
+        #[test]
+        fn test_effector_update_missing_platform_id() {
+            let update = EffectorStateUpdate {
+                platform_id: String::new(),
+                effector: Some(valid_kinetic_effector()),
+                status: EffectorStatus::Operational as i32,
+                timestamp: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+            };
+            let err = validate_effector_state_update(&update).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(f) if f == "platform_id"));
+        }
+
+        #[test]
+        fn test_effector_update_unspecified_status() {
+            let update = EffectorStateUpdate {
+                platform_id: "IFV-Alpha-1".to_string(),
+                effector: Some(valid_kinetic_effector()),
+                status: EffectorStatus::Unspecified as i32,
+                timestamp: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+            };
+            let err = validate_effector_state_update(&update).unwrap_err();
+            assert!(matches!(err, ValidationError::InvalidValue(_)));
+        }
+
+        #[test]
+        fn test_valid_safe_command() {
+            let cmd = EffectorCommand {
+                command_id: "CMD-001".to_string(),
+                platform_id: "IFV-Alpha-1".to_string(),
+                effector_id: "m240-coax".to_string(),
+                command_type: EffectorCommandType::EffectorCommandSafe as i32,
+                target: None,
+                authorization: None, // Not required for SAFE command
+                rounds_authorized: 0,
+                issued_by: "operator-1".to_string(),
+                priority: 1,
+                issued_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                expires_at: None,
+            };
+            assert!(validate_effector_command(&cmd).is_ok());
+        }
+
+        #[test]
+        fn test_arm_command_requires_authorization() {
+            let cmd = EffectorCommand {
+                command_id: "CMD-001".to_string(),
+                platform_id: "IFV-Alpha-1".to_string(),
+                effector_id: "m240-coax".to_string(),
+                command_type: EffectorCommandType::EffectorCommandArm as i32,
+                target: None,
+                authorization: None, // Missing - required for ARM
+                rounds_authorized: 0,
+                issued_by: "operator-1".to_string(),
+                priority: 1,
+                issued_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                expires_at: None,
+            };
+            let err = validate_effector_command(&cmd).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(_)));
+        }
+
+        #[test]
+        fn test_engage_command_requires_target() {
+            let cmd = EffectorCommand {
+                command_id: "CMD-001".to_string(),
+                platform_id: "IFV-Alpha-1".to_string(),
+                effector_id: "m240-coax".to_string(),
+                command_type: EffectorCommandType::EffectorCommandEngage as i32,
+                target: None, // Missing - required for ENGAGE
+                authorization: Some(Authorization {
+                    authorization_id: "AUTH-001".to_string(),
+                    authorized_by: "commander-1".to_string(),
+                    level: AuthorizationLevel::Commander as i32,
+                    authorized_at: Some(Timestamp {
+                        seconds: 1702000000,
+                        nanos: 0,
+                    }),
+                    expires_at: None,
+                    authorized_target_classes: vec!["hostile_vehicle".to_string()],
+                    engagement_zone_id: String::new(),
+                    roe_reference: "ROE-ALPHA-3".to_string(),
+                    special_instructions: String::new(),
+                }),
+                rounds_authorized: 50,
+                issued_by: "operator-1".to_string(),
+                priority: 1,
+                issued_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                expires_at: None,
+            };
+            let err = validate_effector_command(&cmd).unwrap_err();
+            assert!(matches!(err, ValidationError::MissingField(_)));
+        }
+
+        #[test]
+        fn test_effector_command_expires_before_issued() {
+            let cmd = EffectorCommand {
+                command_id: "CMD-001".to_string(),
+                platform_id: "IFV-Alpha-1".to_string(),
+                effector_id: "m240-coax".to_string(),
+                command_type: EffectorCommandType::EffectorCommandSafe as i32,
+                target: None,
+                authorization: None,
+                rounds_authorized: 0,
+                issued_by: "operator-1".to_string(),
+                priority: 1,
+                issued_at: Some(Timestamp {
+                    seconds: 1702000000,
+                    nanos: 0,
+                }),
+                expires_at: Some(Timestamp {
+                    seconds: 1701000000, // Before issued_at
+                    nanos: 0,
+                }),
+            };
+            let err = validate_effector_command(&cmd).unwrap_err();
             assert!(matches!(err, ValidationError::ConstraintViolation(_)));
         }
     }


### PR DESCRIPTION
## Summary
- Adds comprehensive effector schema for weapon systems and countermeasures
- Includes safety states, authorization chains, ammunition tracking, and engagement modeling
- Integrates with actuator.proto via `mount_actuator_id` for physical control
- 9 validation functions with 15 tests (80+ total tests passing)

## Effector Types
| Type | Examples |
|------|----------|
| KINETIC | Machine guns, cannons, missiles, rockets |
| DIRECTED_ENERGY | Lasers, high-power microwave |
| ELECTRONIC | GPS/comm/radar jammers |
| OBSCURANT | Smoke, chaff, flares, decoys |
| ACOUSTIC | LRAD, warning sirens |
| NON_LETHAL | Tasers, flashbang, dazzlers |
| DISPENSER | Riot control, marker dye |

## Safety & Authorization
- **SafetyState**: SAFE → ARMED → READY → FIRING → COOLDOWN → FAULT
- **SafetyInterlocks**: 10 checks (master_arm, authorization_valid, roe_compliant, friendly_clear, human_confirmed, etc.)
- **Authorization**: Required for ARM/ENGAGE commands, includes expiry, target classes, ROE reference

## Key Messages
- `EffectorSpec`: Complete specification with safety state, capacity, engagement state
- `EffectorStateUpdate`: For upward capability advertisements
- `EffectorCommand`: Downward C2 control (SAFE, ARM, ENGAGE, CEASE_FIRE, etc.)
- `EngagementRecord`: Audit logging for compliance

## Relationship to Actuator
```
Effector (weapon system)
  └── mount_actuator_id → Actuator (turret/gimbal)
```
Effector handles weapon employment semantics; actuator handles physical aim/positioning.

## Test Plan
- [x] `cargo build --package hive-schema` passes
- [x] `cargo test --package hive-schema` - 80+ tests pass
- [x] `cargo clippy --package hive-schema` - no errors
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)