### PR TITLE
feat(qos): Implement record deletion and tombstone management (ADR-034 Phase 1) (#365)

### DIFF
--- a/hive-protocol/src/qos/deletion.rs
+++ b/hive-protocol/src/qos/deletion.rs
@@ -1,0 +1,648 @@
+//! Deletion Policy configuration for record deletion and tombstone management (ADR-034)
+//!
+//! This module addresses the CRDT deletion problem where deleted items can "resurrect"
+//! when syncing with offline nodes. We use a hybrid approach with three strategies
+//! based on data semantics.
+//!
+//! # Strategies
+//!
+//! ```text
+//! ImplicitTTL:   beacons, platforms → Auto-superseded by newer, no tombstone
+//! Tombstone:    tracks, nodes, alerts → Explicit delete with bounded retention
+//! SoftDelete:   contact_reports, commands → Permanent audit trail
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use hive_protocol::qos::{DeletionPolicy, DeletionPolicyRegistry};
+//! use std::time::Duration;
+//!
+//! let registry = DeletionPolicyRegistry::with_defaults();
+//!
+//! // Beacons use implicit TTL (auto-superseded)
+//! assert!(registry.get("beacons").is_implicit_ttl());
+//!
+//! // Commands use soft delete (audit trail)
+//! assert!(registry.get("commands").is_soft_delete());
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::RwLock;
+use std::time::{Duration, SystemTime};
+
+/// Deletion policy for a collection (ADR-034)
+///
+/// Determines how documents are deleted and whether tombstones are used.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DeletionPolicy {
+    /// No explicit deletion - documents superseded by newer versions
+    ///
+    /// Best for high-frequency position data (beacons, platforms).
+    /// Documents older than TTL are garbage collected.
+    ImplicitTTL {
+        /// Maximum age before document is garbage collected
+        ttl: Duration,
+        /// Key field for supersession (e.g., "node_id" for beacons)
+        supersession_key: Option<String>,
+    },
+
+    /// Explicit tombstones with bounded retention
+    ///
+    /// Best for data requiring explicit deletion but not permanent audit trail.
+    /// Tombstones are garbage collected after TTL.
+    Tombstone {
+        /// How long to retain tombstones before garbage collection
+        tombstone_ttl: Duration,
+        /// Conflict resolution: true = delete wins over concurrent update
+        delete_wins: bool,
+    },
+
+    /// Soft delete with permanent audit trail
+    ///
+    /// Best for audit-required data (contact_reports, commands).
+    /// Documents are marked deleted but never removed.
+    SoftDelete {
+        /// Whether to include soft-deleted docs in queries by default
+        include_deleted_default: bool,
+    },
+
+    /// No deletion allowed for this collection
+    Immutable,
+}
+
+impl DeletionPolicy {
+    /// Check if this policy uses implicit TTL
+    #[inline]
+    pub fn is_implicit_ttl(&self) -> bool {
+        matches!(self, Self::ImplicitTTL { .. })
+    }
+
+    /// Check if this policy uses tombstones
+    #[inline]
+    pub fn is_tombstone(&self) -> bool {
+        matches!(self, Self::Tombstone { .. })
+    }
+
+    /// Check if this policy uses soft delete
+    #[inline]
+    pub fn is_soft_delete(&self) -> bool {
+        matches!(self, Self::SoftDelete { .. })
+    }
+
+    /// Check if this policy is immutable
+    #[inline]
+    pub fn is_immutable(&self) -> bool {
+        matches!(self, Self::Immutable)
+    }
+
+    /// Get the TTL for implicit TTL policy
+    pub fn implicit_ttl(&self) -> Option<Duration> {
+        match self {
+            Self::ImplicitTTL { ttl, .. } => Some(*ttl),
+            _ => None,
+        }
+    }
+
+    /// Get the tombstone TTL for tombstone policy
+    pub fn tombstone_ttl(&self) -> Option<Duration> {
+        match self {
+            Self::Tombstone { tombstone_ttl, .. } => Some(*tombstone_ttl),
+            _ => None,
+        }
+    }
+
+    /// Check if delete wins over concurrent updates (for tombstone policy)
+    pub fn delete_wins(&self) -> Option<bool> {
+        match self {
+            Self::Tombstone { delete_wins, .. } => Some(*delete_wins),
+            _ => None,
+        }
+    }
+
+    /// Default deletion policy for a collection name
+    ///
+    /// Returns appropriate defaults based on collection semantics:
+    /// - beacons, platforms → ImplicitTTL (position data, superseded)
+    /// - tracks → Tombstone with 1hr TTL
+    /// - nodes, cells → Tombstone with 24hr TTL
+    /// - contact_reports, commands, audit_logs → SoftDelete
+    /// - alerts → Tombstone with 4hr TTL
+    pub fn default_for_collection(collection: &str) -> Self {
+        match collection {
+            // Position/state data - auto-superseded by newer
+            "beacons" | "platforms" => Self::ImplicitTTL {
+                ttl: Duration::from_secs(3600), // 1 hour
+                supersession_key: Some("node_id".to_string()),
+            },
+
+            // Tracks - explicit delete with short TTL
+            "tracks" => Self::Tombstone {
+                tombstone_ttl: Duration::from_secs(3600), // 1 hour
+                delete_wins: true,
+            },
+
+            // Network membership - tombstone with longer TTL
+            "nodes" | "cells" => Self::Tombstone {
+                tombstone_ttl: Duration::from_secs(86400), // 24 hours
+                delete_wins: true,
+            },
+
+            // Alerts - tombstone with medium TTL, update-wins
+            "alerts" => Self::Tombstone {
+                tombstone_ttl: Duration::from_secs(14400), // 4 hours
+                delete_wins: false, // Update wins: alert update cancels delete
+            },
+
+            // Audit-required data - soft delete forever
+            "contact_reports" | "commands" | "audit_logs" => Self::SoftDelete {
+                include_deleted_default: false,
+            },
+
+            // Default: soft delete for safety
+            _ => Self::SoftDelete {
+                include_deleted_default: false,
+            },
+        }
+    }
+}
+
+impl Default for DeletionPolicy {
+    fn default() -> Self {
+        Self::SoftDelete {
+            include_deleted_default: false,
+        }
+    }
+}
+
+impl std::fmt::Display for DeletionPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ImplicitTTL { ttl, .. } => write!(f, "ImplicitTTL({}s)", ttl.as_secs()),
+            Self::Tombstone { tombstone_ttl, .. } => {
+                write!(f, "Tombstone({}s)", tombstone_ttl.as_secs())
+            }
+            Self::SoftDelete { .. } => write!(f, "SoftDelete"),
+            Self::Immutable => write!(f, "Immutable"),
+        }
+    }
+}
+
+/// Tombstone record for deleted documents (ADR-034)
+///
+/// Represents a deletion marker that syncs alongside documents.
+/// Tombstones have a TTL after which they are garbage collected.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Tombstone {
+    /// ID of the deleted document
+    pub document_id: String,
+    /// Collection the document belonged to
+    pub collection: String,
+    /// When deletion occurred
+    pub deleted_at: SystemTime,
+    /// Node that initiated deletion
+    pub deleted_by: String,
+    /// Lamport timestamp for ordering
+    pub lamport: u64,
+    /// Optional reason for deletion
+    pub reason: Option<String>,
+}
+
+impl Tombstone {
+    /// Create a new tombstone
+    pub fn new(
+        document_id: impl Into<String>,
+        collection: impl Into<String>,
+        deleted_by: impl Into<String>,
+        lamport: u64,
+    ) -> Self {
+        Self {
+            document_id: document_id.into(),
+            collection: collection.into(),
+            deleted_at: SystemTime::now(),
+            deleted_by: deleted_by.into(),
+            lamport,
+            reason: None,
+        }
+    }
+
+    /// Create a tombstone with a reason
+    pub fn with_reason(
+        document_id: impl Into<String>,
+        collection: impl Into<String>,
+        deleted_by: impl Into<String>,
+        lamport: u64,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self {
+            document_id: document_id.into(),
+            collection: collection.into(),
+            deleted_at: SystemTime::now(),
+            deleted_by: deleted_by.into(),
+            lamport,
+            reason: Some(reason.into()),
+        }
+    }
+
+    /// Check if this tombstone has expired based on TTL
+    ///
+    /// A tombstone is expired if its age is greater than or equal to the TTL.
+    /// A TTL of zero means immediate expiration.
+    pub fn is_expired(&self, ttl: Duration) -> bool {
+        match SystemTime::now().duration_since(self.deleted_at) {
+            Ok(age) => age >= ttl,
+            Err(_) => false, // Clock went backwards, not expired
+        }
+    }
+
+    /// Get the age of this tombstone
+    pub fn age(&self) -> Option<Duration> {
+        SystemTime::now().duration_since(self.deleted_at).ok()
+    }
+
+    /// Unique key for this tombstone
+    pub fn key(&self) -> String {
+        format!("{}:{}", self.collection, self.document_id)
+    }
+}
+
+/// Result of a delete operation
+#[derive(Debug, Clone)]
+pub struct DeleteResult {
+    /// Whether the document was deleted
+    pub deleted: bool,
+    /// Tombstone ID if one was created
+    pub tombstone_id: Option<String>,
+    /// When the tombstone expires (if applicable)
+    pub expires_at: Option<SystemTime>,
+    /// The deletion policy used
+    pub policy: DeletionPolicy,
+}
+
+impl DeleteResult {
+    /// Create a successful delete result with tombstone
+    pub fn tombstoned(
+        tombstone_id: String,
+        expires_at: SystemTime,
+        policy: DeletionPolicy,
+    ) -> Self {
+        Self {
+            deleted: true,
+            tombstone_id: Some(tombstone_id),
+            expires_at: Some(expires_at),
+            policy,
+        }
+    }
+
+    /// Create a successful soft delete result
+    pub fn soft_deleted(policy: DeletionPolicy) -> Self {
+        Self {
+            deleted: true,
+            tombstone_id: None,
+            expires_at: None,
+            policy,
+        }
+    }
+
+    /// Create a result for immutable collection (delete not allowed)
+    pub fn immutable() -> Self {
+        Self {
+            deleted: false,
+            tombstone_id: None,
+            expires_at: None,
+            policy: DeletionPolicy::Immutable,
+        }
+    }
+
+    /// Create a result for document not found
+    pub fn not_found(policy: DeletionPolicy) -> Self {
+        Self {
+            deleted: false,
+            tombstone_id: None,
+            expires_at: None,
+            policy,
+        }
+    }
+}
+
+/// Registry for per-collection deletion policy configuration
+///
+/// Allows runtime configuration of deletion policies per collection,
+/// with sensible defaults based on collection names.
+#[derive(Debug, Default)]
+pub struct DeletionPolicyRegistry {
+    /// Per-collection deletion policy overrides
+    overrides: RwLock<HashMap<String, DeletionPolicy>>,
+}
+
+impl DeletionPolicyRegistry {
+    /// Create a new empty registry (uses defaults for all collections)
+    pub fn new() -> Self {
+        Self {
+            overrides: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Create a registry with standard defaults pre-configured
+    pub fn with_defaults() -> Self {
+        let registry = Self::new();
+
+        let defaults = [
+            (
+                "beacons",
+                DeletionPolicy::ImplicitTTL {
+                    ttl: Duration::from_secs(3600),
+                    supersession_key: Some("node_id".to_string()),
+                },
+            ),
+            (
+                "platforms",
+                DeletionPolicy::ImplicitTTL {
+                    ttl: Duration::from_secs(3600),
+                    supersession_key: Some("node_id".to_string()),
+                },
+            ),
+            (
+                "tracks",
+                DeletionPolicy::Tombstone {
+                    tombstone_ttl: Duration::from_secs(3600),
+                    delete_wins: true,
+                },
+            ),
+            (
+                "nodes",
+                DeletionPolicy::Tombstone {
+                    tombstone_ttl: Duration::from_secs(86400),
+                    delete_wins: true,
+                },
+            ),
+            (
+                "cells",
+                DeletionPolicy::Tombstone {
+                    tombstone_ttl: Duration::from_secs(86400),
+                    delete_wins: true,
+                },
+            ),
+            (
+                "alerts",
+                DeletionPolicy::Tombstone {
+                    tombstone_ttl: Duration::from_secs(14400),
+                    delete_wins: false,
+                },
+            ),
+            (
+                "contact_reports",
+                DeletionPolicy::SoftDelete {
+                    include_deleted_default: false,
+                },
+            ),
+            (
+                "commands",
+                DeletionPolicy::SoftDelete {
+                    include_deleted_default: false,
+                },
+            ),
+            (
+                "audit_logs",
+                DeletionPolicy::SoftDelete {
+                    include_deleted_default: false,
+                },
+            ),
+        ];
+
+        {
+            let mut overrides = registry.overrides.write().unwrap();
+            for (collection, policy) in defaults {
+                overrides.insert(collection.to_string(), policy);
+            }
+        }
+
+        registry
+    }
+
+    /// Get the deletion policy for a collection
+    pub fn get(&self, collection: &str) -> DeletionPolicy {
+        self.overrides
+            .read()
+            .unwrap()
+            .get(collection)
+            .cloned()
+            .unwrap_or_else(|| DeletionPolicy::default_for_collection(collection))
+    }
+
+    /// Set the deletion policy for a collection
+    pub fn set(&self, collection: &str, policy: DeletionPolicy) {
+        self.overrides
+            .write()
+            .unwrap()
+            .insert(collection.to_string(), policy);
+    }
+
+    /// Remove a collection override (will use default)
+    pub fn remove(&self, collection: &str) -> Option<DeletionPolicy> {
+        self.overrides.write().unwrap().remove(collection)
+    }
+
+    /// Check if deletion is allowed for a collection
+    pub fn allows_delete(&self, collection: &str) -> bool {
+        !self.get(collection).is_immutable()
+    }
+
+    /// Check if a collection uses tombstones
+    pub fn uses_tombstones(&self, collection: &str) -> bool {
+        self.get(collection).is_tombstone()
+    }
+
+    /// Check if a collection uses soft delete
+    pub fn uses_soft_delete(&self, collection: &str) -> bool {
+        self.get(collection).is_soft_delete()
+    }
+}
+
+impl Clone for DeletionPolicyRegistry {
+    fn clone(&self) -> Self {
+        Self {
+            overrides: RwLock::new(self.overrides.read().unwrap().clone()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deletion_policy_defaults() {
+        // Position data should be ImplicitTTL
+        assert!(DeletionPolicy::default_for_collection("beacons").is_implicit_ttl());
+        assert!(DeletionPolicy::default_for_collection("platforms").is_implicit_ttl());
+
+        // Tracks should be Tombstone
+        assert!(DeletionPolicy::default_for_collection("tracks").is_tombstone());
+        assert!(DeletionPolicy::default_for_collection("nodes").is_tombstone());
+
+        // Audit data should be SoftDelete
+        assert!(DeletionPolicy::default_for_collection("commands").is_soft_delete());
+        assert!(DeletionPolicy::default_for_collection("contact_reports").is_soft_delete());
+
+        // Unknown should default to SoftDelete
+        assert!(DeletionPolicy::default_for_collection("unknown").is_soft_delete());
+    }
+
+    #[test]
+    fn test_deletion_policy_accessors() {
+        let implicit = DeletionPolicy::ImplicitTTL {
+            ttl: Duration::from_secs(3600),
+            supersession_key: Some("node_id".to_string()),
+        };
+        assert_eq!(implicit.implicit_ttl(), Some(Duration::from_secs(3600)));
+        assert_eq!(implicit.tombstone_ttl(), None);
+
+        let tombstone = DeletionPolicy::Tombstone {
+            tombstone_ttl: Duration::from_secs(7200),
+            delete_wins: true,
+        };
+        assert_eq!(tombstone.tombstone_ttl(), Some(Duration::from_secs(7200)));
+        assert_eq!(tombstone.delete_wins(), Some(true));
+        assert_eq!(tombstone.implicit_ttl(), None);
+    }
+
+    #[test]
+    fn test_deletion_policy_display() {
+        let implicit = DeletionPolicy::ImplicitTTL {
+            ttl: Duration::from_secs(3600),
+            supersession_key: None,
+        };
+        assert_eq!(implicit.to_string(), "ImplicitTTL(3600s)");
+
+        let tombstone = DeletionPolicy::Tombstone {
+            tombstone_ttl: Duration::from_secs(86400),
+            delete_wins: true,
+        };
+        assert_eq!(tombstone.to_string(), "Tombstone(86400s)");
+
+        assert_eq!(
+            DeletionPolicy::SoftDelete {
+                include_deleted_default: false
+            }
+            .to_string(),
+            "SoftDelete"
+        );
+        assert_eq!(DeletionPolicy::Immutable.to_string(), "Immutable");
+    }
+
+    #[test]
+    fn test_tombstone_creation() {
+        let tombstone = Tombstone::new("doc-123", "tracks", "node-alpha", 42);
+
+        assert_eq!(tombstone.document_id, "doc-123");
+        assert_eq!(tombstone.collection, "tracks");
+        assert_eq!(tombstone.deleted_by, "node-alpha");
+        assert_eq!(tombstone.lamport, 42);
+        assert!(tombstone.reason.is_none());
+        assert_eq!(tombstone.key(), "tracks:doc-123");
+    }
+
+    #[test]
+    fn test_tombstone_with_reason() {
+        let tombstone =
+            Tombstone::with_reason("doc-456", "alerts", "node-beta", 100, "User dismissed");
+
+        assert_eq!(tombstone.reason, Some("User dismissed".to_string()));
+    }
+
+    #[test]
+    fn test_tombstone_expiration() {
+        let tombstone = Tombstone::new("doc-123", "tracks", "node-alpha", 42);
+
+        // Should not be expired immediately with 1 hour TTL
+        assert!(!tombstone.is_expired(Duration::from_secs(3600)));
+
+        // Should be expired with 0 TTL
+        assert!(tombstone.is_expired(Duration::ZERO));
+    }
+
+    #[test]
+    fn test_tombstone_age() {
+        let tombstone = Tombstone::new("doc-123", "tracks", "node-alpha", 42);
+
+        // Age should be very small (just created)
+        let age = tombstone.age().unwrap();
+        assert!(age < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_delete_result() {
+        let policy = DeletionPolicy::Tombstone {
+            tombstone_ttl: Duration::from_secs(3600),
+            delete_wins: true,
+        };
+
+        let result = DeleteResult::tombstoned(
+            "tomb-123".to_string(),
+            SystemTime::now() + Duration::from_secs(3600),
+            policy.clone(),
+        );
+        assert!(result.deleted);
+        assert_eq!(result.tombstone_id, Some("tomb-123".to_string()));
+        assert!(result.expires_at.is_some());
+
+        let soft = DeleteResult::soft_deleted(DeletionPolicy::SoftDelete {
+            include_deleted_default: false,
+        });
+        assert!(soft.deleted);
+        assert!(soft.tombstone_id.is_none());
+
+        let immutable = DeleteResult::immutable();
+        assert!(!immutable.deleted);
+    }
+
+    #[test]
+    fn test_deletion_policy_registry() {
+        let registry = DeletionPolicyRegistry::with_defaults();
+
+        // Check defaults
+        assert!(registry.get("beacons").is_implicit_ttl());
+        assert!(registry.get("commands").is_soft_delete());
+        assert!(registry.get("tracks").is_tombstone());
+
+        // Override
+        registry.set("beacons", DeletionPolicy::Immutable);
+        assert!(registry.get("beacons").is_immutable());
+
+        // Remove override
+        registry.remove("beacons");
+        assert!(registry.get("beacons").is_implicit_ttl());
+    }
+
+    #[test]
+    fn test_deletion_policy_registry_helpers() {
+        let registry = DeletionPolicyRegistry::with_defaults();
+
+        assert!(registry.allows_delete("beacons"));
+        assert!(registry.allows_delete("commands"));
+
+        registry.set("special", DeletionPolicy::Immutable);
+        assert!(!registry.allows_delete("special"));
+
+        assert!(registry.uses_tombstones("tracks"));
+        assert!(!registry.uses_tombstones("commands"));
+
+        assert!(registry.uses_soft_delete("commands"));
+        assert!(!registry.uses_soft_delete("tracks"));
+    }
+
+    #[test]
+    fn test_tombstone_serialization() {
+        let tombstone = Tombstone::with_reason("doc-123", "tracks", "node-alpha", 42, "Test");
+
+        let json = serde_json::to_string(&tombstone).unwrap();
+        let deserialized: Tombstone = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(tombstone.document_id, deserialized.document_id);
+        assert_eq!(tombstone.collection, deserialized.collection);
+        assert_eq!(tombstone.lamport, deserialized.lamport);
+        assert_eq!(tombstone.reason, deserialized.reason);
+    }
+}

--- a/hive-protocol/src/qos/mod.rs
+++ b/hive-protocol/src/qos/mod.rs
@@ -69,6 +69,7 @@ pub mod bandwidth;
 pub mod classification;
 pub mod context;
 pub mod context_manager;
+pub mod deletion;
 pub mod eviction;
 pub mod lifecycle;
 pub mod preemption;
@@ -90,6 +91,7 @@ pub use bandwidth::{
 pub use classification::DataType;
 pub use context::{ContextProfile, MissionContext, QoSClassAdjustment};
 pub use context_manager::{ContextChangeListener, ContextChangeLog, ContextManager};
+pub use deletion::{DeleteResult, DeletionPolicy, DeletionPolicyRegistry, Tombstone};
 pub use eviction::{EvictionConfig, EvictionController, EvictionResult};
 pub use lifecycle::{
     make_lifecycle_decision, LifecycleDecision, LifecyclePolicies, LifecyclePolicy,

--- a/hive-protocol/src/sync/automerge.rs
+++ b/hive-protocol/src/sync/automerge.rs
@@ -34,6 +34,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 use crate::error::{Error, Result};
+use crate::qos::{DeletionPolicy, DeletionPolicyRegistry, Tombstone};
 use crate::sync::traits::*;
 use crate::sync::types::*;
 
@@ -57,6 +58,12 @@ pub struct AutomergeBackend {
 
     /// Change notification channels for observers
     observers: Arc<Mutex<Vec<mpsc::UnboundedSender<ChangeEvent>>>>,
+
+    /// Tombstone storage indexed by collection:doc_id (ADR-034)
+    tombstones: Arc<Mutex<HashMap<String, Tombstone>>>,
+
+    /// Deletion policy registry (ADR-034)
+    deletion_policy_registry: Arc<DeletionPolicyRegistry>,
 }
 
 impl AutomergeBackend {
@@ -76,6 +83,8 @@ impl AutomergeBackend {
             config: Arc::new(Mutex::new(None)),
             initialized: Arc::new(Mutex::new(false)),
             observers: Arc::new(Mutex::new(Vec::new())),
+            tombstones: Arc::new(Mutex::new(HashMap::new())),
+            deletion_policy_registry: Arc::new(DeletionPolicyRegistry::new()),
         }
     }
 
@@ -601,6 +610,151 @@ impl DocumentStore for AutomergeBackend {
         self.observers.lock().unwrap().push(tx.clone());
 
         Ok(ChangeStream { receiver: rx })
+    }
+
+    // === Deletion methods (ADR-034) ===
+
+    async fn delete(
+        &self,
+        collection: &str,
+        doc_id: &DocumentId,
+        reason: Option<&str>,
+    ) -> Result<crate::qos::DeleteResult> {
+        let policy = self.deletion_policy(collection);
+
+        match policy {
+            DeletionPolicy::Immutable => {
+                // Cannot delete immutable documents
+                Ok(crate::qos::DeleteResult::immutable())
+            }
+            DeletionPolicy::ImplicitTTL { .. } => {
+                // Implicit TTL: no-op, documents expire automatically
+                Ok(crate::qos::DeleteResult {
+                    deleted: false,
+                    tombstone_id: None,
+                    expires_at: None,
+                    policy: policy.clone(),
+                })
+            }
+            DeletionPolicy::Tombstone {
+                tombstone_ttl,
+                delete_wins: _,
+            } => {
+                // Create tombstone
+                let tombstone = if let Some(reason_str) = reason {
+                    Tombstone::with_reason(
+                        doc_id.clone(),
+                        collection.to_string(),
+                        "local".to_string(), // TODO: Use actual node ID
+                        0,                   // TODO: Use actual Lamport timestamp
+                        reason_str,
+                    )
+                } else {
+                    Tombstone::new(
+                        doc_id.clone(),
+                        collection.to_string(),
+                        "local".to_string(), // TODO: Use actual node ID
+                        0,                   // TODO: Use actual Lamport timestamp
+                    )
+                };
+                let tombstone_id = format!("{}:{}", collection, doc_id);
+
+                // Store tombstone
+                self.tombstones
+                    .lock()
+                    .unwrap()
+                    .insert(tombstone_id.clone(), tombstone.clone());
+
+                // Remove the actual document
+                self.remove(collection, doc_id).await.ok(); // Ignore if not found
+
+                Ok(crate::qos::DeleteResult {
+                    deleted: true,
+                    tombstone_id: Some(tombstone_id),
+                    expires_at: Some(std::time::SystemTime::now() + tombstone_ttl),
+                    policy: policy.clone(),
+                })
+            }
+            DeletionPolicy::SoftDelete {
+                include_deleted_default: _,
+            } => {
+                // Soft delete: mark document with _deleted=true
+                if let Some(mut doc) = self.get(collection, doc_id).await? {
+                    doc.fields.insert("_deleted".to_string(), Value::Bool(true));
+                    doc.fields.insert(
+                        "_deleted_at".to_string(),
+                        Value::String(chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()),
+                    );
+                    if let Some(reason) = reason {
+                        doc.fields.insert(
+                            "_deleted_reason".to_string(),
+                            Value::String(reason.to_string()),
+                        );
+                    }
+                    self.upsert(collection, doc).await?;
+
+                    Ok(crate::qos::DeleteResult::soft_deleted(policy.clone()))
+                } else {
+                    // Document not found - still report as deleted
+                    Ok(crate::qos::DeleteResult {
+                        deleted: false,
+                        tombstone_id: None,
+                        expires_at: None,
+                        policy: policy.clone(),
+                    })
+                }
+            }
+        }
+    }
+
+    async fn is_deleted(&self, collection: &str, doc_id: &DocumentId) -> Result<bool> {
+        let key = format!("{}:{}", collection, doc_id);
+
+        // Check if there's a tombstone
+        if self.tombstones.lock().unwrap().contains_key(&key) {
+            return Ok(true);
+        }
+
+        // Check for soft-delete (_deleted field)
+        if let Some(doc) = self.get(collection, doc_id).await? {
+            if let Some(deleted) = doc.fields.get("_deleted") {
+                return Ok(deleted.as_bool().unwrap_or(false));
+            }
+        }
+
+        Ok(false)
+    }
+
+    fn deletion_policy(&self, collection: &str) -> crate::qos::DeletionPolicy {
+        self.deletion_policy_registry.get(collection)
+    }
+
+    async fn get_tombstones(&self, collection: &str) -> Result<Vec<crate::qos::Tombstone>> {
+        let tombstones = self.tombstones.lock().unwrap();
+        let prefix = format!("{}:", collection);
+
+        Ok(tombstones
+            .iter()
+            .filter(|(key, _)| key.starts_with(&prefix))
+            .map(|(_, tombstone)| tombstone.clone())
+            .collect())
+    }
+
+    async fn apply_tombstone(&self, tombstone: &crate::qos::Tombstone) -> Result<()> {
+        let key = format!("{}:{}", tombstone.collection, tombstone.document_id);
+
+        // Store the tombstone
+        self.tombstones
+            .lock()
+            .unwrap()
+            .insert(key, tombstone.clone());
+
+        // Remove the document if it exists
+        self.remove(&tombstone.collection, &tombstone.document_id)
+            .await
+            .ok();
+
+        Ok(())
     }
 }
 
@@ -2630,5 +2784,215 @@ mod issue_271_clone_tests {
             cloned_before.is_ready().await,
             "Clone (created before init) should also be ready, proving Arc is shared"
         );
+    }
+
+    // === Deletion Tests (ADR-034) ===
+
+    fn deletion_test_config() -> BackendConfig {
+        let test_secret = crate::security::FormationKey::generate_secret();
+        BackendConfig {
+            app_id: "deletion_test".to_string(),
+            persistence_dir: std::path::PathBuf::from("/tmp/deletion_test"),
+            shared_key: Some(test_secret),
+            transport: TransportConfig::default(),
+            extra: HashMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_soft_delete() {
+        let backend = AutomergeBackend::new();
+        backend.initialize(deletion_test_config()).await.unwrap();
+
+        // Insert document
+        let mut fields = HashMap::new();
+        fields.insert("data".to_string(), serde_json::json!("test_value"));
+        let doc = Document::new(fields);
+        let doc_id = backend
+            .document_store()
+            .upsert("test_collection", doc)
+            .await
+            .unwrap();
+
+        // Verify document exists
+        let retrieved = backend
+            .document_store()
+            .get("test_collection", &doc_id)
+            .await
+            .unwrap();
+        assert!(retrieved.is_some());
+        assert!(!backend
+            .document_store()
+            .is_deleted("test_collection", &doc_id)
+            .await
+            .unwrap());
+
+        // Delete (default policy is SoftDelete)
+        let result = backend
+            .document_store()
+            .delete("test_collection", &doc_id, Some("test deletion"))
+            .await
+            .unwrap();
+        assert!(result.deleted);
+
+        // Document should now be marked as deleted
+        assert!(backend
+            .document_store()
+            .is_deleted("test_collection", &doc_id)
+            .await
+            .unwrap());
+
+        // Document should still exist (soft delete preserves it)
+        let deleted_doc = backend
+            .document_store()
+            .get("test_collection", &doc_id)
+            .await
+            .unwrap();
+        assert!(deleted_doc.is_some());
+        let deleted_doc = deleted_doc.unwrap();
+        assert_eq!(
+            deleted_doc.fields.get("_deleted"),
+            Some(&serde_json::json!(true))
+        );
+        assert!(deleted_doc.fields.contains_key("_deleted_at"));
+        assert_eq!(
+            deleted_doc.fields.get("_deleted_reason"),
+            Some(&serde_json::json!("test deletion"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tombstone_delete() {
+        let backend = AutomergeBackend::new();
+        backend.initialize(deletion_test_config()).await.unwrap();
+
+        // Configure tombstone policy for this collection
+        backend.deletion_policy_registry.set(
+            "tombstone_collection",
+            crate::qos::DeletionPolicy::Tombstone {
+                tombstone_ttl: std::time::Duration::from_secs(3600),
+                delete_wins: true,
+            },
+        );
+
+        // Insert document
+        let mut fields = HashMap::new();
+        fields.insert("data".to_string(), serde_json::json!("tombstone_test"));
+        let doc = Document::new(fields);
+        let doc_id = backend
+            .document_store()
+            .upsert("tombstone_collection", doc)
+            .await
+            .unwrap();
+
+        // Delete with tombstone policy
+        let result = backend
+            .document_store()
+            .delete("tombstone_collection", &doc_id, Some("removed"))
+            .await
+            .unwrap();
+        assert!(result.deleted);
+        assert!(result.tombstone_id.is_some());
+        assert!(result.expires_at.is_some());
+
+        // Document should be deleted
+        assert!(backend
+            .document_store()
+            .is_deleted("tombstone_collection", &doc_id)
+            .await
+            .unwrap());
+
+        // Document should be removed (not just marked)
+        let removed_doc = backend
+            .document_store()
+            .get("tombstone_collection", &doc_id)
+            .await
+            .unwrap();
+        assert!(removed_doc.is_none());
+
+        // Tombstone should exist
+        let tombstones = backend
+            .document_store()
+            .get_tombstones("tombstone_collection")
+            .await
+            .unwrap();
+        assert_eq!(tombstones.len(), 1);
+        assert_eq!(tombstones[0].document_id, doc_id);
+        assert_eq!(tombstones[0].reason, Some("removed".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_deletion_policy() {
+        let backend = AutomergeBackend::new();
+
+        // Default policy is SoftDelete
+        let policy = backend
+            .document_store()
+            .deletion_policy("unknown_collection");
+        assert!(matches!(
+            policy,
+            crate::qos::DeletionPolicy::SoftDelete { .. }
+        ));
+
+        // Verify default policies for known collections
+        assert!(matches!(
+            backend.document_store().deletion_policy("beacons"),
+            crate::qos::DeletionPolicy::ImplicitTTL { .. }
+        ));
+        assert!(matches!(
+            backend.document_store().deletion_policy("nodes"),
+            crate::qos::DeletionPolicy::Tombstone { .. }
+        ));
+        assert!(matches!(
+            backend.document_store().deletion_policy("contact_reports"),
+            crate::qos::DeletionPolicy::SoftDelete { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_apply_tombstone() {
+        let backend = AutomergeBackend::new();
+        backend.initialize(deletion_test_config()).await.unwrap();
+
+        // Insert document
+        let mut fields = HashMap::new();
+        fields.insert("data".to_string(), serde_json::json!("to_be_deleted"));
+        let doc = Document::new(fields);
+        let doc_id = backend
+            .document_store()
+            .upsert("sync_test", doc)
+            .await
+            .unwrap();
+
+        // Create a tombstone (simulating receiving from sync)
+        let tombstone = crate::qos::Tombstone::with_reason(
+            doc_id.clone(),
+            "sync_test".to_string(),
+            "remote_node".to_string(),
+            1, // Lamport timestamp
+            "synced deletion",
+        );
+
+        // Apply tombstone
+        backend
+            .document_store()
+            .apply_tombstone(&tombstone)
+            .await
+            .unwrap();
+
+        // Document should be deleted
+        assert!(backend
+            .document_store()
+            .is_deleted("sync_test", &doc_id)
+            .await
+            .unwrap());
+
+        // Document should be removed
+        let removed_doc = backend
+            .document_store()
+            .get("sync_test", &doc_id)
+            .await
+            .unwrap();
+        assert!(removed_doc.is_none());
     }
 }

--- a/hive-protocol/src/sync/traits.rs
+++ b/hive-protocol/src/sync/traits.rs
@@ -70,6 +70,82 @@ pub trait DocumentStore: Send + Sync {
         let docs = self.query(collection, query).await?;
         Ok(docs.len())
     }
+
+    // === Deletion methods (ADR-034) ===
+
+    /// Delete a document according to collection policy (ADR-034)
+    ///
+    /// Behavior depends on the collection's DeletionPolicy:
+    /// - ImplicitTTL: No-op (documents expire automatically)
+    /// - Tombstone: Creates a tombstone record
+    /// - SoftDelete: Marks document with _deleted=true
+    /// - Immutable: Returns error
+    ///
+    /// Returns DeleteResult with details about what action was taken.
+    async fn delete(
+        &self,
+        collection: &str,
+        doc_id: &DocumentId,
+        reason: Option<&str>,
+    ) -> Result<crate::qos::DeleteResult> {
+        // Default implementation: fall back to remove() with SoftDelete semantics
+        let policy = self.deletion_policy(collection);
+
+        if policy.is_immutable() {
+            return Ok(crate::qos::DeleteResult::immutable());
+        }
+
+        // For non-tombstone policies, just use remove
+        self.remove(collection, doc_id).await?;
+        let _ = reason; // Unused in default impl
+
+        Ok(crate::qos::DeleteResult::soft_deleted(policy))
+    }
+
+    /// Check if a document is deleted (tombstoned or soft-deleted)
+    ///
+    /// Returns true if:
+    /// - Document has a tombstone record, OR
+    /// - Document has _deleted=true field (soft delete)
+    ///
+    /// Returns false if document exists and is not deleted,
+    /// or if document doesn't exist.
+    async fn is_deleted(&self, collection: &str, doc_id: &DocumentId) -> Result<bool> {
+        // Default: check if document exists with _deleted field
+        if let Some(doc) = self.get(collection, doc_id).await? {
+            if let Some(deleted) = doc.fields.get("_deleted") {
+                return Ok(deleted.as_bool().unwrap_or(false));
+            }
+        }
+        Ok(false)
+    }
+
+    /// Get the deletion policy for a collection
+    ///
+    /// Returns the configured DeletionPolicy for this collection.
+    /// Default implementation returns SoftDelete for all collections.
+    fn deletion_policy(&self, _collection: &str) -> crate::qos::DeletionPolicy {
+        crate::qos::DeletionPolicy::default()
+    }
+
+    /// Get all tombstones for a collection
+    ///
+    /// Returns tombstones that haven't expired yet.
+    /// Used for sync protocol to exchange deletion markers.
+    async fn get_tombstones(&self, collection: &str) -> Result<Vec<crate::qos::Tombstone>> {
+        // Default: no tombstones (backends override)
+        let _ = collection;
+        Ok(vec![])
+    }
+
+    /// Apply a tombstone received from sync
+    ///
+    /// Used by sync protocol to apply remote deletions.
+    async fn apply_tombstone(&self, tombstone: &crate::qos::Tombstone) -> Result<()> {
+        // Default: just remove the document
+        self.remove(&tombstone.collection, &tombstone.document_id)
+            .await
+    }
 }
 
 /// Trait 2: Peer Discovery and Connection Management

--- a/hive-protocol/src/sync/types.rs
+++ b/hive-protocol/src/sync/types.rs
@@ -610,9 +610,10 @@ pub enum Priority {
 ///
 /// ```
 /// use hive_protocol::sync::types::SyncModeMetrics;
+/// use hive_protocol::qos::SyncMode;
 ///
 /// let mut metrics = SyncModeMetrics::new();
-/// metrics.record_sync("beacons", crate::qos::SyncMode::LatestOnly, 1024, std::time::Duration::from_millis(5));
+/// metrics.record_sync("beacons", SyncMode::LatestOnly, 1024, std::time::Duration::from_millis(5));
 /// assert_eq!(metrics.total_syncs, 1);
 /// assert_eq!(metrics.latest_only_syncs, 1);
 /// ```


### PR DESCRIPTION
## Summary

Implements Phase 1 of ADR-034 record deletion framework, providing the core infrastructure for CRDT-compatible deletion with multiple strategies.

- **Core Types** (`qos/deletion.rs`): `DeletionPolicy` enum (ImplicitTTL, Tombstone, SoftDelete, Immutable), `Tombstone` struct, `DeleteResult` struct, `DeletionPolicyRegistry` with per-collection defaults
- **DocumentStore Trait Extensions** (`sync/traits.rs`): `delete()`, `is_deleted()`, `deletion_policy()`, `get_tombstones()`, `apply_tombstone()`
- **AutomergeBackend Implementation** (`sync/automerge.rs`): Full deletion support with tombstone storage and soft-delete markers

### Collection Policy Defaults (per ADR-034)

| Collection | Strategy | TTL | Semantics |
|------------|----------|-----|-----------|
| beacons/platforms | ImplicitTTL | 1hr | Superseded by newer |
| tracks | Tombstone | 1hr | delete_wins |
| nodes/cells | Tombstone | 24hr | delete_wins |
| contact_reports/commands | SoftDelete | forever | audit trail |
| alerts | Tombstone | 4hr | update_wins |

## Test plan

- [x] 11 unit tests for deletion primitives in `qos/deletion.rs`
- [x] 4 integration tests for AutomergeBackend deletion (soft_delete, tombstone_delete, deletion_policy, apply_tombstone)
- [x] All existing tests pass (34 passed, 0 failed)
- [x] Pre-commit checks pass (format + clippy)

Related: #365, ADR-034

🤖 Generated with [Claude Code](https://claude.com/claude-code)