### PR TITLE
fix(atak): Improve connection status and add global node handle for APK survival

### DIFF
--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveJni.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveJni.kt
@@ -115,6 +115,13 @@ object HiveJni {
     external fun freeNodeJni(handle: Long)
 
     /**
+     * Get the global node handle that survives APK replacement.
+     * @return Handle (pointer) to the HiveNode, or 0 if no node exists
+     */
+    @JvmStatic
+    external fun getGlobalNodeHandleJni(): Long
+
+    /**
      * Get all cells as JSON array string.
      * @param handle Node handle from createNodeJni
      * @return JSON array of cell objects, or "[]" on error
@@ -165,25 +172,57 @@ object HiveJni {
 /**
  * Wrapper class for a HIVE node using JNI.
  * Provides a more idiomatic Kotlin API over the raw JNI functions.
+ *
+ * Uses a global singleton handle that survives APK replacement to avoid
+ * losing the native node connection when the plugin is hot-swapped.
  */
 class HiveNodeJni private constructor(private val handle: Long) : AutoCloseable {
 
     companion object {
         private const val TAG = "HiveNodeJni"
 
+        // Global handle that survives APK replacement
+        // The native node lives in native memory which persists across plugin reloads
+        @Volatile
+        private var globalHandle: Long = 0L
+
+        @Volatile
+        private var globalInstance: HiveNodeJni? = null
+
         /**
-         * Create a new HIVE node.
+         * Create a new HIVE node, or return existing one if handle is still valid.
          * @param appId Formation/app identifier
          * @param sharedKey Base64-encoded shared key
          * @param storagePath Path for persistent storage
          * @return HiveNodeJni instance, or null on failure
          */
         fun create(appId: String, sharedKey: String, storagePath: String): HiveNodeJni? {
+            // Check if we have an existing valid handle
+            if (globalHandle != 0L) {
+                try {
+                    // Verify handle is still valid by calling peerCount
+                    val peerCount = HiveJni.peerCountJni(globalHandle)
+                    if (peerCount >= 0) {
+                        Log.i(TAG, "Reusing existing HIVE node handle: $globalHandle (peers: $peerCount)")
+                        if (globalInstance == null) {
+                            globalInstance = HiveNodeJni(globalHandle)
+                        }
+                        return globalInstance
+                    }
+                } catch (e: Exception) {
+                    Log.w(TAG, "Existing handle invalid, will create new node: ${e.message}")
+                    globalHandle = 0L
+                    globalInstance = null
+                }
+            }
+
             return try {
                 val handle = HiveJni.createNodeJni(appId, sharedKey, storagePath)
                 if (handle != 0L) {
                     Log.i(TAG, "Created HIVE node with handle: $handle")
-                    HiveNodeJni(handle)
+                    globalHandle = handle
+                    globalInstance = HiveNodeJni(handle)
+                    globalInstance
                 } else {
                     Log.e(TAG, "Failed to create HIVE node (handle=0)")
                     null
@@ -192,6 +231,36 @@ class HiveNodeJni private constructor(private val handle: Long) : AutoCloseable 
                 Log.e(TAG, "Exception creating HIVE node: ${e.message}", e)
                 null
             }
+        }
+
+        /**
+         * Get the existing instance without creating a new one.
+         * Recovers from native global handle if Kotlin state was lost (APK replacement).
+         */
+        fun getInstance(): HiveNodeJni? {
+            // First check if we have a local instance
+            if (globalInstance != null) {
+                return globalInstance
+            }
+
+            // Try to recover from native global handle (survives APK replacement)
+            try {
+                val nativeHandle = HiveJni.getGlobalNodeHandleJni()
+                if (nativeHandle != 0L) {
+                    // Verify handle is still valid
+                    val peerCount = HiveJni.peerCountJni(nativeHandle)
+                    if (peerCount >= 0) {
+                        Log.i(TAG, "Recovered HIVE node from native global handle: $nativeHandle (peers: $peerCount)")
+                        globalHandle = nativeHandle
+                        globalInstance = HiveNodeJni(nativeHandle)
+                        return globalInstance
+                    }
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to recover from native handle: ${e.message}")
+            }
+
+            return null
         }
     }
 

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
@@ -129,15 +129,17 @@ class HiveMapComponent : DropDownMapComponent() {
     }
 
     /**
-     * Update connection status based on HIVE node availability
+     * Update connection status based on HIVE node availability and peer count
      */
     private fun updateConnectionStatus() {
-        _connectionStatus = if (HivePluginLifecycle.getInstance()?.getHiveNodeJni() != null) {
-            ConnectionStatus.CONNECTED
-        } else {
-            ConnectionStatus.DISCONNECTED
+        val node = HivePluginLifecycle.getInstance()?.getHiveNodeJni()
+        val currentPeerCount = peerCount  // Use the property which gets live peer count
+        _connectionStatus = when {
+            node == null -> ConnectionStatus.DISCONNECTED
+            currentPeerCount > 0 -> ConnectionStatus.CONNECTED
+            else -> ConnectionStatus.CONNECTING  // Node exists but no peers
         }
-        Log.d(TAG, "Connection status: $_connectionStatus")
+        Log.d(TAG, "Connection status: $_connectionStatus (peers: $currentPeerCount)")
     }
 
     /**
@@ -147,9 +149,10 @@ class HiveMapComponent : DropDownMapComponent() {
         Log.d(TAG, "Refreshing HIVE data")
         updateConnectionStatus()
 
-        val node = HivePluginLifecycle.getInstance()?.getHiveNodeJni()
+        val lifecycle = HivePluginLifecycle.getInstance()
+        val node = lifecycle?.getHiveNodeJni()
         if (node == null) {
-            Log.w(TAG, "No HIVE node available - clearing data")
+            Log.w(TAG, "No HIVE node available - lifecycle=$lifecycle, node=$node")
             _cells.clear()
             _platforms.clear()
             _tracks.clear()

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HivePluginLifecycle.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HivePluginLifecycle.kt
@@ -136,11 +136,23 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
 
     fun isHiveFfiAvailable(): Boolean = hiveFfiInitialized
 
-    fun getHiveNodeJni(): HiveNodeJni? = hiveNodeJni
+    fun getHiveNodeJni(): HiveNodeJni? {
+        // First check our instance
+        if (hiveNodeJni != null) {
+            return hiveNodeJni
+        }
+        // Try to recover from global singleton (survives APK replacement)
+        val recovered = HiveNodeJni.getInstance()
+        if (recovered != null) {
+            Log.i(TAG, "Recovered HIVE node from global singleton")
+            hiveNodeJni = recovered
+        }
+        return hiveNodeJni
+    }
 
-    fun getPeerCount(): Int = hiveNodeJni?.peerCount() ?: 0
+    fun getPeerCount(): Int = getHiveNodeJni()?.peerCount() ?: 0
 
-    fun getNodeId(): String? = hiveNodeJni?.nodeId()
+    fun getNodeId(): String? = getHiveNodeJni()?.nodeId()
 
-    fun getConnectedPeers(): String = hiveNodeJni?.connectedPeers() ?: "[]"
+    fun getConnectedPeers(): String = getHiveNodeJni()?.connectedPeers() ?: "[]"
 }

--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -33,6 +33,11 @@ static JAVA_VM: LazyLock<Mutex<Option<jni::JavaVM>>> = LazyLock::new(|| Mutex::n
 static PEER_EVENT_MANAGER_CLASS: LazyLock<Mutex<Option<GlobalRef>>> =
     LazyLock::new(|| Mutex::new(None));
 
+// Global HIVE node handle that survives APK replacement
+// This allows Kotlin code to recover the node connection after plugin hot-swap
+#[cfg(feature = "sync")]
+static GLOBAL_NODE_HANDLE: LazyLock<Mutex<i64>> = LazyLock::new(|| Mutex::new(0));
+
 use hive_protocol::cot::{
     CotEncoder, Position as CotPosition, TrackUpdate, Velocity as CotVelocity,
 };
@@ -1611,13 +1616,40 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_createNodeJni(
             #[cfg(target_os = "android")]
             android_log("createNodeJni: Node created successfully");
             // Return the Arc pointer as a handle
-            Arc::into_raw(node) as i64
+            let handle = Arc::into_raw(node) as i64;
+            // Store globally so it survives APK replacement
+            if let Ok(mut global) = GLOBAL_NODE_HANDLE.lock() {
+                *global = handle;
+                #[cfg(target_os = "android")]
+                android_log(&format!("createNodeJni: Stored global handle: {}", handle));
+            }
+            handle
         }
         Err(e) => {
             #[cfg(target_os = "android")]
             android_log(&format!("createNodeJni: Error creating node: {:?}", e));
             0
         }
+    }
+}
+
+/// JNI: Get the global node handle (survives APK replacement)
+///
+/// Kotlin signature: external fun getGlobalNodeHandleJni(): Long
+#[cfg(feature = "sync")]
+#[no_mangle]
+pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_getGlobalNodeHandleJni(
+    _env: JNIEnv,
+    _class: JClass,
+) -> i64 {
+    match GLOBAL_NODE_HANDLE.lock() {
+        Ok(handle) => {
+            let h = *handle;
+            #[cfg(target_os = "android")]
+            android_log(&format!("getGlobalNodeHandleJni: Returning handle: {}", h));
+            h
+        }
+        Err(_) => 0,
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix connection status indicator to show CONNECTING (yellow) when node exists but has 0 peers, instead of always showing CONNECTED (green)
- Add global node handle in Rust FFI that survives APK replacement, allowing the native HIVE node to persist across plugin hot-swaps
- Implement handle recovery in Kotlin layer for seamless plugin reloads

## Changes
- **hive-ffi/src/lib.rs**: Add `GLOBAL_NODE_HANDLE` static and `getGlobalNodeHandleJni()` JNI function
- **HiveJni.kt**: Add `getGlobalNodeHandleJni()` declaration and global handle management in `HiveNodeJni`
- **HiveMapComponent.kt**: Fix `updateConnectionStatus()` to use actual peer count (CONNECTING vs CONNECTED)
- **HivePluginLifecycle.kt**: Add recovery from global singleton on `getHiveNodeJni()`

## Test plan
- [x] Verified connection status shows CONNECTING when 0 peers
- [x] Verified connection status shows CONNECTED when 1+ peers
- [x] Verified native node survives APK replacement (test client shows peer still connected after plugin reload)
- [x] Verified tracks display on ATAK map (4 Atlanta flight pattern tracks syncing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)