### PR TITLE
feat(atak): Add ATAK PLI broadcast to HIVE network

### DIFF
--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
@@ -7,6 +7,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.Gravity
 import android.view.View
+import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
@@ -115,6 +116,7 @@ class HiveDropDownReceiver(
     }
 
     private fun buildContentContainer(): LinearLayout {
+        Log.d(TAG, "Building content - cells: ${mapComponent.cells.size}, tracks: ${mapComponent.tracks.size}, platforms: ${mapComponent.platforms.size}")
         val container = LinearLayout(pluginContext).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(32, 32, 32, 32)
@@ -148,6 +150,11 @@ class HiveDropDownReceiver(
         container.addView(header)
 
         // Spacer
+        container.addView(createSpacer(24))
+
+        // PLI Broadcast section
+        val pliSection = createPliBroadcastSection()
+        container.addView(pliSection)
         container.addView(createSpacer(24))
 
         // Cells section
@@ -478,6 +485,74 @@ class HiveDropDownReceiver(
         }
 
         return card
+    }
+
+    private fun createPliBroadcastSection(): View {
+        val section = LinearLayout(pluginContext).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+
+        // Title
+        val title = TextView(pluginContext).apply {
+            text = "PLI Broadcast"
+            textSize = 16f
+            setTextColor(Color.WHITE)
+        }
+        section.addView(title)
+        section.addView(createSpacer(12))
+
+        // Card with toggle and status
+        val card = LinearLayout(pluginContext).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.parseColor("#2d2d2d"))
+            setPadding(24, 16, 24, 16)
+        }
+
+        // Description
+        val description = TextView(pluginContext).apply {
+            text = "Share your position with HIVE network peers"
+            textSize = 12f
+            setTextColor(Color.GRAY)
+        }
+        card.addView(description)
+        card.addView(createSpacer(12))
+
+        // Toggle button row
+        val buttonRow = LinearLayout(pluginContext).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+
+        val isEnabled = mapComponent.pliBroadcastEnabled
+        val toggleButton = Button(pluginContext).apply {
+            text = if (isEnabled) "Stop Broadcasting" else "Start Broadcasting"
+            setBackgroundColor(if (isEnabled) Color.parseColor("#F44336") else Color.parseColor("#4CAF50"))
+            setTextColor(Color.WHITE)
+            textSize = 12f
+            setPadding(32, 16, 32, 16)
+
+            setOnClickListener {
+                val newState = !mapComponent.pliBroadcastEnabled
+                mapComponent.setPliBroadcastEnabled(newState)
+                // Refresh the UI to show updated state
+                handler.postDelayed({ refreshContent() }, 100)
+            }
+        }
+        buttonRow.addView(toggleButton)
+        card.addView(buttonRow)
+        card.addView(createSpacer(12))
+
+        // Status indicator
+        val statusColor = if (isEnabled) Color.parseColor("#4CAF50") else Color.GRAY
+        val statusText = TextView(pluginContext).apply {
+            text = "Status: ${mapComponent.lastBroadcastStatus}"
+            textSize = 11f
+            setTextColor(statusColor)
+        }
+        card.addView(statusText)
+
+        section.addView(card)
+        return section
     }
 
     override fun onDropDownSelectionRemoved() {}

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveJni.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveJni.kt
@@ -146,6 +146,15 @@ object HiveJni {
     external fun getPlatformsJni(handle: Long): String
 
     /**
+     * Publish a platform (self-position/PLI) to the HIVE network.
+     * @param handle Node handle from createNodeJni
+     * @param platformJson JSON string representing the platform data
+     * @return true if published successfully
+     */
+    @JvmStatic
+    external fun publishPlatformJni(handle: Long, platformJson: String): Boolean
+
+    /**
      * Test if JNI bindings are working.
      * @return true if JNI is functional
      */
@@ -303,6 +312,13 @@ class HiveNodeJni private constructor(private val handle: Long) : AutoCloseable 
      * @return JSON array of platform objects
      */
     fun getPlatformsJson(): String = HiveJni.getPlatformsJni(handle)
+
+    /**
+     * Publish a platform (self-position/PLI) to the HIVE network.
+     * @param platformJson JSON string representing the platform data
+     * @return true if published successfully
+     */
+    fun publishPlatform(platformJson: String): Boolean = HiveJni.publishPlatformJni(handle, platformJson)
 
     /**
      * Free the native node resources.

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
@@ -38,6 +38,13 @@ class HiveMapComponent : DropDownMapComponent() {
     private val refreshHandler = Handler(Looper.getMainLooper())
     private var isRefreshing = false
 
+    // Self-position broadcaster for PLI
+    private var selfPositionBroadcaster: SelfPositionBroadcaster? = null
+    private var _pliBroadcastEnabled = false
+    val pliBroadcastEnabled: Boolean get() = _pliBroadcastEnabled
+    private var _lastBroadcastStatus: String = "Not started"
+    val lastBroadcastStatus: String get() = _lastBroadcastStatus
+
     // Simple state management without coroutines
     private val _cells = mutableListOf<HiveCell>()
     val cells: List<HiveCell> get() = _cells.toList()
@@ -65,6 +72,14 @@ class HiveMapComponent : DropDownMapComponent() {
         trackOverlay = HiveTrackOverlay(view)
         Log.d(TAG, "Track overlay created")
 
+        // Create self-position broadcaster for PLI
+        selfPositionBroadcaster = SelfPositionBroadcaster(view)
+        selfPositionBroadcaster?.onBroadcastCallback = { success, message ->
+            _lastBroadcastStatus = message
+            Log.d(TAG, "PLI broadcast: $success - $message")
+        }
+        Log.d(TAG, "Self-position broadcaster created")
+
         // Create dropdown receiver
         dropDownReceiver = HiveDropDownReceiver(view, context, this)
 
@@ -85,6 +100,8 @@ class HiveMapComponent : DropDownMapComponent() {
     override fun onDestroyImpl(context: Context, view: MapView) {
         Log.d(TAG, "HiveMapComponent onDestroy")
         stopPeriodicRefresh()
+        selfPositionBroadcaster?.stop()
+        selfPositionBroadcaster = null
         trackOverlay?.dispose()
         trackOverlay = null
         super.onDestroyImpl(context, view)
@@ -392,6 +409,29 @@ class HiveMapComponent : DropDownMapComponent() {
      */
     fun updateMapMarkers() {
         trackOverlay?.updateTracks(_tracks)
+    }
+
+    /**
+     * Enable or disable PLI (self-position) broadcasting to HIVE network.
+     * @param enabled true to start broadcasting, false to stop
+     */
+    fun setPliBroadcastEnabled(enabled: Boolean) {
+        _pliBroadcastEnabled = enabled
+        if (enabled) {
+            selfPositionBroadcaster?.start()
+            Log.i(TAG, "PLI broadcast enabled")
+        } else {
+            selfPositionBroadcaster?.stop()
+            _lastBroadcastStatus = "Disabled"
+            Log.i(TAG, "PLI broadcast disabled")
+        }
+    }
+
+    /**
+     * Manually trigger a single PLI broadcast (for testing).
+     */
+    fun broadcastPliNow() {
+        selfPositionBroadcaster?.broadcastNow()
     }
 
     /**

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/SelfPositionBroadcaster.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/SelfPositionBroadcaster.kt
@@ -1,0 +1,187 @@
+package com.revolveteam.atak.hive
+
+import android.os.Handler
+import android.os.Looper
+import com.atakmap.android.maps.MapView
+import com.atakmap.android.maps.PointMapItem
+import com.atakmap.coremap.log.Log
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Broadcasts ATAK self-position (PLI) to the HIVE network.
+ *
+ * This class monitors the device's self-marker in ATAK and periodically
+ * publishes the position as a platform to the HIVE mesh network. This allows
+ * other HIVE nodes (including the test client) to see the ATAK user's position.
+ *
+ * @param mapView The ATAK MapView to get self-marker from
+ */
+class SelfPositionBroadcaster(private val mapView: MapView) {
+
+    companion object {
+        private const val TAG = "SelfPositionBroadcaster"
+        private const val DEFAULT_BROADCAST_INTERVAL_MS = 5000L // 5 seconds
+        private const val MIN_BROADCAST_INTERVAL_MS = 1000L    // 1 second minimum
+    }
+
+    private val handler = Handler(Looper.getMainLooper())
+    private var isRunning = false
+    private var broadcastIntervalMs = DEFAULT_BROADCAST_INTERVAL_MS
+
+    // Callback for broadcast events
+    var onBroadcastCallback: ((success: Boolean, message: String) -> Unit)? = null
+
+    /**
+     * Start broadcasting self-position to HIVE network.
+     * Does nothing if already running.
+     */
+    fun start() {
+        if (isRunning) {
+            Log.d(TAG, "Already running")
+            return
+        }
+
+        isRunning = true
+        Log.i(TAG, "Starting self-position broadcast (interval: ${broadcastIntervalMs}ms)")
+        handler.post(broadcastRunnable)
+    }
+
+    /**
+     * Stop broadcasting self-position.
+     */
+    fun stop() {
+        if (!isRunning) {
+            Log.d(TAG, "Not running")
+            return
+        }
+
+        isRunning = false
+        handler.removeCallbacks(broadcastRunnable)
+        Log.i(TAG, "Stopped self-position broadcast")
+    }
+
+    /**
+     * Check if broadcasting is active.
+     */
+    fun isActive(): Boolean = isRunning
+
+    /**
+     * Set the broadcast interval in milliseconds.
+     * @param intervalMs Interval between broadcasts (minimum 1000ms)
+     */
+    fun setBroadcastInterval(intervalMs: Long) {
+        broadcastIntervalMs = maxOf(intervalMs, MIN_BROADCAST_INTERVAL_MS)
+        Log.d(TAG, "Broadcast interval set to ${broadcastIntervalMs}ms")
+    }
+
+    private val broadcastRunnable = object : Runnable {
+        override fun run() {
+            if (!isRunning) return
+
+            try {
+                broadcastSelfPosition()
+            } catch (e: Exception) {
+                Log.e(TAG, "Error in broadcast: ${e.message}", e)
+                onBroadcastCallback?.invoke(false, "Error: ${e.message}")
+            }
+
+            // Schedule next broadcast
+            if (isRunning) {
+                handler.postDelayed(this, broadcastIntervalMs)
+            }
+        }
+    }
+
+    /**
+     * Broadcast current self-position to HIVE network.
+     */
+    private fun broadcastSelfPosition() {
+        // Get the self-marker from ATAK
+        val selfMarker = mapView.selfMarker
+        if (selfMarker == null) {
+            Log.w(TAG, "No self-marker available")
+            onBroadcastCallback?.invoke(false, "No self-marker")
+            return
+        }
+
+        // Extract position data
+        val point = selfMarker.point
+        if (point == null) {
+            Log.w(TAG, "Self-marker has no position")
+            onBroadcastCallback?.invoke(false, "No position")
+            return
+        }
+
+        val uid = selfMarker.uid ?: "unknown-device"
+        val callsign = getCallsign(selfMarker)
+        val lat = point.latitude
+        val lon = point.longitude
+        val hae = if (point.isAltitudeValid) point.altitude else null
+
+        // Get heading and speed if available (from track data)
+        val heading = selfMarker.getMetaDouble("heading", Double.NaN).takeIf { !it.isNaN() }
+        val speed = selfMarker.getMetaDouble("Speed", Double.NaN).takeIf { !it.isNaN() }
+
+        Log.d(TAG, "Broadcasting PLI: uid=$uid, callsign=$callsign, lat=$lat, lon=$lon")
+
+        // Build platform JSON
+        val platformJson = JSONObject().apply {
+            put("id", uid)
+            put("name", callsign)
+            put("platform_type", "SOLDIER")
+            put("lat", lat)
+            put("lon", lon)
+            if (hae != null) put("hae", hae)
+            if (heading != null) put("heading", heading)
+            if (speed != null) put("speed", speed)
+            put("status", "ACTIVE")
+            put("capabilities", JSONArray().put("PLI"))
+            put("readiness", 1.0)
+            // cell_id is null for now - could be set if user joins a cell
+        }
+
+        // Get HIVE node and publish
+        val node = HivePluginLifecycle.getInstance()?.getHiveNodeJni()
+        if (node == null) {
+            Log.w(TAG, "HIVE node not available")
+            onBroadcastCallback?.invoke(false, "HIVE not connected")
+            return
+        }
+
+        val success = node.publishPlatform(platformJson.toString())
+        if (success) {
+            Log.d(TAG, "PLI broadcast successful")
+            onBroadcastCallback?.invoke(true, "Broadcast OK: $callsign @ ${String.format("%.4f, %.4f", lat, lon)}")
+        } else {
+            Log.w(TAG, "PLI broadcast failed")
+            onBroadcastCallback?.invoke(false, "Broadcast failed")
+        }
+    }
+
+    /**
+     * Get the callsign from a map item, with fallbacks.
+     */
+    private fun getCallsign(item: PointMapItem): String {
+        // Try various metadata keys that might contain the callsign
+        val callsign = item.getMetaString("callsign", null)
+            ?: item.getMetaString("title", null)
+            ?: item.title
+            ?: item.uid?.take(8)
+            ?: "Unknown"
+
+        return callsign
+    }
+
+    /**
+     * Manually trigger a single broadcast (for testing).
+     */
+    fun broadcastNow() {
+        try {
+            broadcastSelfPosition()
+        } catch (e: Exception) {
+            Log.e(TAG, "Manual broadcast failed: ${e.message}", e)
+            onBroadcastCallback?.invoke(false, "Error: ${e.message}")
+        }
+    }
+}

--- a/hive-ffi/examples/hive_tak_client.rs
+++ b/hive-ffi/examples/hive_tak_client.rs
@@ -167,6 +167,7 @@ fn main() {
     println!("\nFlying patterns over Atlanta... (Ctrl+C to exit)");
     println!("ATAK plugin should discover this node via mDNS.\n");
 
+    let mut last_platform_count = 0;
     loop {
         std::thread::sleep(std::time::Duration::from_secs(2));
         time_offset += 2;
@@ -176,6 +177,36 @@ fn main() {
 
         // Update track positions
         publish_flight_patterns(&node, &patterns, time_offset);
+
+        // Check for received platforms (ATAK PLI)
+        let platforms = match node.get_platforms() {
+            Ok(p) => p,
+            Err(_) => vec![],
+        };
+
+        // Log new platforms received from ATAK
+        if platforms.len() != last_platform_count {
+            println!(
+                "\n=== Received {} platforms from network ===",
+                platforms.len()
+            );
+            for p in &platforms {
+                // Skip our own platforms (they have "platform-" prefix)
+                if p.id.starts_with("platform-") {
+                    continue;
+                }
+                println!(
+                    "  [PLI] {} ({}) @ {:.4}, {:.4} - {}",
+                    p.name,
+                    p.id,
+                    p.lat,
+                    p.lon,
+                    p.status.as_str()
+                );
+            }
+            println!();
+            last_platform_count = platforms.len();
+        }
 
         println!("[t={}s] Peers: {} | Tracks updated", time_offset, peers);
 

--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -30,7 +30,7 @@ use std::sync::Arc;
 
 // JNI support for Android
 use jni::objects::{GlobalRef, JClass, JString, JValue};
-use jni::sys::{jint, jstring, JavaVM, JNI_VERSION_1_6};
+use jni::sys::{jboolean, jint, jstring, JavaVM, JNI_VERSION_1_6};
 use jni::JNIEnv;
 use std::os::raw::c_void;
 use std::sync::{LazyLock, Mutex};
@@ -973,7 +973,7 @@ impl PlatformStatus {
         }
     }
 
-    fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Ready => "READY",
             Self::Active => "ACTIVE",
@@ -1959,6 +1959,126 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_getPlatformsJni(
         .into_raw()
 }
 
+/// JNI: Publish a platform (self-position/PLI) to the HIVE network
+///
+/// Kotlin signature: external fun publishPlatformJni(handle: Long, platformJson: String): Boolean
+/// Stores the platform in the "platforms" collection for sync to peers.
+///
+/// Expected JSON format:
+/// ```json
+/// {
+///   "id": "atak-device-uid",
+///   "name": "CALLSIGN",
+///   "platform_type": "SOLDIER",
+///   "lat": 33.7490,
+///   "lon": -84.3880,
+///   "hae": 320.0,
+///   "heading": 45.0,
+///   "speed": 1.5,
+///   "status": "ACTIVE",
+///   "capabilities": ["PLI"],
+///   "cell_id": null,
+///   "readiness": 1.0
+/// }
+/// ```
+#[cfg(feature = "sync")]
+#[no_mangle]
+pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_publishPlatformJni(
+    mut env: JNIEnv,
+    _class: JClass,
+    handle: i64,
+    platform_json: JString,
+) -> jboolean {
+    if handle == 0 {
+        #[cfg(target_os = "android")]
+        android_log("publishPlatformJni: Invalid handle (0)");
+        return 0; // JNI_FALSE
+    }
+
+    // Get platform JSON string from Java
+    let json_str: String = match env.get_string(&platform_json) {
+        Ok(s) => s.into(),
+        Err(e) => {
+            #[cfg(target_os = "android")]
+            android_log(&format!(
+                "publishPlatformJni: Failed to get JSON string: {:?}",
+                e
+            ));
+            return 0; // JNI_FALSE
+        }
+    };
+
+    #[cfg(target_os = "android")]
+    android_log(&format!("publishPlatformJni: Received JSON: {}", json_str));
+
+    // Parse JSON to validate and extract platform info
+    let platform: PlatformInfo = match serde_json::from_str::<serde_json::Value>(&json_str) {
+        Ok(v) => {
+            // Extract platform ID - required field
+            let id = match v["id"].as_str() {
+                Some(id) if !id.is_empty() => id.to_string(),
+                _ => {
+                    #[cfg(target_os = "android")]
+                    android_log("publishPlatformJni: Missing or empty 'id' field");
+                    return 0; // JNI_FALSE
+                }
+            };
+
+            PlatformInfo {
+                id,
+                platform_type: v["platform_type"].as_str().unwrap_or("SOLDIER").to_string(),
+                name: v["name"].as_str().unwrap_or("Unknown").to_string(),
+                status: PlatformStatus::from_str(v["status"].as_str().unwrap_or("ACTIVE")),
+                lat: v["lat"].as_f64().unwrap_or(0.0),
+                lon: v["lon"].as_f64().unwrap_or(0.0),
+                hae: v["hae"].as_f64(),
+                readiness: v["readiness"].as_f64().unwrap_or(1.0),
+                capabilities: v["capabilities"]
+                    .as_array()
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                            .collect()
+                    })
+                    .unwrap_or_else(|| vec!["PLI".to_string()]),
+                cell_id: v["cell_id"].as_str().map(|s| s.to_string()),
+                last_heartbeat: chrono::Utc::now().timestamp_millis(),
+            }
+        }
+        Err(e) => {
+            #[cfg(target_os = "android")]
+            android_log(&format!("publishPlatformJni: Invalid JSON: {:?}", e));
+            return 0; // JNI_FALSE
+        }
+    };
+
+    #[cfg(target_os = "android")]
+    android_log(&format!(
+        "publishPlatformJni: Publishing platform id={}, name={}, lat={}, lon={}",
+        platform.id, platform.name, platform.lat, platform.lon
+    ));
+
+    // Get node from handle and store platform
+    let node = unsafe { Arc::from_raw(handle as *const HiveNode) };
+    let result = match node.put_platform(platform) {
+        Ok(_) => {
+            #[cfg(target_os = "android")]
+            android_log("publishPlatformJni: Platform published successfully");
+            1 // JNI_TRUE
+        }
+        Err(e) => {
+            #[cfg(target_os = "android")]
+            android_log(&format!("publishPlatformJni: Failed to publish: {:?}", e));
+            0 // JNI_FALSE
+        }
+    };
+
+    // Don't drop the Arc - we're just borrowing
+    std::mem::forget(node);
+
+    result
+}
+
 // =============================================================================
 // JNI Native Method Registration
 // =============================================================================
@@ -2008,6 +2128,12 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_nativeInit(
         },
         #[cfg(feature = "sync")]
         NativeMethod {
+            name: "getGlobalNodeHandleJni".into(),
+            sig: "()J".into(),
+            fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_getGlobalNodeHandleJni as *mut c_void,
+        },
+        #[cfg(feature = "sync")]
+        NativeMethod {
             name: "nodeIdJni".into(),
             sig: "(J)Ljava/lang/String;".into(),
             fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_nodeIdJni as *mut c_void,
@@ -2053,6 +2179,12 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_nativeInit(
             name: "getPlatformsJni".into(),
             sig: "(J)Ljava/lang/String;".into(),
             fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_getPlatformsJni as *mut c_void,
+        },
+        #[cfg(feature = "sync")]
+        NativeMethod {
+            name: "publishPlatformJni".into(),
+            sig: "(JLjava/lang/String;)Z".into(),
+            fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_publishPlatformJni as *mut c_void,
         },
     ];
 
@@ -2172,6 +2304,13 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
                 },
                 #[cfg(feature = "sync")]
                 NativeMethod {
+                    name: "getGlobalNodeHandleJni".into(),
+                    sig: "()J".into(),
+                    fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_getGlobalNodeHandleJni
+                        as *mut c_void,
+                },
+                #[cfg(feature = "sync")]
+                NativeMethod {
                     name: "nodeIdJni".into(),
                     sig: "(J)Ljava/lang/String;".into(),
                     fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_nodeIdJni as *mut c_void,
@@ -2217,6 +2356,13 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
                     name: "getPlatformsJni".into(),
                     sig: "(J)Ljava/lang/String;".into(),
                     fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_getPlatformsJni as *mut c_void,
+                },
+                #[cfg(feature = "sync")]
+                NativeMethod {
+                    name: "publishPlatformJni".into(),
+                    sig: "(JLjava/lang/String;)Z".into(),
+                    fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_publishPlatformJni
+                        as *mut c_void,
                 },
             ];
 


### PR DESCRIPTION
## Summary
- Add SelfPositionBroadcaster class that monitors ATAK self-marker and periodically broadcasts position to HIVE mesh network
- Add `publishPlatformJni` JNI function in Rust FFI to store platform data
- Add PLI toggle button in plugin dropdown UI with status display
- Update test client to log received platforms from network

## Test plan
- [x] Build and deploy APK to Android device
- [x] Open HIVE plugin and tap "Start Broadcasting"
- [x] Verify PLI appears in logs and syncs to connected peers
- [x] Test client receives DINO platform data

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)