### PR TITLE
feat(atak): Add hierarchical cell navigation (#353)

### DIFF
--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
@@ -46,6 +46,11 @@ class HiveDropDownReceiver(
     init {
         // Register for peer events
         PeerEventManager.addListener(this)
+
+        // Register for cell selection changes
+        mapComponent.onCellSelectionChanged = { _, _ ->
+            refreshContentOnMainThread()
+        }
     }
 
     override fun disposeImpl() {
@@ -116,20 +121,40 @@ class HiveDropDownReceiver(
     }
 
     private fun buildContentContainer(): LinearLayout {
-        Log.d(TAG, "Building content - cells: ${mapComponent.cells.size}, tracks: ${mapComponent.tracks.size}, platforms: ${mapComponent.platforms.size}")
+        val selectedCellId = mapComponent.selectedCellId
+        val selectedCellName = mapComponent.selectedCellName
+
+        Log.d(TAG, "Building content - cells: ${mapComponent.cells.size}, tracks: ${mapComponent.tracks.size}, platforms: ${mapComponent.platforms.size}, selectedCell: $selectedCellId")
+
         val container = LinearLayout(pluginContext).apply {
             orientation = LinearLayout.VERTICAL
             setPadding(32, 32, 32, 32)
         }
 
-        // Header
+        // Header with optional back button for cell-filtered view
         val header = LinearLayout(pluginContext).apply {
             orientation = LinearLayout.HORIZONTAL
             gravity = Gravity.CENTER_VERTICAL
         }
 
+        // Back button when viewing a specific cell
+        if (selectedCellId != null) {
+            val backButton = Button(pluginContext).apply {
+                text = "←"
+                textSize = 16f
+                setTextColor(Color.WHITE)
+                setBackgroundColor(Color.parseColor("#444444"))
+                setPadding(24, 8, 24, 8)
+                setOnClickListener {
+                    mapComponent.clearCellSelection()
+                }
+            }
+            header.addView(backButton)
+            header.addView(createHorizontalSpacer(16))
+        }
+
         val title = TextView(pluginContext).apply {
-            text = "HIVE Manager"
+            text = if (selectedCellId != null) "Cell: $selectedCellName" else "HIVE Manager"
             textSize = 20f
             setTextColor(Color.WHITE)
             layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
@@ -152,80 +177,99 @@ class HiveDropDownReceiver(
         // Spacer
         container.addView(createSpacer(24))
 
-        // PLI Broadcast section
-        val pliSection = createPliBroadcastSection()
-        container.addView(pliSection)
-        container.addView(createSpacer(24))
-
-        // Cells section
-        val cellsTitle = TextView(pluginContext).apply {
-            text = "Active Cells"
-            textSize = 16f
-            setTextColor(Color.WHITE)
-        }
-        container.addView(cellsTitle)
-        container.addView(createSpacer(12))
-
-        if (mapComponent.cells.isEmpty()) {
-            val noCells = TextView(pluginContext).apply {
-                text = "No active cells"
-                textSize = 14f
-                setTextColor(Color.GRAY)
-            }
-            container.addView(noCells)
-        } else {
-            mapComponent.cells.forEach { cell ->
-                container.addView(createCellCard(cell))
-                container.addView(createSpacer(8))
-            }
+        // PLI Broadcast section (only in main view)
+        if (selectedCellId == null) {
+            val pliSection = createPliBroadcastSection()
+            container.addView(pliSection)
+            container.addView(createSpacer(24))
         }
 
-        container.addView(createSpacer(24))
-
-        // Tracks section
-        val mapMarkerCount = mapComponent.getMapMarkerCount()
-        val tracksTitle = TextView(pluginContext).apply {
-            text = "Tracks (${mapComponent.tracks.size}) • Map: $mapMarkerCount"
-            textSize = 16f
-            setTextColor(Color.WHITE)
-        }
-        container.addView(tracksTitle)
-        container.addView(createSpacer(12))
-
-        if (mapComponent.tracks.isEmpty()) {
-            val noTracks = TextView(pluginContext).apply {
-                text = "No tracks"
-                textSize = 14f
-                setTextColor(Color.GRAY)
+        // Cells section (only in main view, not when viewing a specific cell)
+        if (selectedCellId == null) {
+            val cellsTitle = TextView(pluginContext).apply {
+                text = "Active Cells"
+                textSize = 16f
+                setTextColor(Color.WHITE)
             }
-            container.addView(noTracks)
-        } else {
-            mapComponent.tracks.forEach { track ->
-                container.addView(createTrackCard(track))
-                container.addView(createSpacer(8))
+            container.addView(cellsTitle)
+            container.addView(createSpacer(8))
+
+            val cellsHint = TextView(pluginContext).apply {
+                text = "Tap a cell on the map to view its platforms"
+                textSize = 11f
+                setTextColor(Color.parseColor("#888888"))
             }
+            container.addView(cellsHint)
+            container.addView(createSpacer(12))
+
+            if (mapComponent.cells.isEmpty()) {
+                val noCells = TextView(pluginContext).apply {
+                    text = "No active cells"
+                    textSize = 14f
+                    setTextColor(Color.GRAY)
+                }
+                container.addView(noCells)
+            } else {
+                mapComponent.cells.forEach { cell ->
+                    container.addView(createCellCard(cell))
+                    container.addView(createSpacer(8))
+                }
+            }
+
+            container.addView(createSpacer(24))
         }
 
-        container.addView(createSpacer(24))
+        // Tracks section (only in main view)
+        if (selectedCellId == null) {
+            val mapMarkerCount = mapComponent.getMapMarkerCount()
+            val tracksTitle = TextView(pluginContext).apply {
+                text = "Tracks (${mapComponent.tracks.size}) • Map: $mapMarkerCount"
+                textSize = 16f
+                setTextColor(Color.WHITE)
+            }
+            container.addView(tracksTitle)
+            container.addView(createSpacer(12))
 
-        // Platforms section
+            if (mapComponent.tracks.isEmpty()) {
+                val noTracks = TextView(pluginContext).apply {
+                    text = "No tracks"
+                    textSize = 14f
+                    setTextColor(Color.GRAY)
+                }
+                container.addView(noTracks)
+            } else {
+                mapComponent.tracks.forEach { track ->
+                    container.addView(createTrackCard(track))
+                    container.addView(createSpacer(8))
+                }
+            }
+
+            container.addView(createSpacer(24))
+        }
+
+        // Platforms section - filtered when cell is selected
+        val filteredPlatforms = mapComponent.getFilteredPlatforms()
         val platformsTitle = TextView(pluginContext).apply {
-            text = "Platforms (${mapComponent.platforms.size})"
+            text = if (selectedCellId != null) {
+                "Platforms in Cell (${filteredPlatforms.size})"
+            } else {
+                "Platforms (${mapComponent.platforms.size})"
+            }
             textSize = 16f
             setTextColor(Color.WHITE)
         }
         container.addView(platformsTitle)
         container.addView(createSpacer(12))
 
-        if (mapComponent.platforms.isEmpty()) {
+        if (filteredPlatforms.isEmpty()) {
             val noPlatforms = TextView(pluginContext).apply {
-                text = "No platforms"
+                text = if (selectedCellId != null) "No platforms in this cell" else "No platforms"
                 textSize = 14f
                 setTextColor(Color.GRAY)
             }
             container.addView(noPlatforms)
         } else {
-            mapComponent.platforms.forEach { platform ->
+            filteredPlatforms.forEach { platform ->
                 container.addView(createPlatformCard(platform))
                 container.addView(createSpacer(8))
             }
@@ -246,6 +290,15 @@ class HiveDropDownReceiver(
         container.addView(infoCard)
 
         return container
+    }
+
+    private fun createHorizontalSpacer(widthDp: Int): View {
+        return View(pluginContext).apply {
+            layoutParams = LinearLayout.LayoutParams(
+                (widthDp * pluginContext.resources.displayMetrics.density).toInt(),
+                LinearLayout.LayoutParams.MATCH_PARENT
+            )
+        }
     }
 
     private fun createSpacer(heightDp: Int): View {

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
@@ -8,6 +8,7 @@ import com.atakmap.android.dropdown.DropDownMapComponent
 import com.atakmap.android.ipc.AtakBroadcast.DocumentedIntentFilter
 import com.atakmap.android.maps.MapView
 import com.atakmap.coremap.log.Log
+import com.atakmap.coremap.maps.coords.GeoPoint
 import com.revolveteam.atak.hive.model.HiveCell
 import com.revolveteam.atak.hive.model.HivePlatform
 import com.revolveteam.atak.hive.model.HiveTrack
@@ -64,6 +65,16 @@ class HiveMapComponent : DropDownMapComponent() {
 
     val peerCount: Int get() = HivePluginLifecycle.getInstance()?.getPeerCount() ?: 0
 
+    // Selected cell for hierarchical navigation
+    private var _selectedCellId: String? = null
+    val selectedCellId: String? get() = _selectedCellId
+
+    private var _selectedCellName: String? = null
+    val selectedCellName: String? get() = _selectedCellName
+
+    /** Callback for when cell selection changes */
+    var onCellSelectionChanged: ((cellId: String?, cellName: String?) -> Unit)? = null
+
     override fun onCreate(context: Context, intent: Intent, view: MapView) {
         context.setTheme(R.style.ATAKPluginTheme)
         super.onCreate(context, intent, view)
@@ -78,6 +89,12 @@ class HiveMapComponent : DropDownMapComponent() {
 
         // Create cell overlay for cell boundaries (kept for cell metadata, but cell markers are secondary to platforms)
         cellOverlay = HiveCellOverlay(view)
+        cellOverlay?.onCellSelectedListener = object : HiveCellOverlay.OnCellSelectedListener {
+            override fun onCellSelected(cellId: String, cellName: String, centerLat: Double, centerLon: Double, radiusMeters: Double) {
+                selectCell(cellId, cellName)
+                zoomToCell(centerLat, centerLon, radiusMeters)
+            }
+        }
         Log.d(TAG, "Cell overlay created")
 
         // Create platform overlay for individual platform markers
@@ -407,10 +424,57 @@ class HiveMapComponent : DropDownMapComponent() {
     }
 
     /**
-     * Select a cell
+     * Select a cell for hierarchical navigation view.
+     * @param cellId The cell ID to select, or null to clear selection
+     * @param cellName The cell name for display
      */
-    fun selectCell(cellId: String) {
-        Log.d(TAG, "Cell selected: $cellId")
+    fun selectCell(cellId: String?, cellName: String? = null) {
+        _selectedCellId = cellId
+        _selectedCellName = cellName ?: cellId?.let { id ->
+            _cells.find { it.id == id }?.name
+        }
+        Log.d(TAG, "Cell selected: $cellId ($cellName)")
+        onCellSelectionChanged?.invoke(_selectedCellId, _selectedCellName)
+    }
+
+    /**
+     * Clear the selected cell and return to all-cells view.
+     */
+    fun clearCellSelection() {
+        selectCell(null, null)
+    }
+
+    /**
+     * Get platforms filtered by the currently selected cell.
+     * @return All platforms if no cell selected, otherwise only platforms in selected cell
+     */
+    fun getFilteredPlatforms(): List<HivePlatform> {
+        val selectedId = _selectedCellId ?: return _platforms.toList()
+        return _platforms.filter { it.cellId == selectedId }
+    }
+
+    /**
+     * Zoom the map to show the specified cell bounds.
+     * @param centerLat Center latitude
+     * @param centerLon Center longitude
+     * @param radiusMeters Radius in meters to show
+     */
+    fun zoomToCell(centerLat: Double, centerLon: Double, radiusMeters: Double) {
+        try {
+            val centerPoint = GeoPoint(centerLat, centerLon)
+            // Calculate appropriate zoom scale based on radius
+            // ATAK uses map scale where lower = more zoomed in
+            // Roughly: scale = radiusMeters * 2 / screenWidthPixels * metersPerPixel
+            // For simplicity, use a scale that shows ~2x the radius
+            val zoomScale = (radiusMeters * 4.0).coerceIn(500.0, 100000.0)
+
+            mapView.mapController.panTo(centerPoint, true)
+            mapView.mapController.zoomTo(zoomScale, true)
+
+            Log.i(TAG, "Zoomed to cell at ($centerLat, $centerLon) with radius ${radiusMeters}m")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to zoom to cell: ${e.message}", e)
+        }
     }
 
     /**

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/overlay/HiveCellOverlay.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/overlay/HiveCellOverlay.kt
@@ -2,7 +2,10 @@ package com.revolveteam.atak.hive.overlay
 
 import android.graphics.Color
 import com.atakmap.android.drawing.mapItems.DrawingCircle
+import com.atakmap.android.maps.MapEvent
+import com.atakmap.android.maps.MapEventDispatcher
 import com.atakmap.android.maps.MapGroup
+import com.atakmap.android.maps.MapItem
 import com.atakmap.android.maps.MapView
 import com.atakmap.coremap.log.Log
 import com.atakmap.coremap.maps.coords.GeoPoint
@@ -21,8 +24,16 @@ import kotlin.math.*
  * - Circle color based on cell status (active=green, degraded=yellow, offline=red)
  * - Circle is semi-transparent with a colored border
  * - Label shows cell name
+ * - Tap on circle to zoom and view contained platforms
  */
 class HiveCellOverlay(private val mapView: MapView) {
+
+    /**
+     * Callback interface for cell selection events.
+     */
+    interface OnCellSelectedListener {
+        fun onCellSelected(cellId: String, cellName: String, centerLat: Double, centerLon: Double, radiusMeters: Double)
+    }
 
     companion object {
         private const val TAG = "HiveCellOverlay"
@@ -33,9 +44,44 @@ class HiveCellOverlay(private val mapView: MapView) {
 
     private var mapGroup: MapGroup? = null
     private val cellCircles = mutableMapOf<String, DrawingCircle>()
+    private val cellBounds = mutableMapOf<String, CellBounds>()
+
+    /** Listener for cell selection events */
+    var onCellSelectedListener: OnCellSelectedListener? = null
+
+    /** Data class to store cell bounds for zoom calculations */
+    data class CellBounds(
+        val centerLat: Double,
+        val centerLon: Double,
+        val radiusMeters: Double,
+        val cellName: String
+    )
+
+    /** Map event listener for handling cell clicks */
+    private val mapEventListener = MapEventDispatcher.MapEventDispatchListener { event ->
+        if (event.type == MapEvent.ITEM_CLICK) {
+            val item = event.item
+            if (item != null && item.getMetaString("hiveCellId", "").isNotEmpty()) {
+                val cellId = item.getMetaString("hiveCellId", "")
+                val bounds = cellBounds[cellId]
+                if (bounds != null) {
+                    Log.i(TAG, "Cell clicked: $cellId (${bounds.cellName})")
+                    onCellSelectedListener?.onCellSelected(
+                        cellId,
+                        bounds.cellName,
+                        bounds.centerLat,
+                        bounds.centerLon,
+                        bounds.radiusMeters
+                    )
+                }
+            }
+        }
+    }
 
     init {
         initMapGroup()
+        // Register for map item click events
+        mapView.mapEventDispatcher.addMapEventListener(MapEvent.ITEM_CLICK, mapEventListener)
     }
 
     private fun initMapGroup() {
@@ -187,9 +233,13 @@ class HiveCellOverlay(private val mapView: MapView) {
             circle.title = cellName
             circle.setMetaString("hiveCellId", cellId)
             circle.setMetaInteger("platformCount", platforms.size)
+            circle.setClickable(true)
 
             group.addItem(circle)
             cellCircles[cellId] = circle
+
+            // Store bounds for zoom calculations
+            cellBounds[cellId] = CellBounds(centerLat, centerLon, radius, cellName)
 
             Log.d(TAG, "Created bounding circle for cell: $cellId (${platforms.size} platforms, ${radius.toInt()}m radius)")
         } catch (e: Exception) {
@@ -214,6 +264,13 @@ class HiveCellOverlay(private val mapView: MapView) {
 
             // Update metadata
             circle.setMetaInteger("platformCount", platforms.size)
+
+            // Update stored bounds
+            val cellId = circle.getMetaString("hiveCellId", "")
+            val cellName = cell?.name ?: "Cell $cellId"
+            if (cellId.isNotEmpty()) {
+                cellBounds[cellId] = CellBounds(centerLat, centerLon, radius, cellName)
+            }
 
             Log.v(TAG, "Updated bounding circle: ${platforms.size} platforms, ${radius.toInt()}m radius")
         } catch (e: Exception) {
@@ -242,6 +299,7 @@ class HiveCellOverlay(private val mapView: MapView) {
             circle.dispose()
             Log.d(TAG, "Removed bounding circle for cell: $cellId")
         }
+        cellBounds.remove(cellId)
     }
 
     /**
@@ -261,6 +319,7 @@ class HiveCellOverlay(private val mapView: MapView) {
             circle.dispose()
         }
         cellCircles.clear()
+        cellBounds.clear()
         Log.i(TAG, "Cleared all cell bounding circles")
     }
 
@@ -273,12 +332,23 @@ class HiveCellOverlay(private val mapView: MapView) {
      * Dispose of the overlay and clean up resources.
      */
     fun dispose() {
+        // Unregister map event listener
+        mapView.mapEventDispatcher.removeMapEventListener(MapEvent.ITEM_CLICK, mapEventListener)
+
         clearAll()
         mapGroup?.let { group ->
             // Don't remove the Drawing Objects group as other components may use it
             mapView.rootGroup?.findMapGroup("Drawing Objects")?.removeGroup(group)
         }
         mapGroup = null
+        onCellSelectedListener = null
         Log.i(TAG, "HiveCellOverlay disposed")
     }
+
+    /**
+     * Get the bounds for a specific cell.
+     * @param cellId The cell ID to look up
+     * @return CellBounds if found, null otherwise
+     */
+    fun getCellBounds(cellId: String): CellBounds? = cellBounds[cellId]
 }


### PR DESCRIPTION
## Summary
- Add tap-to-zoom on cell circles: clicking a cell on the map zooms to show all platforms in that cell
- Add filtered platform view in dropdown: when a cell is selected, only platforms in that cell are shown  
- Add back navigation button to return to all-cells view
- Add cell selection state management in HiveMapComponent
- Register map event listener for cell circle clicks
- Add hint text to guide users to tap cells on map

Completes the hierarchical navigation tasks from #353:
- [x] Tap cell to zoom and show contained platforms
- [x] Platform list in dropdown filtered by cell
- [x] Back navigation to cell view

## Test plan
- [ ] Build and install APK on ATAK device
- [ ] Run hive_tak_client test example to publish cells and platforms
- [ ] Tap a cell circle on the map
- [ ] Verify map zooms to cell bounds
- [ ] Verify dropdown shows "Cell: [name]" header with back button
- [ ] Verify only platforms in selected cell are shown
- [ ] Tap back button
- [ ] Verify returns to all-cells view with full platform list

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)