### PR TITLE
fix(transport): Make accept loop resilient to transient errors (#346)

### DIFF
--- a/hive-protocol/src/network/iroh_transport.rs
+++ b/hive-protocol/src/network/iroh_transport.rs
@@ -917,14 +917,32 @@ impl IrohTransport {
     /// connection and accept the new one.
     ///
     /// Callers MUST check for `None` and skip authentication in that case.
+    ///
+    /// # Error Handling (Issue #346)
+    ///
+    /// - Returns `Ok(None)` for transient errors (failed QUIC handshake, connection timeout)
+    /// - Returns `Err` only when the endpoint is closed (accept loop should stop)
+    ///
+    /// This ensures the accept loop survives transient network issues.
     pub async fn accept(&self) -> Result<Option<Connection>> {
         let incoming = self
             .endpoint
             .accept()
             .await
-            .context("No incoming connection")?;
+            .context("Endpoint closed - no more incoming connections")?;
 
-        let conn = incoming.await.context("Failed to accept connection")?;
+        // Issue #346: Handle transient errors gracefully
+        // If the QUIC handshake fails (e.g., timeout, client abort), don't kill the accept loop
+        let conn = match incoming.await {
+            Ok(conn) => conn,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Incoming connection failed during QUIC handshake (transient, continuing)"
+                );
+                return Ok(None); // Transient error - accept loop should continue
+            }
+        };
         let remote_id = conn.remote_id();
 
         let mut connections = self.connections.write().unwrap();

--- a/hive-protocol/src/sync/automerge.rs
+++ b/hive-protocol/src/sync/automerge.rs
@@ -1209,13 +1209,18 @@ impl PeerDiscovery for IrohPeerDiscovery {
             tokio::spawn(async move {
                 use crate::network::formation_handshake::perform_responder_handshake;
 
+                // Issue #346: Track consecutive errors to detect permanent failures
+                let mut consecutive_errors = 0u32;
+                const MAX_CONSECUTIVE_ERRORS: u32 = 10;
+
                 loop {
                     // Accept incoming connection
                     // Note (Issue #229): accept() returns Option<Connection>
                     // - Some(conn) = new connection that needs authentication
-                    // - None = duplicate connection (already have one to this peer), skip handshake
+                    // - None = duplicate/transient (already handled or failed QUIC handshake)
                     match transport.accept().await {
                         Ok(Some(conn)) => {
+                            consecutive_errors = 0; // Reset on success
                             let peer_id = conn.remote_id();
                             tracing::debug!("Accepted connection from: {:?}", peer_id);
 
@@ -1238,18 +1243,48 @@ impl PeerDiscovery for IrohPeerDiscovery {
                             }
                         }
                         Ok(None) => {
-                            // Duplicate connection - already have one to this peer (Issue #229)
-                            // Skip handshake since the existing connection is already authenticated
-                            tracing::debug!("Duplicate connection closed, using existing");
+                            // Issue #346: This now includes transient errors (failed QUIC handshake)
+                            // as well as duplicate connections. Either way, continue accepting.
+                            consecutive_errors = 0; // Reset - we're still accepting
+                            tracing::debug!(
+                                "Accept returned None (duplicate conn or transient error), continuing"
+                            );
                         }
                         Err(e) => {
-                            // Accept loop stopped or endpoint closed
-                            tracing::debug!("Accept loop ended: {}", e);
-                            break;
+                            // Issue #346: Only fatal errors (endpoint closed) should stop the loop
+                            // But add a circuit breaker for repeated failures
+                            consecutive_errors += 1;
+                            let error_msg = format!("{}", e);
+
+                            if error_msg.contains("Endpoint closed")
+                                || error_msg.contains("no more")
+                            {
+                                tracing::info!("Accept loop stopped: endpoint closed");
+                                break;
+                            }
+
+                            if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                                tracing::error!(
+                                    consecutive_errors,
+                                    error = %e,
+                                    "Accept loop stopping after {} consecutive errors",
+                                    MAX_CONSECUTIVE_ERRORS
+                                );
+                                break;
+                            }
+
+                            tracing::warn!(
+                                error = %e,
+                                consecutive_errors,
+                                "Accept error (will retry, {} more before stopping)",
+                                MAX_CONSECUTIVE_ERRORS - consecutive_errors
+                            );
+                            // Small delay before retrying to avoid tight error loop
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                         }
                     }
                 }
-                tracing::debug!("Authenticated accept loop stopped");
+                tracing::info!("Authenticated accept loop stopped");
             });
         }
 

--- a/hive-sim/src/main.rs
+++ b/hive-sim/src/main.rs
@@ -1213,10 +1213,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     if let Some(port) = tcp_listen_port {
-        println!("[{}] TCP: Will listen on port {}", node_id, port);
+        // Note: For automerge backend, this is actually QUIC (UDP), not TCP
+        // The env var name is TCP_LISTEN for Ditto compatibility but automerge uses QUIC
+        if backend_type == "automerge" {
+            println!("[{}] QUIC: Will listen on UDP port {}", node_id, port);
+        } else {
+            println!("[{}] TCP: Will listen on port {}", node_id, port);
+        }
     }
     if let Some(ref addr) = tcp_connect_addr {
-        println!("[{}] TCP: Will connect to {}", node_id, addr);
+        if backend_type == "automerge" {
+            println!("[{}] QUIC: Will connect to {}", node_id, addr);
+        } else {
+            println!("[{}] TCP: Will connect to {}", node_id, addr);
+        }
     }
 
     // Create backend


### PR DESCRIPTION
## Summary

Fixes #346 (P1-Critical: Automerge-iroh TCP connection instability in hierarchical mode)

**Root Cause Identified**: The QUIC accept loop was dying permanently after ANY error, including transient ones like failed handshakes.

The symptoms in #346 were:
1. "✓ Connected to peer 'company-1-platoon-1-leader'" - initial connection works
2. "✗ Failed to connect to peer 'company-1-platoon-1-leader' after 10 attempts" - reconnection fails

This happened because:
1. Initial connections worked while the accept loop was running
2. A transient error (e.g., failed QUIC handshake from another node) killed the accept loop
3. No more connections could be accepted, so all reconnection attempts failed

## Changes

### IrohTransport::accept() 
- Handle `incoming.await` errors gracefully - return `Ok(None)` for transient failures
- Only return `Err` when the endpoint is truly closed
- Documents the error handling contract

### IrohPeerDiscovery accept loop
- Added circuit breaker with consecutive error tracking (max 10)
- Only break loop on fatal errors (endpoint closed) or after 10 consecutive failures
- Continue accepting on transient errors with warning log
- Small delay (100ms) between retries to avoid tight error loops

### hive-sim logging
- Fixed misleading "TCP" messages - now correctly says "QUIC/UDP" for automerge backend
- This caused confusion during debugging (netstat -tlnp shows TCP, but QUIC uses UDP)

## Test plan

- [x] All 1174 unit tests pass
- [x] Pre-commit checks (fmt, clippy) pass
- [ ] Lab 4 containerlab validation (Experiments team)

## Note on Previous Fix (#349)

PR #349 (tie-breaking bypass) was correctly diagnosed but insufficient. The tie-breaking fix ensures connections CAN be initiated, but this fix ensures they can actually be ACCEPTED. Both fixes are needed:
- #349: Ensures child nodes initiate connections to parents
- This PR: Ensures parent nodes keep accepting connections

🤖 Generated with [Claude Code](https://claude.com/claude-code)