### PR TITLE
fix(hive-sim): Add DNS retry and remove IPv6 for containerlab

### DIFF
--- a/hive-sim/src/main.rs
+++ b/hive-sim/src/main.rs
@@ -1947,16 +1947,39 @@ async fn connect_to_automerge_peers(
         );
 
         // Resolve hostname to IP addresses (containerlab uses Docker DNS)
-        let resolved_addrs: Vec<String> = match tokio::net::lookup_host(peer_addr).await {
-            Ok(addrs) => addrs.map(|a| a.to_string()).collect(),
-            Err(e) => {
-                eprintln!("[{}] ✗ Failed to resolve '{}': {}", node_id, peer_addr, e);
-                continue;
+        // Retry DNS resolution with backoff since containers start in parallel
+        // Use 30 attempts with 2-second intervals to handle slow container startup
+        let mut resolved_addrs: Vec<String> = Vec::new();
+        for attempt in 1..=30 {
+            match tokio::net::lookup_host(peer_addr).await {
+                Ok(addrs) => {
+                    resolved_addrs = addrs.map(|a| a.to_string()).collect();
+                    if !resolved_addrs.is_empty() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    if attempt == 30 {
+                        eprintln!(
+                            "[{}] ✗ Failed to resolve '{}' after 30 attempts: {}",
+                            node_id, peer_addr, e
+                        );
+                    } else if attempt % 5 == 0 {
+                        eprintln!(
+                            "[{}] DNS attempt {}/30 for '{}' still failing, retrying...",
+                            node_id, attempt, peer_addr
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+                }
             }
-        };
+        }
 
         if resolved_addrs.is_empty() {
-            eprintln!("[{}] ✗ No addresses resolved for '{}'", node_id, peer_addr);
+            eprintln!(
+                "[{}] ✗ No addresses resolved for '{}' after retries",
+                node_id, peer_addr
+            );
             continue;
         }
 
@@ -1965,22 +1988,43 @@ async fn connect_to_automerge_peers(
             node_id, peer_addr, resolved_addrs
         );
 
-        // Connect using the SyncEngine trait method
+        // Connect using the SyncEngine trait method with retry logic
         // Note: connect_to_peer uses connect_force() which bypasses tie-breaking,
         // so it will always attempt to connect for static configurations
-        match sync_engine
-            .connect_to_peer(&peer_endpoint_hex, &resolved_addrs)
-            .await
-        {
-            Ok(_) => {
-                eprintln!("[{}] ✓ Connected to peer '{}'", node_id, peer_name);
+        // Retry connection up to 10 times with 3-second intervals to handle
+        // timing issues where the peer's listener isn't ready yet
+        let mut connected = false;
+        for conn_attempt in 1..=10 {
+            match sync_engine
+                .connect_to_peer(&peer_endpoint_hex, &resolved_addrs)
+                .await
+            {
+                Ok(_) => {
+                    eprintln!("[{}] ✓ Connected to peer '{}'", node_id, peer_name);
+                    connected = true;
+                    break;
+                }
+                Err(e) => {
+                    if conn_attempt == 10 {
+                        eprintln!(
+                            "[{}] ✗ Failed to connect to peer '{}' after 10 attempts: {}",
+                            node_id, peer_name, e
+                        );
+                    } else if conn_attempt % 3 == 0 {
+                        eprintln!(
+                            "[{}] Connection attempt {}/10 for '{}' failed, retrying...",
+                            node_id, conn_attempt, peer_name
+                        );
+                    }
+                    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+                }
             }
-            Err(e) => {
-                eprintln!(
-                    "[{}] ✗ Failed to connect to peer '{}': {}",
-                    node_id, peer_name, e
-                );
-            }
+        }
+        if !connected {
+            eprintln!(
+                "[{}] ⚠ Continuing without connection to '{}' - sync may still work via other peers",
+                node_id, peer_name
+            );
         }
     }
 

--- a/hive-sim/topologies/lab4-automerge-384n-1gbps.yaml
+++ b/hive-sim/topologies/lab4-automerge-384n-1gbps.yaml
@@ -1,0 +1,8152 @@
+# Lab 4: Hierarchical HIVE CRDT - lab4-automerge-384n-1gbps
+# Target nodes: 384, Actual: 447
+# Structure: 3 companies × 4 platoons × 4 squads × 8 soldiers
+# Bandwidth: 1gbps
+
+name: lab4-automerge-384n-1gbps
+
+mgmt:
+  network: lab4-automerge-384n-1gbps
+  ipv4-subnet: 172.30.0.0/20
+
+topology:
+  nodes:
+
+    # ===== COMPANY 1 =====
+
+    company-1-commander:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-commander
+        ROLE: company_commander
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        COMPANY_ID: company-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12345"
+        TCP_CONNECT: "company-1-platoon-1-leader|company-1-platoon-1-leader:12346,company-1-platoon-2-leader|company-1-platoon-2-leader:12383,company-1-platoon-3-leader|company-1-platoon-3-leader:12420,company-1-platoon-4-leader|company-1-platoon-4-leader:12457"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-commander
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 1-1 -----
+
+    company-1-platoon-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-1-platoon-1
+        SQUAD_IDS: "company-1-platoon-1-squad-1,company-1-platoon-1-squad-2,company-1-platoon-1-squad-3,company-1-platoon-1-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12346"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-commander|company-1-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-1-squad-1-soldier-1,company-1-platoon-1-squad-1-soldier-2,company-1-platoon-1-squad-1-soldier-3,company-1-platoon-1-squad-1-soldier-4,company-1-platoon-1-squad-1-soldier-5,company-1-platoon-1-squad-1-soldier-6,company-1-platoon-1-squad-1-soldier-7,company-1-platoon-1-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12347"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355,company-1-platoon-1-leader|company-1-platoon-1-leader:12346"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12348"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12349"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12350"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12351"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12352"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12353"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12354"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-8|company-1-platoon-1-squad-1-soldier-8:12355"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12355"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|company-1-platoon-1-squad-1-leader:12347,company-1-platoon-1-squad-1-soldier-1|company-1-platoon-1-squad-1-soldier-1:12348,company-1-platoon-1-squad-1-soldier-2|company-1-platoon-1-squad-1-soldier-2:12349,company-1-platoon-1-squad-1-soldier-3|company-1-platoon-1-squad-1-soldier-3:12350,company-1-platoon-1-squad-1-soldier-4|company-1-platoon-1-squad-1-soldier-4:12351,company-1-platoon-1-squad-1-soldier-5|company-1-platoon-1-squad-1-soldier-5:12352,company-1-platoon-1-squad-1-soldier-6|company-1-platoon-1-squad-1-soldier-6:12353,company-1-platoon-1-squad-1-soldier-7|company-1-platoon-1-squad-1-soldier-7:12354"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-1-squad-2-soldier-1,company-1-platoon-1-squad-2-soldier-2,company-1-platoon-1-squad-2-soldier-3,company-1-platoon-1-squad-2-soldier-4,company-1-platoon-1-squad-2-soldier-5,company-1-platoon-1-squad-2-soldier-6,company-1-platoon-1-squad-2-soldier-7,company-1-platoon-1-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12356"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364,company-1-platoon-1-leader|company-1-platoon-1-leader:12346"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12357"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12358"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12359"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12360"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12361"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12362"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12363"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-8|company-1-platoon-1-squad-2-soldier-8:12364"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12364"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|company-1-platoon-1-squad-2-leader:12356,company-1-platoon-1-squad-2-soldier-1|company-1-platoon-1-squad-2-soldier-1:12357,company-1-platoon-1-squad-2-soldier-2|company-1-platoon-1-squad-2-soldier-2:12358,company-1-platoon-1-squad-2-soldier-3|company-1-platoon-1-squad-2-soldier-3:12359,company-1-platoon-1-squad-2-soldier-4|company-1-platoon-1-squad-2-soldier-4:12360,company-1-platoon-1-squad-2-soldier-5|company-1-platoon-1-squad-2-soldier-5:12361,company-1-platoon-1-squad-2-soldier-6|company-1-platoon-1-squad-2-soldier-6:12362,company-1-platoon-1-squad-2-soldier-7|company-1-platoon-1-squad-2-soldier-7:12363"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-1-squad-3-soldier-1,company-1-platoon-1-squad-3-soldier-2,company-1-platoon-1-squad-3-soldier-3,company-1-platoon-1-squad-3-soldier-4,company-1-platoon-1-squad-3-soldier-5,company-1-platoon-1-squad-3-soldier-6,company-1-platoon-1-squad-3-soldier-7,company-1-platoon-1-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12365"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373,company-1-platoon-1-leader|company-1-platoon-1-leader:12346"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12366"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12367"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12368"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12369"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12370"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12371"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12372"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-8|company-1-platoon-1-squad-3-soldier-8:12373"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12373"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|company-1-platoon-1-squad-3-leader:12365,company-1-platoon-1-squad-3-soldier-1|company-1-platoon-1-squad-3-soldier-1:12366,company-1-platoon-1-squad-3-soldier-2|company-1-platoon-1-squad-3-soldier-2:12367,company-1-platoon-1-squad-3-soldier-3|company-1-platoon-1-squad-3-soldier-3:12368,company-1-platoon-1-squad-3-soldier-4|company-1-platoon-1-squad-3-soldier-4:12369,company-1-platoon-1-squad-3-soldier-5|company-1-platoon-1-squad-3-soldier-5:12370,company-1-platoon-1-squad-3-soldier-6|company-1-platoon-1-squad-3-soldier-6:12371,company-1-platoon-1-squad-3-soldier-7|company-1-platoon-1-squad-3-soldier-7:12372"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        SQUAD_MEMBERS: "company-1-platoon-1-squad-4-soldier-1,company-1-platoon-1-squad-4-soldier-2,company-1-platoon-1-squad-4-soldier-3,company-1-platoon-1-squad-4-soldier-4,company-1-platoon-1-squad-4-soldier-5,company-1-platoon-1-squad-4-soldier-6,company-1-platoon-1-squad-4-soldier-7,company-1-platoon-1-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12374"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382,company-1-platoon-1-leader|company-1-platoon-1-leader:12346"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12375"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12376"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12377"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12378"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12379"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12380"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12381"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-8|company-1-platoon-1-squad-4-soldier-8:12382"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-1-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12382"
+        TCP_CONNECT: "company-1-platoon-1-squad-4-leader|company-1-platoon-1-squad-4-leader:12374,company-1-platoon-1-squad-4-soldier-1|company-1-platoon-1-squad-4-soldier-1:12375,company-1-platoon-1-squad-4-soldier-2|company-1-platoon-1-squad-4-soldier-2:12376,company-1-platoon-1-squad-4-soldier-3|company-1-platoon-1-squad-4-soldier-3:12377,company-1-platoon-1-squad-4-soldier-4|company-1-platoon-1-squad-4-soldier-4:12378,company-1-platoon-1-squad-4-soldier-5|company-1-platoon-1-squad-4-soldier-5:12379,company-1-platoon-1-squad-4-soldier-6|company-1-platoon-1-squad-4-soldier-6:12380,company-1-platoon-1-squad-4-soldier-7|company-1-platoon-1-squad-4-soldier-7:12381"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-1-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 1-2 -----
+
+    company-1-platoon-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-1-platoon-2
+        SQUAD_IDS: "company-1-platoon-2-squad-1,company-1-platoon-2-squad-2,company-1-platoon-2-squad-3,company-1-platoon-2-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12383"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-commander|company-1-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-2-squad-1-soldier-1,company-1-platoon-2-squad-1-soldier-2,company-1-platoon-2-squad-1-soldier-3,company-1-platoon-2-squad-1-soldier-4,company-1-platoon-2-squad-1-soldier-5,company-1-platoon-2-squad-1-soldier-6,company-1-platoon-2-squad-1-soldier-7,company-1-platoon-2-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12384"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392,company-1-platoon-2-leader|company-1-platoon-2-leader:12383"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12385"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12386"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12387"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12388"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12389"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12390"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12391"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-8|company-1-platoon-2-squad-1-soldier-8:12392"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12392"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|company-1-platoon-2-squad-1-leader:12384,company-1-platoon-2-squad-1-soldier-1|company-1-platoon-2-squad-1-soldier-1:12385,company-1-platoon-2-squad-1-soldier-2|company-1-platoon-2-squad-1-soldier-2:12386,company-1-platoon-2-squad-1-soldier-3|company-1-platoon-2-squad-1-soldier-3:12387,company-1-platoon-2-squad-1-soldier-4|company-1-platoon-2-squad-1-soldier-4:12388,company-1-platoon-2-squad-1-soldier-5|company-1-platoon-2-squad-1-soldier-5:12389,company-1-platoon-2-squad-1-soldier-6|company-1-platoon-2-squad-1-soldier-6:12390,company-1-platoon-2-squad-1-soldier-7|company-1-platoon-2-squad-1-soldier-7:12391"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-2-squad-2-soldier-1,company-1-platoon-2-squad-2-soldier-2,company-1-platoon-2-squad-2-soldier-3,company-1-platoon-2-squad-2-soldier-4,company-1-platoon-2-squad-2-soldier-5,company-1-platoon-2-squad-2-soldier-6,company-1-platoon-2-squad-2-soldier-7,company-1-platoon-2-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12393"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401,company-1-platoon-2-leader|company-1-platoon-2-leader:12383"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12394"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12395"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12396"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12397"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12398"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12399"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12400"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-8|company-1-platoon-2-squad-2-soldier-8:12401"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12401"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|company-1-platoon-2-squad-2-leader:12393,company-1-platoon-2-squad-2-soldier-1|company-1-platoon-2-squad-2-soldier-1:12394,company-1-platoon-2-squad-2-soldier-2|company-1-platoon-2-squad-2-soldier-2:12395,company-1-platoon-2-squad-2-soldier-3|company-1-platoon-2-squad-2-soldier-3:12396,company-1-platoon-2-squad-2-soldier-4|company-1-platoon-2-squad-2-soldier-4:12397,company-1-platoon-2-squad-2-soldier-5|company-1-platoon-2-squad-2-soldier-5:12398,company-1-platoon-2-squad-2-soldier-6|company-1-platoon-2-squad-2-soldier-6:12399,company-1-platoon-2-squad-2-soldier-7|company-1-platoon-2-squad-2-soldier-7:12400"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-2-squad-3-soldier-1,company-1-platoon-2-squad-3-soldier-2,company-1-platoon-2-squad-3-soldier-3,company-1-platoon-2-squad-3-soldier-4,company-1-platoon-2-squad-3-soldier-5,company-1-platoon-2-squad-3-soldier-6,company-1-platoon-2-squad-3-soldier-7,company-1-platoon-2-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12402"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410,company-1-platoon-2-leader|company-1-platoon-2-leader:12383"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12403"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12404"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12405"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12406"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12407"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12408"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12409"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-8|company-1-platoon-2-squad-3-soldier-8:12410"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12410"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|company-1-platoon-2-squad-3-leader:12402,company-1-platoon-2-squad-3-soldier-1|company-1-platoon-2-squad-3-soldier-1:12403,company-1-platoon-2-squad-3-soldier-2|company-1-platoon-2-squad-3-soldier-2:12404,company-1-platoon-2-squad-3-soldier-3|company-1-platoon-2-squad-3-soldier-3:12405,company-1-platoon-2-squad-3-soldier-4|company-1-platoon-2-squad-3-soldier-4:12406,company-1-platoon-2-squad-3-soldier-5|company-1-platoon-2-squad-3-soldier-5:12407,company-1-platoon-2-squad-3-soldier-6|company-1-platoon-2-squad-3-soldier-6:12408,company-1-platoon-2-squad-3-soldier-7|company-1-platoon-2-squad-3-soldier-7:12409"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        SQUAD_MEMBERS: "company-1-platoon-2-squad-4-soldier-1,company-1-platoon-2-squad-4-soldier-2,company-1-platoon-2-squad-4-soldier-3,company-1-platoon-2-squad-4-soldier-4,company-1-platoon-2-squad-4-soldier-5,company-1-platoon-2-squad-4-soldier-6,company-1-platoon-2-squad-4-soldier-7,company-1-platoon-2-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12411"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419,company-1-platoon-2-leader|company-1-platoon-2-leader:12383"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12412"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12413"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12414"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12415"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12416"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12417"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12418"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-8|company-1-platoon-2-squad-4-soldier-8:12419"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-2-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12419"
+        TCP_CONNECT: "company-1-platoon-2-squad-4-leader|company-1-platoon-2-squad-4-leader:12411,company-1-platoon-2-squad-4-soldier-1|company-1-platoon-2-squad-4-soldier-1:12412,company-1-platoon-2-squad-4-soldier-2|company-1-platoon-2-squad-4-soldier-2:12413,company-1-platoon-2-squad-4-soldier-3|company-1-platoon-2-squad-4-soldier-3:12414,company-1-platoon-2-squad-4-soldier-4|company-1-platoon-2-squad-4-soldier-4:12415,company-1-platoon-2-squad-4-soldier-5|company-1-platoon-2-squad-4-soldier-5:12416,company-1-platoon-2-squad-4-soldier-6|company-1-platoon-2-squad-4-soldier-6:12417,company-1-platoon-2-squad-4-soldier-7|company-1-platoon-2-squad-4-soldier-7:12418"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-2-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 1-3 -----
+
+    company-1-platoon-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-1-platoon-3
+        SQUAD_IDS: "company-1-platoon-3-squad-1,company-1-platoon-3-squad-2,company-1-platoon-3-squad-3,company-1-platoon-3-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12420"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-commander|company-1-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-3-squad-1-soldier-1,company-1-platoon-3-squad-1-soldier-2,company-1-platoon-3-squad-1-soldier-3,company-1-platoon-3-squad-1-soldier-4,company-1-platoon-3-squad-1-soldier-5,company-1-platoon-3-squad-1-soldier-6,company-1-platoon-3-squad-1-soldier-7,company-1-platoon-3-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12421"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429,company-1-platoon-3-leader|company-1-platoon-3-leader:12420"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12422"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12423"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12424"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12425"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12426"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12427"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12428"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-8|company-1-platoon-3-squad-1-soldier-8:12429"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12429"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|company-1-platoon-3-squad-1-leader:12421,company-1-platoon-3-squad-1-soldier-1|company-1-platoon-3-squad-1-soldier-1:12422,company-1-platoon-3-squad-1-soldier-2|company-1-platoon-3-squad-1-soldier-2:12423,company-1-platoon-3-squad-1-soldier-3|company-1-platoon-3-squad-1-soldier-3:12424,company-1-platoon-3-squad-1-soldier-4|company-1-platoon-3-squad-1-soldier-4:12425,company-1-platoon-3-squad-1-soldier-5|company-1-platoon-3-squad-1-soldier-5:12426,company-1-platoon-3-squad-1-soldier-6|company-1-platoon-3-squad-1-soldier-6:12427,company-1-platoon-3-squad-1-soldier-7|company-1-platoon-3-squad-1-soldier-7:12428"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-3-squad-2-soldier-1,company-1-platoon-3-squad-2-soldier-2,company-1-platoon-3-squad-2-soldier-3,company-1-platoon-3-squad-2-soldier-4,company-1-platoon-3-squad-2-soldier-5,company-1-platoon-3-squad-2-soldier-6,company-1-platoon-3-squad-2-soldier-7,company-1-platoon-3-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12430"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438,company-1-platoon-3-leader|company-1-platoon-3-leader:12420"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12431"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12432"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12433"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12434"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12435"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12436"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12437"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-8|company-1-platoon-3-squad-2-soldier-8:12438"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12438"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|company-1-platoon-3-squad-2-leader:12430,company-1-platoon-3-squad-2-soldier-1|company-1-platoon-3-squad-2-soldier-1:12431,company-1-platoon-3-squad-2-soldier-2|company-1-platoon-3-squad-2-soldier-2:12432,company-1-platoon-3-squad-2-soldier-3|company-1-platoon-3-squad-2-soldier-3:12433,company-1-platoon-3-squad-2-soldier-4|company-1-platoon-3-squad-2-soldier-4:12434,company-1-platoon-3-squad-2-soldier-5|company-1-platoon-3-squad-2-soldier-5:12435,company-1-platoon-3-squad-2-soldier-6|company-1-platoon-3-squad-2-soldier-6:12436,company-1-platoon-3-squad-2-soldier-7|company-1-platoon-3-squad-2-soldier-7:12437"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-3-squad-3-soldier-1,company-1-platoon-3-squad-3-soldier-2,company-1-platoon-3-squad-3-soldier-3,company-1-platoon-3-squad-3-soldier-4,company-1-platoon-3-squad-3-soldier-5,company-1-platoon-3-squad-3-soldier-6,company-1-platoon-3-squad-3-soldier-7,company-1-platoon-3-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12439"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447,company-1-platoon-3-leader|company-1-platoon-3-leader:12420"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12440"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12441"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12442"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12443"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12444"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12445"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12446"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-8|company-1-platoon-3-squad-3-soldier-8:12447"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12447"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|company-1-platoon-3-squad-3-leader:12439,company-1-platoon-3-squad-3-soldier-1|company-1-platoon-3-squad-3-soldier-1:12440,company-1-platoon-3-squad-3-soldier-2|company-1-platoon-3-squad-3-soldier-2:12441,company-1-platoon-3-squad-3-soldier-3|company-1-platoon-3-squad-3-soldier-3:12442,company-1-platoon-3-squad-3-soldier-4|company-1-platoon-3-squad-3-soldier-4:12443,company-1-platoon-3-squad-3-soldier-5|company-1-platoon-3-squad-3-soldier-5:12444,company-1-platoon-3-squad-3-soldier-6|company-1-platoon-3-squad-3-soldier-6:12445,company-1-platoon-3-squad-3-soldier-7|company-1-platoon-3-squad-3-soldier-7:12446"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        SQUAD_MEMBERS: "company-1-platoon-3-squad-4-soldier-1,company-1-platoon-3-squad-4-soldier-2,company-1-platoon-3-squad-4-soldier-3,company-1-platoon-3-squad-4-soldier-4,company-1-platoon-3-squad-4-soldier-5,company-1-platoon-3-squad-4-soldier-6,company-1-platoon-3-squad-4-soldier-7,company-1-platoon-3-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12448"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456,company-1-platoon-3-leader|company-1-platoon-3-leader:12420"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12449"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12450"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12451"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12452"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12453"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12454"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12455"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-8|company-1-platoon-3-squad-4-soldier-8:12456"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-3-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12456"
+        TCP_CONNECT: "company-1-platoon-3-squad-4-leader|company-1-platoon-3-squad-4-leader:12448,company-1-platoon-3-squad-4-soldier-1|company-1-platoon-3-squad-4-soldier-1:12449,company-1-platoon-3-squad-4-soldier-2|company-1-platoon-3-squad-4-soldier-2:12450,company-1-platoon-3-squad-4-soldier-3|company-1-platoon-3-squad-4-soldier-3:12451,company-1-platoon-3-squad-4-soldier-4|company-1-platoon-3-squad-4-soldier-4:12452,company-1-platoon-3-squad-4-soldier-5|company-1-platoon-3-squad-4-soldier-5:12453,company-1-platoon-3-squad-4-soldier-6|company-1-platoon-3-squad-4-soldier-6:12454,company-1-platoon-3-squad-4-soldier-7|company-1-platoon-3-squad-4-soldier-7:12455"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-3-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 1-4 -----
+
+    company-1-platoon-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-1-platoon-4
+        SQUAD_IDS: "company-1-platoon-4-squad-1,company-1-platoon-4-squad-2,company-1-platoon-4-squad-3,company-1-platoon-4-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12457"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-commander|company-1-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-4-squad-1-soldier-1,company-1-platoon-4-squad-1-soldier-2,company-1-platoon-4-squad-1-soldier-3,company-1-platoon-4-squad-1-soldier-4,company-1-platoon-4-squad-1-soldier-5,company-1-platoon-4-squad-1-soldier-6,company-1-platoon-4-squad-1-soldier-7,company-1-platoon-4-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12458"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466,company-1-platoon-4-leader|company-1-platoon-4-leader:12457"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12459"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12460"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12461"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12462"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12463"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12464"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12465"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-8|company-1-platoon-4-squad-1-soldier-8:12466"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12466"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|company-1-platoon-4-squad-1-leader:12458,company-1-platoon-4-squad-1-soldier-1|company-1-platoon-4-squad-1-soldier-1:12459,company-1-platoon-4-squad-1-soldier-2|company-1-platoon-4-squad-1-soldier-2:12460,company-1-platoon-4-squad-1-soldier-3|company-1-platoon-4-squad-1-soldier-3:12461,company-1-platoon-4-squad-1-soldier-4|company-1-platoon-4-squad-1-soldier-4:12462,company-1-platoon-4-squad-1-soldier-5|company-1-platoon-4-squad-1-soldier-5:12463,company-1-platoon-4-squad-1-soldier-6|company-1-platoon-4-squad-1-soldier-6:12464,company-1-platoon-4-squad-1-soldier-7|company-1-platoon-4-squad-1-soldier-7:12465"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-4-squad-2-soldier-1,company-1-platoon-4-squad-2-soldier-2,company-1-platoon-4-squad-2-soldier-3,company-1-platoon-4-squad-2-soldier-4,company-1-platoon-4-squad-2-soldier-5,company-1-platoon-4-squad-2-soldier-6,company-1-platoon-4-squad-2-soldier-7,company-1-platoon-4-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12467"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475,company-1-platoon-4-leader|company-1-platoon-4-leader:12457"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12468"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12469"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12470"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12471"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12472"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12473"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12474"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-8|company-1-platoon-4-squad-2-soldier-8:12475"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12475"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|company-1-platoon-4-squad-2-leader:12467,company-1-platoon-4-squad-2-soldier-1|company-1-platoon-4-squad-2-soldier-1:12468,company-1-platoon-4-squad-2-soldier-2|company-1-platoon-4-squad-2-soldier-2:12469,company-1-platoon-4-squad-2-soldier-3|company-1-platoon-4-squad-2-soldier-3:12470,company-1-platoon-4-squad-2-soldier-4|company-1-platoon-4-squad-2-soldier-4:12471,company-1-platoon-4-squad-2-soldier-5|company-1-platoon-4-squad-2-soldier-5:12472,company-1-platoon-4-squad-2-soldier-6|company-1-platoon-4-squad-2-soldier-6:12473,company-1-platoon-4-squad-2-soldier-7|company-1-platoon-4-squad-2-soldier-7:12474"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-4-squad-3-soldier-1,company-1-platoon-4-squad-3-soldier-2,company-1-platoon-4-squad-3-soldier-3,company-1-platoon-4-squad-3-soldier-4,company-1-platoon-4-squad-3-soldier-5,company-1-platoon-4-squad-3-soldier-6,company-1-platoon-4-squad-3-soldier-7,company-1-platoon-4-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12476"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484,company-1-platoon-4-leader|company-1-platoon-4-leader:12457"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12477"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12478"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12479"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12480"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12481"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12482"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12483"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-8|company-1-platoon-4-squad-3-soldier-8:12484"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12484"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|company-1-platoon-4-squad-3-leader:12476,company-1-platoon-4-squad-3-soldier-1|company-1-platoon-4-squad-3-soldier-1:12477,company-1-platoon-4-squad-3-soldier-2|company-1-platoon-4-squad-3-soldier-2:12478,company-1-platoon-4-squad-3-soldier-3|company-1-platoon-4-squad-3-soldier-3:12479,company-1-platoon-4-squad-3-soldier-4|company-1-platoon-4-squad-3-soldier-4:12480,company-1-platoon-4-squad-3-soldier-5|company-1-platoon-4-squad-3-soldier-5:12481,company-1-platoon-4-squad-3-soldier-6|company-1-platoon-4-squad-3-soldier-6:12482,company-1-platoon-4-squad-3-soldier-7|company-1-platoon-4-squad-3-soldier-7:12483"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        SQUAD_MEMBERS: "company-1-platoon-4-squad-4-soldier-1,company-1-platoon-4-squad-4-soldier-2,company-1-platoon-4-squad-4-soldier-3,company-1-platoon-4-squad-4-soldier-4,company-1-platoon-4-squad-4-soldier-5,company-1-platoon-4-squad-4-soldier-6,company-1-platoon-4-squad-4-soldier-7,company-1-platoon-4-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12485"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493,company-1-platoon-4-leader|company-1-platoon-4-leader:12457"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12486"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12487"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12488"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12489"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12490"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12491"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12492"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-8|company-1-platoon-4-squad-4-soldier-8:12493"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-1-platoon-4-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-1-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12493"
+        TCP_CONNECT: "company-1-platoon-4-squad-4-leader|company-1-platoon-4-squad-4-leader:12485,company-1-platoon-4-squad-4-soldier-1|company-1-platoon-4-squad-4-soldier-1:12486,company-1-platoon-4-squad-4-soldier-2|company-1-platoon-4-squad-4-soldier-2:12487,company-1-platoon-4-squad-4-soldier-3|company-1-platoon-4-squad-4-soldier-3:12488,company-1-platoon-4-squad-4-soldier-4|company-1-platoon-4-squad-4-soldier-4:12489,company-1-platoon-4-squad-4-soldier-5|company-1-platoon-4-squad-4-soldier-5:12490,company-1-platoon-4-squad-4-soldier-6|company-1-platoon-4-squad-4-soldier-6:12491,company-1-platoon-4-squad-4-soldier-7|company-1-platoon-4-squad-4-soldier-7:12492"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-1-platoon-4-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+
+    # ===== COMPANY 2 =====
+
+    company-2-commander:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-commander
+        ROLE: company_commander
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        COMPANY_ID: company-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12345"
+        TCP_CONNECT: "company-2-platoon-1-leader|company-2-platoon-1-leader:12494,company-2-platoon-2-leader|company-2-platoon-2-leader:12531,company-2-platoon-3-leader|company-2-platoon-3-leader:12568,company-2-platoon-4-leader|company-2-platoon-4-leader:12605"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-commander
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 2-1 -----
+
+    company-2-platoon-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-2-platoon-1
+        SQUAD_IDS: "company-2-platoon-1-squad-1,company-2-platoon-1-squad-2,company-2-platoon-1-squad-3,company-2-platoon-1-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12494"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-commander|company-2-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        SQUAD_MEMBERS: "company-2-platoon-1-squad-1-soldier-1,company-2-platoon-1-squad-1-soldier-2,company-2-platoon-1-squad-1-soldier-3,company-2-platoon-1-squad-1-soldier-4,company-2-platoon-1-squad-1-soldier-5,company-2-platoon-1-squad-1-soldier-6,company-2-platoon-1-squad-1-soldier-7,company-2-platoon-1-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12495"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503,company-2-platoon-1-leader|company-2-platoon-1-leader:12494"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12496"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12497"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12498"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12499"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12500"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12501"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12502"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-8|company-2-platoon-1-squad-1-soldier-8:12503"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12503"
+        TCP_CONNECT: "company-2-platoon-1-squad-1-leader|company-2-platoon-1-squad-1-leader:12495,company-2-platoon-1-squad-1-soldier-1|company-2-platoon-1-squad-1-soldier-1:12496,company-2-platoon-1-squad-1-soldier-2|company-2-platoon-1-squad-1-soldier-2:12497,company-2-platoon-1-squad-1-soldier-3|company-2-platoon-1-squad-1-soldier-3:12498,company-2-platoon-1-squad-1-soldier-4|company-2-platoon-1-squad-1-soldier-4:12499,company-2-platoon-1-squad-1-soldier-5|company-2-platoon-1-squad-1-soldier-5:12500,company-2-platoon-1-squad-1-soldier-6|company-2-platoon-1-squad-1-soldier-6:12501,company-2-platoon-1-squad-1-soldier-7|company-2-platoon-1-squad-1-soldier-7:12502"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        SQUAD_MEMBERS: "company-2-platoon-1-squad-2-soldier-1,company-2-platoon-1-squad-2-soldier-2,company-2-platoon-1-squad-2-soldier-3,company-2-platoon-1-squad-2-soldier-4,company-2-platoon-1-squad-2-soldier-5,company-2-platoon-1-squad-2-soldier-6,company-2-platoon-1-squad-2-soldier-7,company-2-platoon-1-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12504"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512,company-2-platoon-1-leader|company-2-platoon-1-leader:12494"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12505"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12506"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12507"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12508"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12509"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12510"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12511"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-8|company-2-platoon-1-squad-2-soldier-8:12512"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12512"
+        TCP_CONNECT: "company-2-platoon-1-squad-2-leader|company-2-platoon-1-squad-2-leader:12504,company-2-platoon-1-squad-2-soldier-1|company-2-platoon-1-squad-2-soldier-1:12505,company-2-platoon-1-squad-2-soldier-2|company-2-platoon-1-squad-2-soldier-2:12506,company-2-platoon-1-squad-2-soldier-3|company-2-platoon-1-squad-2-soldier-3:12507,company-2-platoon-1-squad-2-soldier-4|company-2-platoon-1-squad-2-soldier-4:12508,company-2-platoon-1-squad-2-soldier-5|company-2-platoon-1-squad-2-soldier-5:12509,company-2-platoon-1-squad-2-soldier-6|company-2-platoon-1-squad-2-soldier-6:12510,company-2-platoon-1-squad-2-soldier-7|company-2-platoon-1-squad-2-soldier-7:12511"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        SQUAD_MEMBERS: "company-2-platoon-1-squad-3-soldier-1,company-2-platoon-1-squad-3-soldier-2,company-2-platoon-1-squad-3-soldier-3,company-2-platoon-1-squad-3-soldier-4,company-2-platoon-1-squad-3-soldier-5,company-2-platoon-1-squad-3-soldier-6,company-2-platoon-1-squad-3-soldier-7,company-2-platoon-1-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12513"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521,company-2-platoon-1-leader|company-2-platoon-1-leader:12494"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12514"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12515"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12516"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12517"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12518"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12519"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12520"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-8|company-2-platoon-1-squad-3-soldier-8:12521"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12521"
+        TCP_CONNECT: "company-2-platoon-1-squad-3-leader|company-2-platoon-1-squad-3-leader:12513,company-2-platoon-1-squad-3-soldier-1|company-2-platoon-1-squad-3-soldier-1:12514,company-2-platoon-1-squad-3-soldier-2|company-2-platoon-1-squad-3-soldier-2:12515,company-2-platoon-1-squad-3-soldier-3|company-2-platoon-1-squad-3-soldier-3:12516,company-2-platoon-1-squad-3-soldier-4|company-2-platoon-1-squad-3-soldier-4:12517,company-2-platoon-1-squad-3-soldier-5|company-2-platoon-1-squad-3-soldier-5:12518,company-2-platoon-1-squad-3-soldier-6|company-2-platoon-1-squad-3-soldier-6:12519,company-2-platoon-1-squad-3-soldier-7|company-2-platoon-1-squad-3-soldier-7:12520"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        SQUAD_MEMBERS: "company-2-platoon-1-squad-4-soldier-1,company-2-platoon-1-squad-4-soldier-2,company-2-platoon-1-squad-4-soldier-3,company-2-platoon-1-squad-4-soldier-4,company-2-platoon-1-squad-4-soldier-5,company-2-platoon-1-squad-4-soldier-6,company-2-platoon-1-squad-4-soldier-7,company-2-platoon-1-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12522"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530,company-2-platoon-1-leader|company-2-platoon-1-leader:12494"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12523"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12524"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12525"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12526"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12527"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12528"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12529"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-8|company-2-platoon-1-squad-4-soldier-8:12530"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-1-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-1-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12530"
+        TCP_CONNECT: "company-2-platoon-1-squad-4-leader|company-2-platoon-1-squad-4-leader:12522,company-2-platoon-1-squad-4-soldier-1|company-2-platoon-1-squad-4-soldier-1:12523,company-2-platoon-1-squad-4-soldier-2|company-2-platoon-1-squad-4-soldier-2:12524,company-2-platoon-1-squad-4-soldier-3|company-2-platoon-1-squad-4-soldier-3:12525,company-2-platoon-1-squad-4-soldier-4|company-2-platoon-1-squad-4-soldier-4:12526,company-2-platoon-1-squad-4-soldier-5|company-2-platoon-1-squad-4-soldier-5:12527,company-2-platoon-1-squad-4-soldier-6|company-2-platoon-1-squad-4-soldier-6:12528,company-2-platoon-1-squad-4-soldier-7|company-2-platoon-1-squad-4-soldier-7:12529"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-1-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 2-2 -----
+
+    company-2-platoon-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-2-platoon-2
+        SQUAD_IDS: "company-2-platoon-2-squad-1,company-2-platoon-2-squad-2,company-2-platoon-2-squad-3,company-2-platoon-2-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12531"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-commander|company-2-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        SQUAD_MEMBERS: "company-2-platoon-2-squad-1-soldier-1,company-2-platoon-2-squad-1-soldier-2,company-2-platoon-2-squad-1-soldier-3,company-2-platoon-2-squad-1-soldier-4,company-2-platoon-2-squad-1-soldier-5,company-2-platoon-2-squad-1-soldier-6,company-2-platoon-2-squad-1-soldier-7,company-2-platoon-2-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12532"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540,company-2-platoon-2-leader|company-2-platoon-2-leader:12531"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12533"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12534"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12535"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12536"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12537"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12538"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12539"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-8|company-2-platoon-2-squad-1-soldier-8:12540"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12540"
+        TCP_CONNECT: "company-2-platoon-2-squad-1-leader|company-2-platoon-2-squad-1-leader:12532,company-2-platoon-2-squad-1-soldier-1|company-2-platoon-2-squad-1-soldier-1:12533,company-2-platoon-2-squad-1-soldier-2|company-2-platoon-2-squad-1-soldier-2:12534,company-2-platoon-2-squad-1-soldier-3|company-2-platoon-2-squad-1-soldier-3:12535,company-2-platoon-2-squad-1-soldier-4|company-2-platoon-2-squad-1-soldier-4:12536,company-2-platoon-2-squad-1-soldier-5|company-2-platoon-2-squad-1-soldier-5:12537,company-2-platoon-2-squad-1-soldier-6|company-2-platoon-2-squad-1-soldier-6:12538,company-2-platoon-2-squad-1-soldier-7|company-2-platoon-2-squad-1-soldier-7:12539"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        SQUAD_MEMBERS: "company-2-platoon-2-squad-2-soldier-1,company-2-platoon-2-squad-2-soldier-2,company-2-platoon-2-squad-2-soldier-3,company-2-platoon-2-squad-2-soldier-4,company-2-platoon-2-squad-2-soldier-5,company-2-platoon-2-squad-2-soldier-6,company-2-platoon-2-squad-2-soldier-7,company-2-platoon-2-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12541"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549,company-2-platoon-2-leader|company-2-platoon-2-leader:12531"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12542"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12543"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12544"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12545"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12546"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12547"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12548"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-8|company-2-platoon-2-squad-2-soldier-8:12549"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12549"
+        TCP_CONNECT: "company-2-platoon-2-squad-2-leader|company-2-platoon-2-squad-2-leader:12541,company-2-platoon-2-squad-2-soldier-1|company-2-platoon-2-squad-2-soldier-1:12542,company-2-platoon-2-squad-2-soldier-2|company-2-platoon-2-squad-2-soldier-2:12543,company-2-platoon-2-squad-2-soldier-3|company-2-platoon-2-squad-2-soldier-3:12544,company-2-platoon-2-squad-2-soldier-4|company-2-platoon-2-squad-2-soldier-4:12545,company-2-platoon-2-squad-2-soldier-5|company-2-platoon-2-squad-2-soldier-5:12546,company-2-platoon-2-squad-2-soldier-6|company-2-platoon-2-squad-2-soldier-6:12547,company-2-platoon-2-squad-2-soldier-7|company-2-platoon-2-squad-2-soldier-7:12548"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        SQUAD_MEMBERS: "company-2-platoon-2-squad-3-soldier-1,company-2-platoon-2-squad-3-soldier-2,company-2-platoon-2-squad-3-soldier-3,company-2-platoon-2-squad-3-soldier-4,company-2-platoon-2-squad-3-soldier-5,company-2-platoon-2-squad-3-soldier-6,company-2-platoon-2-squad-3-soldier-7,company-2-platoon-2-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12550"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558,company-2-platoon-2-leader|company-2-platoon-2-leader:12531"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12551"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12552"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12553"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12554"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12555"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12556"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12557"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-8|company-2-platoon-2-squad-3-soldier-8:12558"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12558"
+        TCP_CONNECT: "company-2-platoon-2-squad-3-leader|company-2-platoon-2-squad-3-leader:12550,company-2-platoon-2-squad-3-soldier-1|company-2-platoon-2-squad-3-soldier-1:12551,company-2-platoon-2-squad-3-soldier-2|company-2-platoon-2-squad-3-soldier-2:12552,company-2-platoon-2-squad-3-soldier-3|company-2-platoon-2-squad-3-soldier-3:12553,company-2-platoon-2-squad-3-soldier-4|company-2-platoon-2-squad-3-soldier-4:12554,company-2-platoon-2-squad-3-soldier-5|company-2-platoon-2-squad-3-soldier-5:12555,company-2-platoon-2-squad-3-soldier-6|company-2-platoon-2-squad-3-soldier-6:12556,company-2-platoon-2-squad-3-soldier-7|company-2-platoon-2-squad-3-soldier-7:12557"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        SQUAD_MEMBERS: "company-2-platoon-2-squad-4-soldier-1,company-2-platoon-2-squad-4-soldier-2,company-2-platoon-2-squad-4-soldier-3,company-2-platoon-2-squad-4-soldier-4,company-2-platoon-2-squad-4-soldier-5,company-2-platoon-2-squad-4-soldier-6,company-2-platoon-2-squad-4-soldier-7,company-2-platoon-2-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12559"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567,company-2-platoon-2-leader|company-2-platoon-2-leader:12531"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12560"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12561"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12562"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12563"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12564"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12565"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12566"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-8|company-2-platoon-2-squad-4-soldier-8:12567"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-2-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-2-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12567"
+        TCP_CONNECT: "company-2-platoon-2-squad-4-leader|company-2-platoon-2-squad-4-leader:12559,company-2-platoon-2-squad-4-soldier-1|company-2-platoon-2-squad-4-soldier-1:12560,company-2-platoon-2-squad-4-soldier-2|company-2-platoon-2-squad-4-soldier-2:12561,company-2-platoon-2-squad-4-soldier-3|company-2-platoon-2-squad-4-soldier-3:12562,company-2-platoon-2-squad-4-soldier-4|company-2-platoon-2-squad-4-soldier-4:12563,company-2-platoon-2-squad-4-soldier-5|company-2-platoon-2-squad-4-soldier-5:12564,company-2-platoon-2-squad-4-soldier-6|company-2-platoon-2-squad-4-soldier-6:12565,company-2-platoon-2-squad-4-soldier-7|company-2-platoon-2-squad-4-soldier-7:12566"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-2-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 2-3 -----
+
+    company-2-platoon-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-2-platoon-3
+        SQUAD_IDS: "company-2-platoon-3-squad-1,company-2-platoon-3-squad-2,company-2-platoon-3-squad-3,company-2-platoon-3-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12568"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-commander|company-2-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        SQUAD_MEMBERS: "company-2-platoon-3-squad-1-soldier-1,company-2-platoon-3-squad-1-soldier-2,company-2-platoon-3-squad-1-soldier-3,company-2-platoon-3-squad-1-soldier-4,company-2-platoon-3-squad-1-soldier-5,company-2-platoon-3-squad-1-soldier-6,company-2-platoon-3-squad-1-soldier-7,company-2-platoon-3-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12569"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577,company-2-platoon-3-leader|company-2-platoon-3-leader:12568"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12570"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12571"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12572"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12573"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12574"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12575"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12576"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-8|company-2-platoon-3-squad-1-soldier-8:12577"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12577"
+        TCP_CONNECT: "company-2-platoon-3-squad-1-leader|company-2-platoon-3-squad-1-leader:12569,company-2-platoon-3-squad-1-soldier-1|company-2-platoon-3-squad-1-soldier-1:12570,company-2-platoon-3-squad-1-soldier-2|company-2-platoon-3-squad-1-soldier-2:12571,company-2-platoon-3-squad-1-soldier-3|company-2-platoon-3-squad-1-soldier-3:12572,company-2-platoon-3-squad-1-soldier-4|company-2-platoon-3-squad-1-soldier-4:12573,company-2-platoon-3-squad-1-soldier-5|company-2-platoon-3-squad-1-soldier-5:12574,company-2-platoon-3-squad-1-soldier-6|company-2-platoon-3-squad-1-soldier-6:12575,company-2-platoon-3-squad-1-soldier-7|company-2-platoon-3-squad-1-soldier-7:12576"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        SQUAD_MEMBERS: "company-2-platoon-3-squad-2-soldier-1,company-2-platoon-3-squad-2-soldier-2,company-2-platoon-3-squad-2-soldier-3,company-2-platoon-3-squad-2-soldier-4,company-2-platoon-3-squad-2-soldier-5,company-2-platoon-3-squad-2-soldier-6,company-2-platoon-3-squad-2-soldier-7,company-2-platoon-3-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12578"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586,company-2-platoon-3-leader|company-2-platoon-3-leader:12568"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12579"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12580"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12581"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12582"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12583"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12584"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12585"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-8|company-2-platoon-3-squad-2-soldier-8:12586"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12586"
+        TCP_CONNECT: "company-2-platoon-3-squad-2-leader|company-2-platoon-3-squad-2-leader:12578,company-2-platoon-3-squad-2-soldier-1|company-2-platoon-3-squad-2-soldier-1:12579,company-2-platoon-3-squad-2-soldier-2|company-2-platoon-3-squad-2-soldier-2:12580,company-2-platoon-3-squad-2-soldier-3|company-2-platoon-3-squad-2-soldier-3:12581,company-2-platoon-3-squad-2-soldier-4|company-2-platoon-3-squad-2-soldier-4:12582,company-2-platoon-3-squad-2-soldier-5|company-2-platoon-3-squad-2-soldier-5:12583,company-2-platoon-3-squad-2-soldier-6|company-2-platoon-3-squad-2-soldier-6:12584,company-2-platoon-3-squad-2-soldier-7|company-2-platoon-3-squad-2-soldier-7:12585"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        SQUAD_MEMBERS: "company-2-platoon-3-squad-3-soldier-1,company-2-platoon-3-squad-3-soldier-2,company-2-platoon-3-squad-3-soldier-3,company-2-platoon-3-squad-3-soldier-4,company-2-platoon-3-squad-3-soldier-5,company-2-platoon-3-squad-3-soldier-6,company-2-platoon-3-squad-3-soldier-7,company-2-platoon-3-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12587"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595,company-2-platoon-3-leader|company-2-platoon-3-leader:12568"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12588"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12589"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12590"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12591"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12592"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12593"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12594"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-8|company-2-platoon-3-squad-3-soldier-8:12595"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12595"
+        TCP_CONNECT: "company-2-platoon-3-squad-3-leader|company-2-platoon-3-squad-3-leader:12587,company-2-platoon-3-squad-3-soldier-1|company-2-platoon-3-squad-3-soldier-1:12588,company-2-platoon-3-squad-3-soldier-2|company-2-platoon-3-squad-3-soldier-2:12589,company-2-platoon-3-squad-3-soldier-3|company-2-platoon-3-squad-3-soldier-3:12590,company-2-platoon-3-squad-3-soldier-4|company-2-platoon-3-squad-3-soldier-4:12591,company-2-platoon-3-squad-3-soldier-5|company-2-platoon-3-squad-3-soldier-5:12592,company-2-platoon-3-squad-3-soldier-6|company-2-platoon-3-squad-3-soldier-6:12593,company-2-platoon-3-squad-3-soldier-7|company-2-platoon-3-squad-3-soldier-7:12594"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        SQUAD_MEMBERS: "company-2-platoon-3-squad-4-soldier-1,company-2-platoon-3-squad-4-soldier-2,company-2-platoon-3-squad-4-soldier-3,company-2-platoon-3-squad-4-soldier-4,company-2-platoon-3-squad-4-soldier-5,company-2-platoon-3-squad-4-soldier-6,company-2-platoon-3-squad-4-soldier-7,company-2-platoon-3-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12596"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604,company-2-platoon-3-leader|company-2-platoon-3-leader:12568"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12597"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12598"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12599"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12600"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12601"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12602"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12603"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-8|company-2-platoon-3-squad-4-soldier-8:12604"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-3-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-3-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12604"
+        TCP_CONNECT: "company-2-platoon-3-squad-4-leader|company-2-platoon-3-squad-4-leader:12596,company-2-platoon-3-squad-4-soldier-1|company-2-platoon-3-squad-4-soldier-1:12597,company-2-platoon-3-squad-4-soldier-2|company-2-platoon-3-squad-4-soldier-2:12598,company-2-platoon-3-squad-4-soldier-3|company-2-platoon-3-squad-4-soldier-3:12599,company-2-platoon-3-squad-4-soldier-4|company-2-platoon-3-squad-4-soldier-4:12600,company-2-platoon-3-squad-4-soldier-5|company-2-platoon-3-squad-4-soldier-5:12601,company-2-platoon-3-squad-4-soldier-6|company-2-platoon-3-squad-4-soldier-6:12602,company-2-platoon-3-squad-4-soldier-7|company-2-platoon-3-squad-4-soldier-7:12603"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-3-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 2-4 -----
+
+    company-2-platoon-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-2-platoon-4
+        SQUAD_IDS: "company-2-platoon-4-squad-1,company-2-platoon-4-squad-2,company-2-platoon-4-squad-3,company-2-platoon-4-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12605"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-commander|company-2-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        SQUAD_MEMBERS: "company-2-platoon-4-squad-1-soldier-1,company-2-platoon-4-squad-1-soldier-2,company-2-platoon-4-squad-1-soldier-3,company-2-platoon-4-squad-1-soldier-4,company-2-platoon-4-squad-1-soldier-5,company-2-platoon-4-squad-1-soldier-6,company-2-platoon-4-squad-1-soldier-7,company-2-platoon-4-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12606"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614,company-2-platoon-4-leader|company-2-platoon-4-leader:12605"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12607"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12608"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12609"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12610"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12611"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12612"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12613"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-8|company-2-platoon-4-squad-1-soldier-8:12614"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12614"
+        TCP_CONNECT: "company-2-platoon-4-squad-1-leader|company-2-platoon-4-squad-1-leader:12606,company-2-platoon-4-squad-1-soldier-1|company-2-platoon-4-squad-1-soldier-1:12607,company-2-platoon-4-squad-1-soldier-2|company-2-platoon-4-squad-1-soldier-2:12608,company-2-platoon-4-squad-1-soldier-3|company-2-platoon-4-squad-1-soldier-3:12609,company-2-platoon-4-squad-1-soldier-4|company-2-platoon-4-squad-1-soldier-4:12610,company-2-platoon-4-squad-1-soldier-5|company-2-platoon-4-squad-1-soldier-5:12611,company-2-platoon-4-squad-1-soldier-6|company-2-platoon-4-squad-1-soldier-6:12612,company-2-platoon-4-squad-1-soldier-7|company-2-platoon-4-squad-1-soldier-7:12613"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        SQUAD_MEMBERS: "company-2-platoon-4-squad-2-soldier-1,company-2-platoon-4-squad-2-soldier-2,company-2-platoon-4-squad-2-soldier-3,company-2-platoon-4-squad-2-soldier-4,company-2-platoon-4-squad-2-soldier-5,company-2-platoon-4-squad-2-soldier-6,company-2-platoon-4-squad-2-soldier-7,company-2-platoon-4-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12615"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623,company-2-platoon-4-leader|company-2-platoon-4-leader:12605"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12616"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12617"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12618"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12619"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12620"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12621"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12622"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-8|company-2-platoon-4-squad-2-soldier-8:12623"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12623"
+        TCP_CONNECT: "company-2-platoon-4-squad-2-leader|company-2-platoon-4-squad-2-leader:12615,company-2-platoon-4-squad-2-soldier-1|company-2-platoon-4-squad-2-soldier-1:12616,company-2-platoon-4-squad-2-soldier-2|company-2-platoon-4-squad-2-soldier-2:12617,company-2-platoon-4-squad-2-soldier-3|company-2-platoon-4-squad-2-soldier-3:12618,company-2-platoon-4-squad-2-soldier-4|company-2-platoon-4-squad-2-soldier-4:12619,company-2-platoon-4-squad-2-soldier-5|company-2-platoon-4-squad-2-soldier-5:12620,company-2-platoon-4-squad-2-soldier-6|company-2-platoon-4-squad-2-soldier-6:12621,company-2-platoon-4-squad-2-soldier-7|company-2-platoon-4-squad-2-soldier-7:12622"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        SQUAD_MEMBERS: "company-2-platoon-4-squad-3-soldier-1,company-2-platoon-4-squad-3-soldier-2,company-2-platoon-4-squad-3-soldier-3,company-2-platoon-4-squad-3-soldier-4,company-2-platoon-4-squad-3-soldier-5,company-2-platoon-4-squad-3-soldier-6,company-2-platoon-4-squad-3-soldier-7,company-2-platoon-4-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12624"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632,company-2-platoon-4-leader|company-2-platoon-4-leader:12605"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12625"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12626"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12627"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12628"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12629"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12630"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12631"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-8|company-2-platoon-4-squad-3-soldier-8:12632"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12632"
+        TCP_CONNECT: "company-2-platoon-4-squad-3-leader|company-2-platoon-4-squad-3-leader:12624,company-2-platoon-4-squad-3-soldier-1|company-2-platoon-4-squad-3-soldier-1:12625,company-2-platoon-4-squad-3-soldier-2|company-2-platoon-4-squad-3-soldier-2:12626,company-2-platoon-4-squad-3-soldier-3|company-2-platoon-4-squad-3-soldier-3:12627,company-2-platoon-4-squad-3-soldier-4|company-2-platoon-4-squad-3-soldier-4:12628,company-2-platoon-4-squad-3-soldier-5|company-2-platoon-4-squad-3-soldier-5:12629,company-2-platoon-4-squad-3-soldier-6|company-2-platoon-4-squad-3-soldier-6:12630,company-2-platoon-4-squad-3-soldier-7|company-2-platoon-4-squad-3-soldier-7:12631"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        SQUAD_MEMBERS: "company-2-platoon-4-squad-4-soldier-1,company-2-platoon-4-squad-4-soldier-2,company-2-platoon-4-squad-4-soldier-3,company-2-platoon-4-squad-4-soldier-4,company-2-platoon-4-squad-4-soldier-5,company-2-platoon-4-squad-4-soldier-6,company-2-platoon-4-squad-4-soldier-7,company-2-platoon-4-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12633"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641,company-2-platoon-4-leader|company-2-platoon-4-leader:12605"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12634"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12635"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12636"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12637"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12638"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12639"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12640"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-8|company-2-platoon-4-squad-4-soldier-8:12641"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-2-platoon-4-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-2-platoon-4-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-2-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12641"
+        TCP_CONNECT: "company-2-platoon-4-squad-4-leader|company-2-platoon-4-squad-4-leader:12633,company-2-platoon-4-squad-4-soldier-1|company-2-platoon-4-squad-4-soldier-1:12634,company-2-platoon-4-squad-4-soldier-2|company-2-platoon-4-squad-4-soldier-2:12635,company-2-platoon-4-squad-4-soldier-3|company-2-platoon-4-squad-4-soldier-3:12636,company-2-platoon-4-squad-4-soldier-4|company-2-platoon-4-squad-4-soldier-4:12637,company-2-platoon-4-squad-4-soldier-5|company-2-platoon-4-squad-4-soldier-5:12638,company-2-platoon-4-squad-4-soldier-6|company-2-platoon-4-squad-4-soldier-6:12639,company-2-platoon-4-squad-4-soldier-7|company-2-platoon-4-squad-4-soldier-7:12640"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-2-platoon-4-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+
+    # ===== COMPANY 3 =====
+
+    company-3-commander:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-commander
+        ROLE: company_commander
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        COMPANY_ID: company-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12345"
+        TCP_CONNECT: "company-3-platoon-1-leader|company-3-platoon-1-leader:12642,company-3-platoon-2-leader|company-3-platoon-2-leader:12679,company-3-platoon-3-leader|company-3-platoon-3-leader:12716,company-3-platoon-4-leader|company-3-platoon-4-leader:12753"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-commander
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 3-1 -----
+
+    company-3-platoon-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-3-platoon-1
+        SQUAD_IDS: "company-3-platoon-1-squad-1,company-3-platoon-1-squad-2,company-3-platoon-1-squad-3,company-3-platoon-1-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12642"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-commander|company-3-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        SQUAD_MEMBERS: "company-3-platoon-1-squad-1-soldier-1,company-3-platoon-1-squad-1-soldier-2,company-3-platoon-1-squad-1-soldier-3,company-3-platoon-1-squad-1-soldier-4,company-3-platoon-1-squad-1-soldier-5,company-3-platoon-1-squad-1-soldier-6,company-3-platoon-1-squad-1-soldier-7,company-3-platoon-1-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12643"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651,company-3-platoon-1-leader|company-3-platoon-1-leader:12642"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12644"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12645"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12646"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12647"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12648"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12649"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12650"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-8|company-3-platoon-1-squad-1-soldier-8:12651"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12651"
+        TCP_CONNECT: "company-3-platoon-1-squad-1-leader|company-3-platoon-1-squad-1-leader:12643,company-3-platoon-1-squad-1-soldier-1|company-3-platoon-1-squad-1-soldier-1:12644,company-3-platoon-1-squad-1-soldier-2|company-3-platoon-1-squad-1-soldier-2:12645,company-3-platoon-1-squad-1-soldier-3|company-3-platoon-1-squad-1-soldier-3:12646,company-3-platoon-1-squad-1-soldier-4|company-3-platoon-1-squad-1-soldier-4:12647,company-3-platoon-1-squad-1-soldier-5|company-3-platoon-1-squad-1-soldier-5:12648,company-3-platoon-1-squad-1-soldier-6|company-3-platoon-1-squad-1-soldier-6:12649,company-3-platoon-1-squad-1-soldier-7|company-3-platoon-1-squad-1-soldier-7:12650"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        SQUAD_MEMBERS: "company-3-platoon-1-squad-2-soldier-1,company-3-platoon-1-squad-2-soldier-2,company-3-platoon-1-squad-2-soldier-3,company-3-platoon-1-squad-2-soldier-4,company-3-platoon-1-squad-2-soldier-5,company-3-platoon-1-squad-2-soldier-6,company-3-platoon-1-squad-2-soldier-7,company-3-platoon-1-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12652"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660,company-3-platoon-1-leader|company-3-platoon-1-leader:12642"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12653"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12654"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12655"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12656"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12657"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12658"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12659"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-8|company-3-platoon-1-squad-2-soldier-8:12660"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12660"
+        TCP_CONNECT: "company-3-platoon-1-squad-2-leader|company-3-platoon-1-squad-2-leader:12652,company-3-platoon-1-squad-2-soldier-1|company-3-platoon-1-squad-2-soldier-1:12653,company-3-platoon-1-squad-2-soldier-2|company-3-platoon-1-squad-2-soldier-2:12654,company-3-platoon-1-squad-2-soldier-3|company-3-platoon-1-squad-2-soldier-3:12655,company-3-platoon-1-squad-2-soldier-4|company-3-platoon-1-squad-2-soldier-4:12656,company-3-platoon-1-squad-2-soldier-5|company-3-platoon-1-squad-2-soldier-5:12657,company-3-platoon-1-squad-2-soldier-6|company-3-platoon-1-squad-2-soldier-6:12658,company-3-platoon-1-squad-2-soldier-7|company-3-platoon-1-squad-2-soldier-7:12659"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        SQUAD_MEMBERS: "company-3-platoon-1-squad-3-soldier-1,company-3-platoon-1-squad-3-soldier-2,company-3-platoon-1-squad-3-soldier-3,company-3-platoon-1-squad-3-soldier-4,company-3-platoon-1-squad-3-soldier-5,company-3-platoon-1-squad-3-soldier-6,company-3-platoon-1-squad-3-soldier-7,company-3-platoon-1-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12661"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669,company-3-platoon-1-leader|company-3-platoon-1-leader:12642"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12662"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12663"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12664"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12665"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12666"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12667"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12668"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-8|company-3-platoon-1-squad-3-soldier-8:12669"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12669"
+        TCP_CONNECT: "company-3-platoon-1-squad-3-leader|company-3-platoon-1-squad-3-leader:12661,company-3-platoon-1-squad-3-soldier-1|company-3-platoon-1-squad-3-soldier-1:12662,company-3-platoon-1-squad-3-soldier-2|company-3-platoon-1-squad-3-soldier-2:12663,company-3-platoon-1-squad-3-soldier-3|company-3-platoon-1-squad-3-soldier-3:12664,company-3-platoon-1-squad-3-soldier-4|company-3-platoon-1-squad-3-soldier-4:12665,company-3-platoon-1-squad-3-soldier-5|company-3-platoon-1-squad-3-soldier-5:12666,company-3-platoon-1-squad-3-soldier-6|company-3-platoon-1-squad-3-soldier-6:12667,company-3-platoon-1-squad-3-soldier-7|company-3-platoon-1-squad-3-soldier-7:12668"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        SQUAD_MEMBERS: "company-3-platoon-1-squad-4-soldier-1,company-3-platoon-1-squad-4-soldier-2,company-3-platoon-1-squad-4-soldier-3,company-3-platoon-1-squad-4-soldier-4,company-3-platoon-1-squad-4-soldier-5,company-3-platoon-1-squad-4-soldier-6,company-3-platoon-1-squad-4-soldier-7,company-3-platoon-1-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12670"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678,company-3-platoon-1-leader|company-3-platoon-1-leader:12642"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12671"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12672"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12673"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12674"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12675"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12676"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12677"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-8|company-3-platoon-1-squad-4-soldier-8:12678"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-1-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-1-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-1-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12678"
+        TCP_CONNECT: "company-3-platoon-1-squad-4-leader|company-3-platoon-1-squad-4-leader:12670,company-3-platoon-1-squad-4-soldier-1|company-3-platoon-1-squad-4-soldier-1:12671,company-3-platoon-1-squad-4-soldier-2|company-3-platoon-1-squad-4-soldier-2:12672,company-3-platoon-1-squad-4-soldier-3|company-3-platoon-1-squad-4-soldier-3:12673,company-3-platoon-1-squad-4-soldier-4|company-3-platoon-1-squad-4-soldier-4:12674,company-3-platoon-1-squad-4-soldier-5|company-3-platoon-1-squad-4-soldier-5:12675,company-3-platoon-1-squad-4-soldier-6|company-3-platoon-1-squad-4-soldier-6:12676,company-3-platoon-1-squad-4-soldier-7|company-3-platoon-1-squad-4-soldier-7:12677"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-1-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 3-2 -----
+
+    company-3-platoon-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-3-platoon-2
+        SQUAD_IDS: "company-3-platoon-2-squad-1,company-3-platoon-2-squad-2,company-3-platoon-2-squad-3,company-3-platoon-2-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12679"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-commander|company-3-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        SQUAD_MEMBERS: "company-3-platoon-2-squad-1-soldier-1,company-3-platoon-2-squad-1-soldier-2,company-3-platoon-2-squad-1-soldier-3,company-3-platoon-2-squad-1-soldier-4,company-3-platoon-2-squad-1-soldier-5,company-3-platoon-2-squad-1-soldier-6,company-3-platoon-2-squad-1-soldier-7,company-3-platoon-2-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12680"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688,company-3-platoon-2-leader|company-3-platoon-2-leader:12679"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12681"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12682"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12683"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12684"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12685"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12686"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12687"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-8|company-3-platoon-2-squad-1-soldier-8:12688"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12688"
+        TCP_CONNECT: "company-3-platoon-2-squad-1-leader|company-3-platoon-2-squad-1-leader:12680,company-3-platoon-2-squad-1-soldier-1|company-3-platoon-2-squad-1-soldier-1:12681,company-3-platoon-2-squad-1-soldier-2|company-3-platoon-2-squad-1-soldier-2:12682,company-3-platoon-2-squad-1-soldier-3|company-3-platoon-2-squad-1-soldier-3:12683,company-3-platoon-2-squad-1-soldier-4|company-3-platoon-2-squad-1-soldier-4:12684,company-3-platoon-2-squad-1-soldier-5|company-3-platoon-2-squad-1-soldier-5:12685,company-3-platoon-2-squad-1-soldier-6|company-3-platoon-2-squad-1-soldier-6:12686,company-3-platoon-2-squad-1-soldier-7|company-3-platoon-2-squad-1-soldier-7:12687"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        SQUAD_MEMBERS: "company-3-platoon-2-squad-2-soldier-1,company-3-platoon-2-squad-2-soldier-2,company-3-platoon-2-squad-2-soldier-3,company-3-platoon-2-squad-2-soldier-4,company-3-platoon-2-squad-2-soldier-5,company-3-platoon-2-squad-2-soldier-6,company-3-platoon-2-squad-2-soldier-7,company-3-platoon-2-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12689"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697,company-3-platoon-2-leader|company-3-platoon-2-leader:12679"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12690"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12691"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12692"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12693"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12694"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12695"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12696"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-8|company-3-platoon-2-squad-2-soldier-8:12697"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12697"
+        TCP_CONNECT: "company-3-platoon-2-squad-2-leader|company-3-platoon-2-squad-2-leader:12689,company-3-platoon-2-squad-2-soldier-1|company-3-platoon-2-squad-2-soldier-1:12690,company-3-platoon-2-squad-2-soldier-2|company-3-platoon-2-squad-2-soldier-2:12691,company-3-platoon-2-squad-2-soldier-3|company-3-platoon-2-squad-2-soldier-3:12692,company-3-platoon-2-squad-2-soldier-4|company-3-platoon-2-squad-2-soldier-4:12693,company-3-platoon-2-squad-2-soldier-5|company-3-platoon-2-squad-2-soldier-5:12694,company-3-platoon-2-squad-2-soldier-6|company-3-platoon-2-squad-2-soldier-6:12695,company-3-platoon-2-squad-2-soldier-7|company-3-platoon-2-squad-2-soldier-7:12696"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        SQUAD_MEMBERS: "company-3-platoon-2-squad-3-soldier-1,company-3-platoon-2-squad-3-soldier-2,company-3-platoon-2-squad-3-soldier-3,company-3-platoon-2-squad-3-soldier-4,company-3-platoon-2-squad-3-soldier-5,company-3-platoon-2-squad-3-soldier-6,company-3-platoon-2-squad-3-soldier-7,company-3-platoon-2-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12698"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706,company-3-platoon-2-leader|company-3-platoon-2-leader:12679"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12699"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12700"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12701"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12702"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12703"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12704"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12705"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-8|company-3-platoon-2-squad-3-soldier-8:12706"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12706"
+        TCP_CONNECT: "company-3-platoon-2-squad-3-leader|company-3-platoon-2-squad-3-leader:12698,company-3-platoon-2-squad-3-soldier-1|company-3-platoon-2-squad-3-soldier-1:12699,company-3-platoon-2-squad-3-soldier-2|company-3-platoon-2-squad-3-soldier-2:12700,company-3-platoon-2-squad-3-soldier-3|company-3-platoon-2-squad-3-soldier-3:12701,company-3-platoon-2-squad-3-soldier-4|company-3-platoon-2-squad-3-soldier-4:12702,company-3-platoon-2-squad-3-soldier-5|company-3-platoon-2-squad-3-soldier-5:12703,company-3-platoon-2-squad-3-soldier-6|company-3-platoon-2-squad-3-soldier-6:12704,company-3-platoon-2-squad-3-soldier-7|company-3-platoon-2-squad-3-soldier-7:12705"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        SQUAD_MEMBERS: "company-3-platoon-2-squad-4-soldier-1,company-3-platoon-2-squad-4-soldier-2,company-3-platoon-2-squad-4-soldier-3,company-3-platoon-2-squad-4-soldier-4,company-3-platoon-2-squad-4-soldier-5,company-3-platoon-2-squad-4-soldier-6,company-3-platoon-2-squad-4-soldier-7,company-3-platoon-2-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12707"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715,company-3-platoon-2-leader|company-3-platoon-2-leader:12679"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12708"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12709"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12710"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12711"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12712"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12713"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12714"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-8|company-3-platoon-2-squad-4-soldier-8:12715"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-2-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-2-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-2-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12715"
+        TCP_CONNECT: "company-3-platoon-2-squad-4-leader|company-3-platoon-2-squad-4-leader:12707,company-3-platoon-2-squad-4-soldier-1|company-3-platoon-2-squad-4-soldier-1:12708,company-3-platoon-2-squad-4-soldier-2|company-3-platoon-2-squad-4-soldier-2:12709,company-3-platoon-2-squad-4-soldier-3|company-3-platoon-2-squad-4-soldier-3:12710,company-3-platoon-2-squad-4-soldier-4|company-3-platoon-2-squad-4-soldier-4:12711,company-3-platoon-2-squad-4-soldier-5|company-3-platoon-2-squad-4-soldier-5:12712,company-3-platoon-2-squad-4-soldier-6|company-3-platoon-2-squad-4-soldier-6:12713,company-3-platoon-2-squad-4-soldier-7|company-3-platoon-2-squad-4-soldier-7:12714"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-2-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 3-3 -----
+
+    company-3-platoon-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-3-platoon-3
+        SQUAD_IDS: "company-3-platoon-3-squad-1,company-3-platoon-3-squad-2,company-3-platoon-3-squad-3,company-3-platoon-3-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12716"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-commander|company-3-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        SQUAD_MEMBERS: "company-3-platoon-3-squad-1-soldier-1,company-3-platoon-3-squad-1-soldier-2,company-3-platoon-3-squad-1-soldier-3,company-3-platoon-3-squad-1-soldier-4,company-3-platoon-3-squad-1-soldier-5,company-3-platoon-3-squad-1-soldier-6,company-3-platoon-3-squad-1-soldier-7,company-3-platoon-3-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12717"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725,company-3-platoon-3-leader|company-3-platoon-3-leader:12716"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12718"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12719"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12720"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12721"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12722"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12723"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12724"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-8|company-3-platoon-3-squad-1-soldier-8:12725"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12725"
+        TCP_CONNECT: "company-3-platoon-3-squad-1-leader|company-3-platoon-3-squad-1-leader:12717,company-3-platoon-3-squad-1-soldier-1|company-3-platoon-3-squad-1-soldier-1:12718,company-3-platoon-3-squad-1-soldier-2|company-3-platoon-3-squad-1-soldier-2:12719,company-3-platoon-3-squad-1-soldier-3|company-3-platoon-3-squad-1-soldier-3:12720,company-3-platoon-3-squad-1-soldier-4|company-3-platoon-3-squad-1-soldier-4:12721,company-3-platoon-3-squad-1-soldier-5|company-3-platoon-3-squad-1-soldier-5:12722,company-3-platoon-3-squad-1-soldier-6|company-3-platoon-3-squad-1-soldier-6:12723,company-3-platoon-3-squad-1-soldier-7|company-3-platoon-3-squad-1-soldier-7:12724"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        SQUAD_MEMBERS: "company-3-platoon-3-squad-2-soldier-1,company-3-platoon-3-squad-2-soldier-2,company-3-platoon-3-squad-2-soldier-3,company-3-platoon-3-squad-2-soldier-4,company-3-platoon-3-squad-2-soldier-5,company-3-platoon-3-squad-2-soldier-6,company-3-platoon-3-squad-2-soldier-7,company-3-platoon-3-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12726"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734,company-3-platoon-3-leader|company-3-platoon-3-leader:12716"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12727"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12728"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12729"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12730"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12731"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12732"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12733"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-8|company-3-platoon-3-squad-2-soldier-8:12734"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12734"
+        TCP_CONNECT: "company-3-platoon-3-squad-2-leader|company-3-platoon-3-squad-2-leader:12726,company-3-platoon-3-squad-2-soldier-1|company-3-platoon-3-squad-2-soldier-1:12727,company-3-platoon-3-squad-2-soldier-2|company-3-platoon-3-squad-2-soldier-2:12728,company-3-platoon-3-squad-2-soldier-3|company-3-platoon-3-squad-2-soldier-3:12729,company-3-platoon-3-squad-2-soldier-4|company-3-platoon-3-squad-2-soldier-4:12730,company-3-platoon-3-squad-2-soldier-5|company-3-platoon-3-squad-2-soldier-5:12731,company-3-platoon-3-squad-2-soldier-6|company-3-platoon-3-squad-2-soldier-6:12732,company-3-platoon-3-squad-2-soldier-7|company-3-platoon-3-squad-2-soldier-7:12733"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        SQUAD_MEMBERS: "company-3-platoon-3-squad-3-soldier-1,company-3-platoon-3-squad-3-soldier-2,company-3-platoon-3-squad-3-soldier-3,company-3-platoon-3-squad-3-soldier-4,company-3-platoon-3-squad-3-soldier-5,company-3-platoon-3-squad-3-soldier-6,company-3-platoon-3-squad-3-soldier-7,company-3-platoon-3-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12735"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743,company-3-platoon-3-leader|company-3-platoon-3-leader:12716"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12736"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12737"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12738"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12739"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12740"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12741"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12742"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-8|company-3-platoon-3-squad-3-soldier-8:12743"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12743"
+        TCP_CONNECT: "company-3-platoon-3-squad-3-leader|company-3-platoon-3-squad-3-leader:12735,company-3-platoon-3-squad-3-soldier-1|company-3-platoon-3-squad-3-soldier-1:12736,company-3-platoon-3-squad-3-soldier-2|company-3-platoon-3-squad-3-soldier-2:12737,company-3-platoon-3-squad-3-soldier-3|company-3-platoon-3-squad-3-soldier-3:12738,company-3-platoon-3-squad-3-soldier-4|company-3-platoon-3-squad-3-soldier-4:12739,company-3-platoon-3-squad-3-soldier-5|company-3-platoon-3-squad-3-soldier-5:12740,company-3-platoon-3-squad-3-soldier-6|company-3-platoon-3-squad-3-soldier-6:12741,company-3-platoon-3-squad-3-soldier-7|company-3-platoon-3-squad-3-soldier-7:12742"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        SQUAD_MEMBERS: "company-3-platoon-3-squad-4-soldier-1,company-3-platoon-3-squad-4-soldier-2,company-3-platoon-3-squad-4-soldier-3,company-3-platoon-3-squad-4-soldier-4,company-3-platoon-3-squad-4-soldier-5,company-3-platoon-3-squad-4-soldier-6,company-3-platoon-3-squad-4-soldier-7,company-3-platoon-3-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12744"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752,company-3-platoon-3-leader|company-3-platoon-3-leader:12716"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12745"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12746"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12747"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12748"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12749"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12750"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12751"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-8|company-3-platoon-3-squad-4-soldier-8:12752"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-3-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-3-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-3-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12752"
+        TCP_CONNECT: "company-3-platoon-3-squad-4-leader|company-3-platoon-3-squad-4-leader:12744,company-3-platoon-3-squad-4-soldier-1|company-3-platoon-3-squad-4-soldier-1:12745,company-3-platoon-3-squad-4-soldier-2|company-3-platoon-3-squad-4-soldier-2:12746,company-3-platoon-3-squad-4-soldier-3|company-3-platoon-3-squad-4-soldier-3:12747,company-3-platoon-3-squad-4-soldier-4|company-3-platoon-3-squad-4-soldier-4:12748,company-3-platoon-3-squad-4-soldier-5|company-3-platoon-3-squad-4-soldier-5:12749,company-3-platoon-3-squad-4-soldier-6|company-3-platoon-3-squad-4-soldier-6:12750,company-3-platoon-3-squad-4-soldier-7|company-3-platoon-3-squad-4-soldier-7:12751"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-3-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    # ----- Platoon 3-4 -----
+
+    company-3-platoon-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        PLATOON_ID: company-3-platoon-4
+        SQUAD_IDS: "company-3-platoon-4-squad-1,company-3-platoon-4-squad-2,company-3-platoon-4-squad-3,company-3-platoon-4-squad-4"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12753"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-commander|company-3-commander:12345"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        SQUAD_MEMBERS: "company-3-platoon-4-squad-1-soldier-1,company-3-platoon-4-squad-1-soldier-2,company-3-platoon-4-squad-1-soldier-3,company-3-platoon-4-squad-1-soldier-4,company-3-platoon-4-squad-1-soldier-5,company-3-platoon-4-squad-1-soldier-6,company-3-platoon-4-squad-1-soldier-7,company-3-platoon-4-squad-1-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12754"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762,company-3-platoon-4-leader|company-3-platoon-4-leader:12753"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12755"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12756"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12757"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12758"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12759"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12760"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12761"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-8|company-3-platoon-4-squad-1-soldier-8:12762"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-1-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-1-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12762"
+        TCP_CONNECT: "company-3-platoon-4-squad-1-leader|company-3-platoon-4-squad-1-leader:12754,company-3-platoon-4-squad-1-soldier-1|company-3-platoon-4-squad-1-soldier-1:12755,company-3-platoon-4-squad-1-soldier-2|company-3-platoon-4-squad-1-soldier-2:12756,company-3-platoon-4-squad-1-soldier-3|company-3-platoon-4-squad-1-soldier-3:12757,company-3-platoon-4-squad-1-soldier-4|company-3-platoon-4-squad-1-soldier-4:12758,company-3-platoon-4-squad-1-soldier-5|company-3-platoon-4-squad-1-soldier-5:12759,company-3-platoon-4-squad-1-soldier-6|company-3-platoon-4-squad-1-soldier-6:12760,company-3-platoon-4-squad-1-soldier-7|company-3-platoon-4-squad-1-soldier-7:12761"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-1-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        SQUAD_MEMBERS: "company-3-platoon-4-squad-2-soldier-1,company-3-platoon-4-squad-2-soldier-2,company-3-platoon-4-squad-2-soldier-3,company-3-platoon-4-squad-2-soldier-4,company-3-platoon-4-squad-2-soldier-5,company-3-platoon-4-squad-2-soldier-6,company-3-platoon-4-squad-2-soldier-7,company-3-platoon-4-squad-2-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12763"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771,company-3-platoon-4-leader|company-3-platoon-4-leader:12753"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12764"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12765"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12766"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12767"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12768"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12769"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12770"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-8|company-3-platoon-4-squad-2-soldier-8:12771"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-2-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-2-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12771"
+        TCP_CONNECT: "company-3-platoon-4-squad-2-leader|company-3-platoon-4-squad-2-leader:12763,company-3-platoon-4-squad-2-soldier-1|company-3-platoon-4-squad-2-soldier-1:12764,company-3-platoon-4-squad-2-soldier-2|company-3-platoon-4-squad-2-soldier-2:12765,company-3-platoon-4-squad-2-soldier-3|company-3-platoon-4-squad-2-soldier-3:12766,company-3-platoon-4-squad-2-soldier-4|company-3-platoon-4-squad-2-soldier-4:12767,company-3-platoon-4-squad-2-soldier-5|company-3-platoon-4-squad-2-soldier-5:12768,company-3-platoon-4-squad-2-soldier-6|company-3-platoon-4-squad-2-soldier-6:12769,company-3-platoon-4-squad-2-soldier-7|company-3-platoon-4-squad-2-soldier-7:12770"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-2-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        SQUAD_MEMBERS: "company-3-platoon-4-squad-3-soldier-1,company-3-platoon-4-squad-3-soldier-2,company-3-platoon-4-squad-3-soldier-3,company-3-platoon-4-squad-3-soldier-4,company-3-platoon-4-squad-3-soldier-5,company-3-platoon-4-squad-3-soldier-6,company-3-platoon-4-squad-3-soldier-7,company-3-platoon-4-squad-3-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12772"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780,company-3-platoon-4-leader|company-3-platoon-4-leader:12753"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12773"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12774"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12775"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12776"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12777"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12778"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12779"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-8|company-3-platoon-4-squad-3-soldier-8:12780"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-3-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-3-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12780"
+        TCP_CONNECT: "company-3-platoon-4-squad-3-leader|company-3-platoon-4-squad-3-leader:12772,company-3-platoon-4-squad-3-soldier-1|company-3-platoon-4-squad-3-soldier-1:12773,company-3-platoon-4-squad-3-soldier-2|company-3-platoon-4-squad-3-soldier-2:12774,company-3-platoon-4-squad-3-soldier-3|company-3-platoon-4-squad-3-soldier-3:12775,company-3-platoon-4-squad-3-soldier-4|company-3-platoon-4-squad-3-soldier-4:12776,company-3-platoon-4-squad-3-soldier-5|company-3-platoon-4-squad-3-soldier-5:12777,company-3-platoon-4-squad-3-soldier-6|company-3-platoon-4-squad-3-soldier-6:12778,company-3-platoon-4-squad-3-soldier-7|company-3-platoon-4-squad-3-soldier-7:12779"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-3-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        SQUAD_MEMBERS: "company-3-platoon-4-squad-4-soldier-1,company-3-platoon-4-squad-4-soldier-2,company-3-platoon-4-squad-4-soldier-3,company-3-platoon-4-squad-4-soldier-4,company-3-platoon-4-squad-4-soldier-5,company-3-platoon-4-squad-4-soldier-6,company-3-platoon-4-squad-4-soldier-7,company-3-platoon-4-squad-4-soldier-8"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12781"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789,company-3-platoon-4-leader|company-3-platoon-4-leader:12753"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-leader
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12782"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-1
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12783"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-2
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12784"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-3
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12785"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-4
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12786"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-5
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12787"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-6
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12788"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-8|company-3-platoon-4-squad-4-soldier-8:12789"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-7
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+
+    company-3-platoon-4-squad-4-soldier-8:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-3-platoon-4-squad-4-soldier-8
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        SQUAD_ID: company-3-platoon-4-squad-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12789"
+        TCP_CONNECT: "company-3-platoon-4-squad-4-leader|company-3-platoon-4-squad-4-leader:12781,company-3-platoon-4-squad-4-soldier-1|company-3-platoon-4-squad-4-soldier-1:12782,company-3-platoon-4-squad-4-soldier-2|company-3-platoon-4-squad-4-soldier-2:12783,company-3-platoon-4-squad-4-soldier-3|company-3-platoon-4-squad-4-soldier-3:12784,company-3-platoon-4-squad-4-soldier-4|company-3-platoon-4-squad-4-soldier-4:12785,company-3-platoon-4-squad-4-soldier-5|company-3-platoon-4-squad-4-soldier-5:12786,company-3-platoon-4-squad-4-soldier-6|company-3-platoon-4-squad-4-soldier-6:12787,company-3-platoon-4-squad-4-soldier-7|company-3-platoon-4-squad-4-soldier-7:12788"
+        BACKEND: automerge
+        CAP_DATA_PATH: /data/automerge/company-3-platoon-4-squad-4-soldier-8
+        HIVE_SECRET_KEY: MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=
+        ENABLE_MDNS: "false"
+

--- a/hive-sim/topologies/lab4-automerge-96n-1gbps.yaml
+++ b/hive-sim/topologies/lab4-automerge-96n-1gbps.yaml
@@ -1,0 +1,2156 @@
+# Lab 4: Hierarchical HIVE CRDT - am96n
+# Target nodes: 96, Actual: 101
+# Structure: 1 companies × 4 platoons × 3 squads × 7 soldiers
+# Bandwidth: 1gbps
+
+name: am96n
+
+mgmt:
+  network: am96n
+  ipv4-subnet: 172.20.20.0/24
+
+topology:
+  nodes:
+
+    # ===== COMPANY 1 =====
+
+    company-1-commander:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-commander
+        ROLE: company_commander
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        COMPANY_ID: company-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12345"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    # ----- Platoon 1-1 -----
+
+    company-1-platoon-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        PLATOON_ID: company-1-platoon-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12346"
+        TCP_CONNECT: "company-1-commander|clab-am96n-company-1-commander:12345"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-1-squad-1-soldier-1,company-1-platoon-1-squad-1-soldier-2,company-1-platoon-1-squad-1-soldier-3,company-1-platoon-1-squad-1-soldier-4,company-1-platoon-1-squad-1-soldier-5,company-1-platoon-1-squad-1-soldier-6,company-1-platoon-1-squad-1-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12347"
+        TCP_CONNECT: "company-1-platoon-1-leader|clab-am96n-company-1-platoon-1-leader:12346"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12348"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|clab-am96n-company-1-platoon-1-squad-1-leader:12347"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12349"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|clab-am96n-company-1-platoon-1-squad-1-leader:12347"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12350"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|clab-am96n-company-1-platoon-1-squad-1-leader:12347"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12351"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|clab-am96n-company-1-platoon-1-squad-1-leader:12347"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12352"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|clab-am96n-company-1-platoon-1-squad-1-leader:12347"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12353"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|clab-am96n-company-1-platoon-1-squad-1-leader:12347"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12354"
+        TCP_CONNECT: "company-1-platoon-1-squad-1-leader|clab-am96n-company-1-platoon-1-squad-1-leader:12347"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-1-squad-2-soldier-1,company-1-platoon-1-squad-2-soldier-2,company-1-platoon-1-squad-2-soldier-3,company-1-platoon-1-squad-2-soldier-4,company-1-platoon-1-squad-2-soldier-5,company-1-platoon-1-squad-2-soldier-6,company-1-platoon-1-squad-2-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12355"
+        TCP_CONNECT: "company-1-platoon-1-leader|clab-am96n-company-1-platoon-1-leader:12346"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12356"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|clab-am96n-company-1-platoon-1-squad-2-leader:12355"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12357"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|clab-am96n-company-1-platoon-1-squad-2-leader:12355"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12358"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|clab-am96n-company-1-platoon-1-squad-2-leader:12355"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12359"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|clab-am96n-company-1-platoon-1-squad-2-leader:12355"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12360"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|clab-am96n-company-1-platoon-1-squad-2-leader:12355"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12361"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|clab-am96n-company-1-platoon-1-squad-2-leader:12355"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12362"
+        TCP_CONNECT: "company-1-platoon-1-squad-2-leader|clab-am96n-company-1-platoon-1-squad-2-leader:12355"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-1-squad-3-soldier-1,company-1-platoon-1-squad-3-soldier-2,company-1-platoon-1-squad-3-soldier-3,company-1-platoon-1-squad-3-soldier-4,company-1-platoon-1-squad-3-soldier-5,company-1-platoon-1-squad-3-soldier-6,company-1-platoon-1-squad-3-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12363"
+        TCP_CONNECT: "company-1-platoon-1-leader|clab-am96n-company-1-platoon-1-leader:12346"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12364"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|clab-am96n-company-1-platoon-1-squad-3-leader:12363"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12365"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|clab-am96n-company-1-platoon-1-squad-3-leader:12363"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12366"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|clab-am96n-company-1-platoon-1-squad-3-leader:12363"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12367"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|clab-am96n-company-1-platoon-1-squad-3-leader:12363"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12368"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|clab-am96n-company-1-platoon-1-squad-3-leader:12363"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12369"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|clab-am96n-company-1-platoon-1-squad-3-leader:12363"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-1-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-1-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-1-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12370"
+        TCP_CONNECT: "company-1-platoon-1-squad-3-leader|clab-am96n-company-1-platoon-1-squad-3-leader:12363"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    # ----- Platoon 1-2 -----
+
+    company-1-platoon-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        PLATOON_ID: company-1-platoon-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12371"
+        TCP_CONNECT: "company-1-commander|clab-am96n-company-1-commander:12345"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-2-squad-1-soldier-1,company-1-platoon-2-squad-1-soldier-2,company-1-platoon-2-squad-1-soldier-3,company-1-platoon-2-squad-1-soldier-4,company-1-platoon-2-squad-1-soldier-5,company-1-platoon-2-squad-1-soldier-6,company-1-platoon-2-squad-1-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12372"
+        TCP_CONNECT: "company-1-platoon-2-leader|clab-am96n-company-1-platoon-2-leader:12371"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12373"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|clab-am96n-company-1-platoon-2-squad-1-leader:12372"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12374"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|clab-am96n-company-1-platoon-2-squad-1-leader:12372"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12375"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|clab-am96n-company-1-platoon-2-squad-1-leader:12372"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12376"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|clab-am96n-company-1-platoon-2-squad-1-leader:12372"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12377"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|clab-am96n-company-1-platoon-2-squad-1-leader:12372"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12378"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|clab-am96n-company-1-platoon-2-squad-1-leader:12372"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12379"
+        TCP_CONNECT: "company-1-platoon-2-squad-1-leader|clab-am96n-company-1-platoon-2-squad-1-leader:12372"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-2-squad-2-soldier-1,company-1-platoon-2-squad-2-soldier-2,company-1-platoon-2-squad-2-soldier-3,company-1-platoon-2-squad-2-soldier-4,company-1-platoon-2-squad-2-soldier-5,company-1-platoon-2-squad-2-soldier-6,company-1-platoon-2-squad-2-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12380"
+        TCP_CONNECT: "company-1-platoon-2-leader|clab-am96n-company-1-platoon-2-leader:12371"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12381"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|clab-am96n-company-1-platoon-2-squad-2-leader:12380"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12382"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|clab-am96n-company-1-platoon-2-squad-2-leader:12380"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12383"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|clab-am96n-company-1-platoon-2-squad-2-leader:12380"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12384"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|clab-am96n-company-1-platoon-2-squad-2-leader:12380"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12385"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|clab-am96n-company-1-platoon-2-squad-2-leader:12380"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12386"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|clab-am96n-company-1-platoon-2-squad-2-leader:12380"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12387"
+        TCP_CONNECT: "company-1-platoon-2-squad-2-leader|clab-am96n-company-1-platoon-2-squad-2-leader:12380"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-2-squad-3-soldier-1,company-1-platoon-2-squad-3-soldier-2,company-1-platoon-2-squad-3-soldier-3,company-1-platoon-2-squad-3-soldier-4,company-1-platoon-2-squad-3-soldier-5,company-1-platoon-2-squad-3-soldier-6,company-1-platoon-2-squad-3-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12388"
+        TCP_CONNECT: "company-1-platoon-2-leader|clab-am96n-company-1-platoon-2-leader:12371"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12389"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|clab-am96n-company-1-platoon-2-squad-3-leader:12388"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12390"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|clab-am96n-company-1-platoon-2-squad-3-leader:12388"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12391"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|clab-am96n-company-1-platoon-2-squad-3-leader:12388"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12392"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|clab-am96n-company-1-platoon-2-squad-3-leader:12388"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12393"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|clab-am96n-company-1-platoon-2-squad-3-leader:12388"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12394"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|clab-am96n-company-1-platoon-2-squad-3-leader:12388"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-2-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-2-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-2-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12395"
+        TCP_CONNECT: "company-1-platoon-2-squad-3-leader|clab-am96n-company-1-platoon-2-squad-3-leader:12388"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    # ----- Platoon 1-3 -----
+
+    company-1-platoon-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        PLATOON_ID: company-1-platoon-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12396"
+        TCP_CONNECT: "company-1-commander|clab-am96n-company-1-commander:12345"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-3-squad-1-soldier-1,company-1-platoon-3-squad-1-soldier-2,company-1-platoon-3-squad-1-soldier-3,company-1-platoon-3-squad-1-soldier-4,company-1-platoon-3-squad-1-soldier-5,company-1-platoon-3-squad-1-soldier-6,company-1-platoon-3-squad-1-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12397"
+        TCP_CONNECT: "company-1-platoon-3-leader|clab-am96n-company-1-platoon-3-leader:12396"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12398"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|clab-am96n-company-1-platoon-3-squad-1-leader:12397"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12399"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|clab-am96n-company-1-platoon-3-squad-1-leader:12397"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12400"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|clab-am96n-company-1-platoon-3-squad-1-leader:12397"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12401"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|clab-am96n-company-1-platoon-3-squad-1-leader:12397"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12402"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|clab-am96n-company-1-platoon-3-squad-1-leader:12397"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12403"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|clab-am96n-company-1-platoon-3-squad-1-leader:12397"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12404"
+        TCP_CONNECT: "company-1-platoon-3-squad-1-leader|clab-am96n-company-1-platoon-3-squad-1-leader:12397"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-3-squad-2-soldier-1,company-1-platoon-3-squad-2-soldier-2,company-1-platoon-3-squad-2-soldier-3,company-1-platoon-3-squad-2-soldier-4,company-1-platoon-3-squad-2-soldier-5,company-1-platoon-3-squad-2-soldier-6,company-1-platoon-3-squad-2-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12405"
+        TCP_CONNECT: "company-1-platoon-3-leader|clab-am96n-company-1-platoon-3-leader:12396"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12406"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|clab-am96n-company-1-platoon-3-squad-2-leader:12405"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12407"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|clab-am96n-company-1-platoon-3-squad-2-leader:12405"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12408"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|clab-am96n-company-1-platoon-3-squad-2-leader:12405"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12409"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|clab-am96n-company-1-platoon-3-squad-2-leader:12405"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12410"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|clab-am96n-company-1-platoon-3-squad-2-leader:12405"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12411"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|clab-am96n-company-1-platoon-3-squad-2-leader:12405"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12412"
+        TCP_CONNECT: "company-1-platoon-3-squad-2-leader|clab-am96n-company-1-platoon-3-squad-2-leader:12405"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-3-squad-3-soldier-1,company-1-platoon-3-squad-3-soldier-2,company-1-platoon-3-squad-3-soldier-3,company-1-platoon-3-squad-3-soldier-4,company-1-platoon-3-squad-3-soldier-5,company-1-platoon-3-squad-3-soldier-6,company-1-platoon-3-squad-3-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12413"
+        TCP_CONNECT: "company-1-platoon-3-leader|clab-am96n-company-1-platoon-3-leader:12396"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12414"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|clab-am96n-company-1-platoon-3-squad-3-leader:12413"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12415"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|clab-am96n-company-1-platoon-3-squad-3-leader:12413"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12416"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|clab-am96n-company-1-platoon-3-squad-3-leader:12413"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12417"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|clab-am96n-company-1-platoon-3-squad-3-leader:12413"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12418"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|clab-am96n-company-1-platoon-3-squad-3-leader:12413"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12419"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|clab-am96n-company-1-platoon-3-squad-3-leader:12413"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-3-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-3-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-3-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12420"
+        TCP_CONNECT: "company-1-platoon-3-squad-3-leader|clab-am96n-company-1-platoon-3-squad-3-leader:12413"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    # ----- Platoon 1-4 -----
+
+    company-1-platoon-4-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-leader
+        ROLE: platoon_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        PLATOON_ID: company-1-platoon-4
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12421"
+        TCP_CONNECT: "company-1-commander|clab-am96n-company-1-commander:12345"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        SQUAD_MEMBERS: "company-1-platoon-4-squad-1-soldier-1,company-1-platoon-4-squad-1-soldier-2,company-1-platoon-4-squad-1-soldier-3,company-1-platoon-4-squad-1-soldier-4,company-1-platoon-4-squad-1-soldier-5,company-1-platoon-4-squad-1-soldier-6,company-1-platoon-4-squad-1-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12422"
+        TCP_CONNECT: "company-1-platoon-4-leader|clab-am96n-company-1-platoon-4-leader:12421"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12423"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|clab-am96n-company-1-platoon-4-squad-1-leader:12422"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12424"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|clab-am96n-company-1-platoon-4-squad-1-leader:12422"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12425"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|clab-am96n-company-1-platoon-4-squad-1-leader:12422"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12426"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|clab-am96n-company-1-platoon-4-squad-1-leader:12422"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12427"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|clab-am96n-company-1-platoon-4-squad-1-leader:12422"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12428"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|clab-am96n-company-1-platoon-4-squad-1-leader:12422"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-1-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-1-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-1
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12429"
+        TCP_CONNECT: "company-1-platoon-4-squad-1-leader|clab-am96n-company-1-platoon-4-squad-1-leader:12422"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        SQUAD_MEMBERS: "company-1-platoon-4-squad-2-soldier-1,company-1-platoon-4-squad-2-soldier-2,company-1-platoon-4-squad-2-soldier-3,company-1-platoon-4-squad-2-soldier-4,company-1-platoon-4-squad-2-soldier-5,company-1-platoon-4-squad-2-soldier-6,company-1-platoon-4-squad-2-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12430"
+        TCP_CONNECT: "company-1-platoon-4-leader|clab-am96n-company-1-platoon-4-leader:12421"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12431"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|clab-am96n-company-1-platoon-4-squad-2-leader:12430"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12432"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|clab-am96n-company-1-platoon-4-squad-2-leader:12430"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12433"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|clab-am96n-company-1-platoon-4-squad-2-leader:12430"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12434"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|clab-am96n-company-1-platoon-4-squad-2-leader:12430"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12435"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|clab-am96n-company-1-platoon-4-squad-2-leader:12430"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12436"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|clab-am96n-company-1-platoon-4-squad-2-leader:12430"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-2-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-2-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-2
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12437"
+        TCP_CONNECT: "company-1-platoon-4-squad-2-leader|clab-am96n-company-1-platoon-4-squad-2-leader:12430"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-leader:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-leader
+        ROLE: squad_leader
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        SQUAD_MEMBERS: "company-1-platoon-4-squad-3-soldier-1,company-1-platoon-4-squad-3-soldier-2,company-1-platoon-4-squad-3-soldier-3,company-1-platoon-4-squad-3-soldier-4,company-1-platoon-4-squad-3-soldier-5,company-1-platoon-4-squad-3-soldier-6,company-1-platoon-4-squad-3-soldier-7"
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12438"
+        TCP_CONNECT: "company-1-platoon-4-leader|clab-am96n-company-1-platoon-4-leader:12421"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-soldier-1:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-1
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12439"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|clab-am96n-company-1-platoon-4-squad-3-leader:12438"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-soldier-2:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-2
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12440"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|clab-am96n-company-1-platoon-4-squad-3-leader:12438"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-soldier-3:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-3
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12441"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|clab-am96n-company-1-platoon-4-squad-3-leader:12438"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-soldier-4:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-4
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12442"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|clab-am96n-company-1-platoon-4-squad-3-leader:12438"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-soldier-5:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-5
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12443"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|clab-am96n-company-1-platoon-4-squad-3-leader:12438"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-soldier-6:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-6
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12444"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|clab-am96n-company-1-platoon-4-squad-3-leader:12438"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+
+    company-1-platoon-4-squad-3-soldier-7:
+      kind: linux
+      image: hive-sim-node:latest
+      env:
+        NODE_ID: company-1-platoon-4-squad-3-soldier-7
+        ROLE: soldier
+        PLATFORM_TYPE: soldier
+        NODE_TYPE: soldier
+        MODE: hierarchical
+        BACKEND: automerge
+        SQUAD_ID: company-1-platoon-4-squad-3
+        UPDATE_RATE_MS: "5000"
+        TCP_LISTEN: "12445"
+        TCP_CONNECT: "company-1-platoon-4-squad-3-leader|clab-am96n-company-1-platoon-4-squad-3-leader:12438"
+        DITTO_APP_ID: test-formation
+        HIVE_SECRET_KEY: aGl2ZS10ZXN0LWZvcm1hdGlvbi1zZWNyZXQta2V5LTA=
+        CIRCUIT_FAILURE_THRESHOLD: "3"
+        CIRCUIT_FAILURE_WINDOW_SECS: "2"
+        CIRCUIT_OPEN_TIMEOUT_SECS: "2"
+        CIRCUIT_SUCCESS_THRESHOLD: "2"
+


### PR DESCRIPTION
## Summary

Fixes two issues causing container startup failures in containerlab deployments:

1. **DNS Retry Logic**: DNS resolution can fail during container startup race conditions. Previously, a single failed lookup would permanently skip the peer. Now retries 30 times with 2-second intervals (60s total timeout).

2. **IPv6 Removal**: Removed IPv6 subnet from topology files. IPv6 multicast advertisement was causing race conditions during parallel container startup:
   ```
   failed to set up container networking: failed to advertise addresses: 
   write ip ::1->ff02::1: sendmsg: invalid argument
   ```

## Test Results

Before fix: ~10% of containers stuck in "Created" state
After fix: 100% of containers start successfully (101/101 running)

## Test plan
- [x] Verified 96n topology deploys with all 101 containers running
- [ ] Run full 384n test to collect updated metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)