### PR TITLE
feat(hive-btle): Implement mesh topology manager (#406)

### DIFF
--- a/hive-btle/src/lib.rs
+++ b/hive-btle/src/lib.rs
@@ -96,6 +96,7 @@ pub mod config;
 pub mod discovery;
 pub mod error;
 pub mod gatt;
+pub mod mesh;
 pub mod platform;
 pub mod transport;
 
@@ -104,6 +105,7 @@ pub use config::{BleConfig, BlePhy, DiscoveryConfig, GattConfig, MeshConfig, Pow
 pub use discovery::{Advertiser, HiveBeacon, ScanFilter, Scanner};
 pub use error::{BleError, Result};
 pub use gatt::{HiveGattService, SyncProtocol};
+pub use mesh::{MeshManager, MeshRouter, MeshTopology, TopologyConfig, TopologyEvent};
 pub use platform::{BleAdapter, ConnectionEvent, DisconnectReason, DiscoveredDevice, StubAdapter};
 pub use transport::{BleConnection, BluetoothLETransport, MeshTransport, TransportCapabilities};
 

--- a/hive-btle/src/mesh/manager.rs
+++ b/hive-btle/src/mesh/manager.rs
@@ -1,0 +1,732 @@
+//! Mesh Manager
+//!
+//! Manages the mesh topology, connections, and provides parent failover.
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, collections::BTreeMap, vec::Vec};
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(feature = "std")]
+use std::sync::RwLock;
+
+use crate::discovery::HiveBeacon;
+use crate::error::{BleError, Result};
+use crate::{HierarchyLevel, NodeId};
+
+use super::topology::{
+    ConnectionState, DisconnectReason, MeshTopology, ParentCandidate, PeerInfo, PeerRole,
+    TopologyConfig, TopologyEvent,
+};
+
+/// Callback type for topology events
+pub type TopologyCallback = Box<dyn Fn(&TopologyEvent) + Send + Sync>;
+
+/// Mesh manager state
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ManagerState {
+    /// Not started
+    #[default]
+    Stopped,
+    /// Starting up
+    Starting,
+    /// Running and managing topology
+    Running,
+    /// In parent failover mode
+    Failover,
+    /// Stopping
+    Stopping,
+}
+
+/// Manages the BLE mesh topology
+///
+/// Responsible for:
+/// - Tracking parent/child/peer connections
+/// - Parent selection and failover
+/// - Connection lifecycle management
+/// - Publishing topology events
+#[cfg(feature = "std")]
+pub struct MeshManager {
+    /// Our node ID
+    node_id: NodeId,
+    /// Our hierarchy level
+    my_level: HierarchyLevel,
+    /// Configuration
+    config: TopologyConfig,
+    /// Current topology state
+    topology: RwLock<MeshTopology>,
+    /// Connected peer info
+    peers: RwLock<HashMap<NodeId, PeerInfo>>,
+    /// Parent candidates from beacons
+    candidates: RwLock<Vec<ParentCandidate>>,
+    /// Current state
+    state: RwLock<ManagerState>,
+    /// Event callbacks
+    callbacks: RwLock<Vec<TopologyCallback>>,
+    /// Monotonic time in milliseconds (for testing without system time)
+    current_time_ms: AtomicU64,
+}
+
+#[cfg(feature = "std")]
+impl MeshManager {
+    /// Create a new mesh manager
+    pub fn new(node_id: NodeId, my_level: HierarchyLevel, config: TopologyConfig) -> Self {
+        let topology = MeshTopology::new(my_level, config.max_children, config.max_connections);
+
+        Self {
+            node_id,
+            my_level,
+            config,
+            topology: RwLock::new(topology),
+            peers: RwLock::new(HashMap::new()),
+            candidates: RwLock::new(Vec::new()),
+            state: RwLock::new(ManagerState::Stopped),
+            callbacks: RwLock::new(Vec::new()),
+            current_time_ms: AtomicU64::new(0),
+        }
+    }
+
+    /// Get our node ID
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    /// Get our hierarchy level
+    pub fn my_level(&self) -> HierarchyLevel {
+        self.my_level
+    }
+
+    /// Get current state
+    pub fn state(&self) -> ManagerState {
+        *self.state.read().unwrap()
+    }
+
+    /// Start the mesh manager
+    pub fn start(&self) -> Result<()> {
+        let mut state = self.state.write().unwrap();
+        match *state {
+            ManagerState::Stopped => {
+                *state = ManagerState::Running;
+                Ok(())
+            }
+            _ => Err(BleError::InvalidState("Already started".into())),
+        }
+    }
+
+    /// Stop the mesh manager
+    pub fn stop(&self) -> Result<()> {
+        let mut state = self.state.write().unwrap();
+        *state = ManagerState::Stopped;
+
+        // Clear topology
+        let mut topology = self.topology.write().unwrap();
+        topology.parent = None;
+        topology.children.clear();
+        topology.peers.clear();
+
+        // Clear peers
+        self.peers.write().unwrap().clear();
+
+        // Clear candidates
+        self.candidates.write().unwrap().clear();
+
+        Ok(())
+    }
+
+    /// Register a callback for topology events
+    pub fn on_topology_event(&self, callback: TopologyCallback) {
+        self.callbacks.write().unwrap().push(callback);
+    }
+
+    /// Emit a topology event to all listeners
+    fn emit_event(&self, event: TopologyEvent) {
+        let callbacks = self.callbacks.read().unwrap();
+        for callback in callbacks.iter() {
+            callback(&event);
+        }
+    }
+
+    /// Set the current time (for testing or embedded without RTC)
+    pub fn set_time_ms(&self, time_ms: u64) {
+        self.current_time_ms.store(time_ms, Ordering::SeqCst);
+    }
+
+    /// Get the current time
+    pub fn time_ms(&self) -> u64 {
+        self.current_time_ms.load(Ordering::SeqCst)
+    }
+
+    /// Get a snapshot of the current topology
+    pub fn topology(&self) -> MeshTopology {
+        self.topology.read().unwrap().clone()
+    }
+
+    /// Check if we have a parent
+    pub fn has_parent(&self) -> bool {
+        self.topology.read().unwrap().has_parent()
+    }
+
+    /// Get our parent's node ID
+    pub fn parent(&self) -> Option<NodeId> {
+        self.topology.read().unwrap().parent.clone()
+    }
+
+    /// Get list of children
+    pub fn children(&self) -> Vec<NodeId> {
+        self.topology.read().unwrap().children.clone()
+    }
+
+    /// Get number of children
+    pub fn child_count(&self) -> usize {
+        self.topology.read().unwrap().children.len()
+    }
+
+    /// Check if we can accept more children
+    pub fn can_accept_child(&self) -> bool {
+        self.topology.read().unwrap().can_accept_child()
+    }
+
+    /// Get all connected peer IDs
+    pub fn connected_peers(&self) -> Vec<NodeId> {
+        self.topology.read().unwrap().all_connected()
+    }
+
+    /// Get peer info for a node
+    pub fn get_peer_info(&self, node_id: &NodeId) -> Option<PeerInfo> {
+        self.peers.read().unwrap().get(node_id).cloned()
+    }
+
+    /// Process a beacon from a discovered node
+    ///
+    /// This updates our list of potential parents
+    pub fn process_beacon(&self, beacon: &HiveBeacon, rssi: i8) {
+        // Only consider nodes at higher hierarchy levels as parent candidates
+        if beacon.hierarchy_level > self.my_level {
+            let candidate = ParentCandidate {
+                node_id: beacon.node_id.clone(),
+                level: beacon.hierarchy_level,
+                rssi,
+                age_ms: 0,
+                failure_count: self
+                    .peers
+                    .read()
+                    .unwrap()
+                    .get(&beacon.node_id)
+                    .map(|p| p.failure_count)
+                    .unwrap_or(0),
+            };
+
+            let mut candidates = self.candidates.write().unwrap();
+
+            // Update existing or add new
+            if let Some(existing) = candidates.iter_mut().find(|c| c.node_id == beacon.node_id) {
+                existing.rssi = rssi;
+                existing.age_ms = 0;
+                existing.level = beacon.hierarchy_level;
+            } else {
+                candidates.push(candidate);
+            }
+        }
+    }
+
+    /// Select best parent from candidates
+    ///
+    /// Returns the best candidate based on RSSI, age, and failure history
+    pub fn select_best_parent(&self) -> Option<ParentCandidate> {
+        let candidates = self.candidates.read().unwrap();
+
+        candidates
+            .iter()
+            .filter(|c| {
+                c.rssi >= self.config.min_parent_rssi
+                    && c.age_ms <= self.config.max_beacon_age_ms
+                    && c.failure_count < self.config.max_failures
+            })
+            .max_by_key(|c| c.score(self.my_level))
+            .cloned()
+    }
+
+    /// Connect to a node as our parent
+    pub fn connect_parent(&self, node_id: NodeId, level: HierarchyLevel, rssi: i8) -> Result<()> {
+        let mut topology = self.topology.write().unwrap();
+
+        if topology.has_parent() {
+            return Err(BleError::InvalidState("Already have a parent".into()));
+        }
+
+        if !topology.set_parent(node_id.clone()) {
+            return Err(BleError::ConnectionFailed(
+                "Cannot accept connection".into(),
+            ));
+        }
+
+        // Add peer info
+        let mut peer_info = PeerInfo::new(node_id.clone(), PeerRole::Parent, level);
+        peer_info.state = ConnectionState::Connected;
+        peer_info.rssi = Some(rssi);
+        peer_info.connected_at = Some(self.time_ms());
+        peer_info.last_seen_ms = self.time_ms();
+
+        self.peers
+            .write()
+            .unwrap()
+            .insert(node_id.clone(), peer_info);
+
+        // Emit event
+        drop(topology); // Release lock before emitting
+        self.emit_event(TopologyEvent::ParentConnected {
+            node_id,
+            level,
+            rssi: Some(rssi),
+        });
+
+        self.emit_topology_changed();
+        Ok(())
+    }
+
+    /// Disconnect from our parent
+    pub fn disconnect_parent(&self, reason: DisconnectReason) -> Option<NodeId> {
+        let old_parent = {
+            let mut topology = self.topology.write().unwrap();
+            topology.clear_parent()
+        };
+
+        if let Some(ref parent_id) = old_parent {
+            self.peers.write().unwrap().remove(parent_id);
+
+            self.emit_event(TopologyEvent::ParentDisconnected {
+                node_id: parent_id.clone(),
+                reason,
+            });
+            self.emit_topology_changed();
+        }
+
+        old_parent
+    }
+
+    /// Accept a child connection
+    pub fn accept_child(&self, node_id: NodeId, level: HierarchyLevel) -> Result<()> {
+        let mut topology = self.topology.write().unwrap();
+
+        if !topology.add_child(node_id.clone()) {
+            return Err(BleError::ConnectionFailed("Cannot accept child".into()));
+        }
+
+        // Add peer info
+        let mut peer_info = PeerInfo::new(node_id.clone(), PeerRole::Child, level);
+        peer_info.state = ConnectionState::Connected;
+        peer_info.connected_at = Some(self.time_ms());
+        peer_info.last_seen_ms = self.time_ms();
+
+        self.peers
+            .write()
+            .unwrap()
+            .insert(node_id.clone(), peer_info);
+
+        // Emit event
+        drop(topology);
+        self.emit_event(TopologyEvent::ChildConnected { node_id, level });
+
+        self.emit_topology_changed();
+        Ok(())
+    }
+
+    /// Remove a child
+    pub fn remove_child(&self, node_id: &NodeId, reason: DisconnectReason) -> bool {
+        let removed = {
+            let mut topology = self.topology.write().unwrap();
+            topology.remove_child(node_id)
+        };
+
+        if removed {
+            self.peers.write().unwrap().remove(node_id);
+
+            self.emit_event(TopologyEvent::ChildDisconnected {
+                node_id: node_id.clone(),
+                reason,
+            });
+            self.emit_topology_changed();
+        }
+
+        removed
+    }
+
+    /// Start parent failover process
+    pub fn start_failover(&self) -> Result<()> {
+        let mut state = self.state.write().unwrap();
+        if *state != ManagerState::Running {
+            return Err(BleError::InvalidState("Not running".into()));
+        }
+
+        let old_parent = self.disconnect_parent(DisconnectReason::LinkLoss);
+
+        if let Some(old_parent_id) = old_parent {
+            *state = ManagerState::Failover;
+            drop(state);
+
+            self.emit_event(TopologyEvent::ParentFailoverStarted {
+                old_parent: old_parent_id,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Complete failover by connecting to new parent
+    pub fn complete_failover(
+        &self,
+        new_parent: Option<(NodeId, HierarchyLevel, i8)>,
+    ) -> Result<()> {
+        let old_parent = {
+            // Get old parent from candidates list (it was stored there)
+            self.candidates
+                .read()
+                .unwrap()
+                .first()
+                .map(|c| c.node_id.clone())
+                .unwrap_or_else(|| NodeId::new(0))
+        };
+
+        if let Some((node_id, level, rssi)) = new_parent {
+            self.connect_parent(node_id.clone(), level, rssi)?;
+
+            let mut state = self.state.write().unwrap();
+            *state = ManagerState::Running;
+            drop(state);
+
+            self.emit_event(TopologyEvent::ParentFailoverCompleted {
+                old_parent,
+                new_parent: Some(node_id),
+            });
+        } else {
+            let mut state = self.state.write().unwrap();
+            *state = ManagerState::Running;
+            drop(state);
+
+            self.emit_event(TopologyEvent::ParentFailoverCompleted {
+                old_parent,
+                new_parent: None,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Update RSSI for a connected peer
+    pub fn update_rssi(&self, node_id: &NodeId, rssi: i8) {
+        let mut peers = self.peers.write().unwrap();
+        if let Some(peer) = peers.get_mut(node_id) {
+            peer.update_rssi(rssi);
+            peer.last_seen_ms = self.time_ms();
+        }
+        drop(peers);
+
+        self.emit_event(TopologyEvent::ConnectionQualityChanged {
+            node_id: node_id.clone(),
+            rssi,
+        });
+    }
+
+    /// Record a connection failure for a node
+    pub fn record_failure(&self, node_id: &NodeId) {
+        let mut peers = self.peers.write().unwrap();
+        if let Some(peer) = peers.get_mut(node_id) {
+            peer.record_failure();
+        }
+
+        // Also update candidate failure count
+        let mut candidates = self.candidates.write().unwrap();
+        if let Some(candidate) = candidates.iter_mut().find(|c| &c.node_id == node_id) {
+            candidate.failure_count = candidate.failure_count.saturating_add(1);
+        }
+    }
+
+    /// Age all candidates (call periodically)
+    pub fn age_candidates(&self, elapsed_ms: u64) {
+        let mut candidates = self.candidates.write().unwrap();
+        for candidate in candidates.iter_mut() {
+            candidate.age_ms = candidate.age_ms.saturating_add(elapsed_ms);
+        }
+
+        // Remove candidates that are too old
+        candidates.retain(|c| c.age_ms <= self.config.max_beacon_age_ms * 2);
+    }
+
+    /// Check if we should switch parents (better option available)
+    pub fn should_switch_parent(&self) -> Option<ParentCandidate> {
+        let topology = self.topology.read().unwrap();
+        let current_parent = topology.parent.clone()?;
+        drop(topology);
+
+        let peers = self.peers.read().unwrap();
+        let current_rssi = peers.get(&current_parent)?.rssi?;
+        drop(peers);
+
+        // Find best alternative
+        let best = self.select_best_parent()?;
+
+        // Only switch if significantly better (hysteresis)
+        if best.rssi > current_rssi + self.config.rssi_hysteresis as i8 {
+            Some(best)
+        } else {
+            None
+        }
+    }
+
+    /// Helper to emit topology changed event
+    fn emit_topology_changed(&self) {
+        let topology = self.topology.read().unwrap();
+        self.emit_event(TopologyEvent::TopologyChanged {
+            child_count: topology.children.len(),
+            peer_count: topology.peers.len(),
+            has_parent: topology.has_parent(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_manager() -> MeshManager {
+        MeshManager::new(
+            NodeId::new(0x1234),
+            HierarchyLevel::Platform,
+            TopologyConfig::default(),
+        )
+    }
+
+    #[test]
+    fn test_manager_creation() {
+        let manager = create_manager();
+        assert_eq!(manager.node_id().as_u32(), 0x1234);
+        assert_eq!(manager.my_level(), HierarchyLevel::Platform);
+        assert_eq!(manager.state(), ManagerState::Stopped);
+    }
+
+    #[test]
+    fn test_start_stop() {
+        let manager = create_manager();
+
+        assert!(manager.start().is_ok());
+        assert_eq!(manager.state(), ManagerState::Running);
+
+        assert!(manager.stop().is_ok());
+        assert_eq!(manager.state(), ManagerState::Stopped);
+    }
+
+    #[test]
+    fn test_connect_parent() {
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        let parent_id = NodeId::new(0x5678);
+        assert!(manager
+            .connect_parent(parent_id.clone(), HierarchyLevel::Squad, -50)
+            .is_ok());
+
+        assert!(manager.has_parent());
+        assert_eq!(manager.parent(), Some(parent_id.clone()));
+
+        // Can't connect another parent
+        assert!(manager
+            .connect_parent(NodeId::new(0x9999), HierarchyLevel::Squad, -50)
+            .is_err());
+    }
+
+    #[test]
+    fn test_disconnect_parent() {
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        let parent_id = NodeId::new(0x5678);
+        manager
+            .connect_parent(parent_id.clone(), HierarchyLevel::Squad, -50)
+            .unwrap();
+
+        let old = manager.disconnect_parent(DisconnectReason::Requested);
+        assert_eq!(old, Some(parent_id));
+        assert!(!manager.has_parent());
+    }
+
+    #[test]
+    fn test_accept_child() {
+        let manager = MeshManager::new(
+            NodeId::new(0x1234),
+            HierarchyLevel::Squad,
+            TopologyConfig::default(),
+        );
+        manager.start().unwrap();
+
+        let child_id = NodeId::new(0x0001);
+        assert!(manager
+            .accept_child(child_id.clone(), HierarchyLevel::Platform)
+            .is_ok());
+
+        assert_eq!(manager.child_count(), 1);
+        assert_eq!(manager.children(), vec![child_id]);
+    }
+
+    #[test]
+    fn test_max_children() {
+        let config = TopologyConfig {
+            max_children: 2,
+            ..Default::default()
+        };
+
+        let manager = MeshManager::new(NodeId::new(0x1234), HierarchyLevel::Squad, config);
+        manager.start().unwrap();
+
+        assert!(manager
+            .accept_child(NodeId::new(0x0001), HierarchyLevel::Platform)
+            .is_ok());
+        assert!(manager
+            .accept_child(NodeId::new(0x0002), HierarchyLevel::Platform)
+            .is_ok());
+        assert!(manager
+            .accept_child(NodeId::new(0x0003), HierarchyLevel::Platform)
+            .is_err());
+    }
+
+    #[test]
+    fn test_process_beacon() {
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        let beacon = HiveBeacon {
+            node_id: NodeId::new(0x5678),
+            hierarchy_level: HierarchyLevel::Squad,
+            version: 1,
+            seq_num: 1,
+            capabilities: 0,
+            battery_percent: 100,
+            geohash: 0,
+        };
+
+        manager.process_beacon(&beacon, -50);
+
+        let best = manager.select_best_parent();
+        assert!(best.is_some());
+        assert_eq!(best.unwrap().node_id.as_u32(), 0x5678);
+    }
+
+    #[test]
+    fn test_select_best_parent_rssi() {
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        // Add two candidates
+        let beacon1 = HiveBeacon {
+            node_id: NodeId::new(0x1111),
+            hierarchy_level: HierarchyLevel::Squad,
+            version: 1,
+            seq_num: 1,
+            capabilities: 0,
+            battery_percent: 100,
+            geohash: 0,
+        };
+
+        let beacon2 = HiveBeacon {
+            node_id: NodeId::new(0x2222),
+            hierarchy_level: HierarchyLevel::Squad,
+            version: 1,
+            seq_num: 1,
+            capabilities: 0,
+            battery_percent: 100,
+            geohash: 0,
+        };
+
+        manager.process_beacon(&beacon1, -70);
+        manager.process_beacon(&beacon2, -50); // Better RSSI
+
+        let best = manager.select_best_parent().unwrap();
+        assert_eq!(best.node_id.as_u32(), 0x2222);
+    }
+
+    #[test]
+    fn test_failover() {
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        let parent_id = NodeId::new(0x5678);
+        manager
+            .connect_parent(parent_id.clone(), HierarchyLevel::Squad, -50)
+            .unwrap();
+
+        // Start failover
+        assert!(manager.start_failover().is_ok());
+        assert_eq!(manager.state(), ManagerState::Failover);
+        assert!(!manager.has_parent());
+
+        // Complete without new parent
+        assert!(manager.complete_failover(None).is_ok());
+        assert_eq!(manager.state(), ManagerState::Running);
+    }
+
+    #[test]
+    fn test_event_callback() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        let called = Arc::new(AtomicBool::new(false));
+        let called_clone = called.clone();
+
+        manager.on_topology_event(Box::new(move |event| {
+            if matches!(event, TopologyEvent::ParentConnected { .. }) {
+                called_clone.store(true, Ordering::SeqCst);
+            }
+        }));
+
+        manager
+            .connect_parent(NodeId::new(0x5678), HierarchyLevel::Squad, -50)
+            .unwrap();
+
+        assert!(called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn test_update_rssi() {
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        let parent_id = NodeId::new(0x5678);
+        manager
+            .connect_parent(parent_id.clone(), HierarchyLevel::Squad, -50)
+            .unwrap();
+
+        manager.update_rssi(&parent_id, -60);
+
+        let info = manager.get_peer_info(&parent_id).unwrap();
+        assert_eq!(info.rssi, Some(-60));
+    }
+
+    #[test]
+    fn test_age_candidates() {
+        let manager = create_manager();
+        manager.start().unwrap();
+
+        let beacon = HiveBeacon {
+            node_id: NodeId::new(0x5678),
+            hierarchy_level: HierarchyLevel::Squad,
+            version: 1,
+            seq_num: 1,
+            capabilities: 0,
+            battery_percent: 100,
+            geohash: 0,
+        };
+
+        manager.process_beacon(&beacon, -50);
+
+        // Age past the threshold
+        manager.age_candidates(25_000);
+
+        // Should be removed
+        let best = manager.select_best_parent();
+        assert!(best.is_none());
+    }
+}

--- a/hive-btle/src/mesh/mod.rs
+++ b/hive-btle/src/mesh/mod.rs
@@ -1,0 +1,108 @@
+//! Mesh Topology Management
+//!
+//! This module provides mesh topology management for HIVE-BTLE, including:
+//!
+//! - **Topology tracking**: Parent/child/peer relationships
+//! - **Connection management**: Connect, disconnect, failover
+//! - **Message routing**: Upward aggregation, downward dissemination
+//! - **RSSI-based selection**: Best parent/peer selection
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────┐
+//! │                    MeshManager                           │
+//! │  ┌─────────────┐  ┌─────────────┐  ┌─────────────────┐  │
+//! │  │  Topology   │  │   Router    │  │  Parent Failover │  │
+//! │  │   State     │  │             │  │                  │  │
+//! │  └─────────────┘  └─────────────┘  └─────────────────┘  │
+//! └─────────────────────────────────────────────────────────┘
+//!                          │
+//!                          ▼
+//!            ┌──────────────────────────────┐
+//!            │     TopologyEvents           │
+//!            │  • ParentConnected           │
+//!            │  • ChildConnected            │
+//!            │  • TopologyChanged           │
+//!            └──────────────────────────────┘
+//! ```
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_btle::mesh::{MeshManager, TopologyConfig, TopologyEvent};
+//! use hive_btle::{NodeId, HierarchyLevel};
+//!
+//! // Create mesh manager
+//! let manager = MeshManager::new(
+//!     NodeId::new(0x12345678),
+//!     HierarchyLevel::Platform,
+//!     TopologyConfig::default(),
+//! );
+//!
+//! // Register for topology events
+//! manager.on_topology_event(Box::new(|event| {
+//!     match event {
+//!         TopologyEvent::ParentConnected { node_id, .. } => {
+//!             println!("Connected to parent: {}", node_id);
+//!         }
+//!         _ => {}
+//!     }
+//! }));
+//!
+//! // Start the manager
+//! manager.start()?;
+//!
+//! // Process discovered beacons
+//! manager.process_beacon(&beacon, rssi);
+//!
+//! // Select and connect to best parent
+//! if let Some(candidate) = manager.select_best_parent() {
+//!     manager.connect_parent(candidate.node_id, candidate.level, candidate.rssi)?;
+//! }
+//! ```
+//!
+//! ## Parent Failover
+//!
+//! When parent connection is lost:
+//!
+//! 1. `start_failover()` is called
+//! 2. Manager enters `Failover` state
+//! 3. `ParentFailoverStarted` event is emitted
+//! 4. Application scans for new parent candidates
+//! 5. `complete_failover()` connects to new parent (or gives up)
+//! 6. `ParentFailoverCompleted` event is emitted
+//!
+//! ## Message Routing
+//!
+//! The `MeshRouter` provides routing decisions:
+//!
+//! - **Upward**: To parent (aggregation)
+//! - **Downward**: To children (dissemination)
+//! - **Broadcast**: To all connected peers
+//! - **Targeted**: To a specific node
+//!
+//! ```ignore
+//! use hive_btle::mesh::{MeshRouter, RouteDirection};
+//!
+//! let router = MeshRouter::new(node_id, my_level);
+//! let topology = manager.topology();
+//!
+//! let decision = router.route(RouteDirection::Upward, &topology);
+//! if decision.routed {
+//!     for next_hop in decision.next_hops {
+//!         send_to(&next_hop, &message);
+//!     }
+//! }
+//! ```
+
+mod manager;
+mod routing;
+mod topology;
+
+pub use manager::{ManagerState, MeshManager, TopologyCallback};
+pub use routing::{HopTracker, MeshRouter, RouteDecision, RouteDirection, RouteFailure};
+pub use topology::{
+    ConnectionState, DisconnectReason, MeshTopology, ParentCandidate, PeerInfo, PeerRole,
+    TopologyConfig, TopologyEvent,
+};

--- a/hive-btle/src/mesh/routing.rs
+++ b/hive-btle/src/mesh/routing.rs
@@ -1,0 +1,415 @@
+//! Message routing for HIVE-BTLE mesh
+//!
+//! Handles routing messages through the mesh topology, including:
+//! - Upward routing to parent
+//! - Downward routing to children
+//! - Broadcast to all connected peers
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::{HierarchyLevel, NodeId};
+
+use super::topology::MeshTopology;
+
+/// Message routing direction
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteDirection {
+    /// Route upward toward the root (parent direction)
+    Upward,
+    /// Route downward toward leaves (children direction)
+    Downward,
+    /// Route to all connected peers
+    Broadcast,
+    /// Route to a specific node
+    Targeted(u32), // NodeId as u32 for Copy
+}
+
+/// A routing decision for a message
+#[derive(Debug, Clone)]
+pub struct RouteDecision {
+    /// Next hop(s) for the message
+    pub next_hops: Vec<NodeId>,
+    /// Whether to keep a local copy
+    pub local_copy: bool,
+    /// Whether routing succeeded
+    pub routed: bool,
+    /// Reason if routing failed
+    pub failure_reason: Option<RouteFailure>,
+}
+
+impl RouteDecision {
+    /// Create a successful route decision
+    pub fn success(next_hops: Vec<NodeId>, local_copy: bool) -> Self {
+        Self {
+            next_hops,
+            local_copy,
+            routed: true,
+            failure_reason: None,
+        }
+    }
+
+    /// Create a failed route decision
+    pub fn failed(reason: RouteFailure) -> Self {
+        Self {
+            next_hops: Vec::new(),
+            local_copy: false,
+            routed: false,
+            failure_reason: Some(reason),
+        }
+    }
+
+    /// Route for local processing only
+    pub fn local_only() -> Self {
+        Self {
+            next_hops: Vec::new(),
+            local_copy: true,
+            routed: true,
+            failure_reason: None,
+        }
+    }
+}
+
+/// Reason for routing failure
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteFailure {
+    /// No parent available for upward routing
+    NoParent,
+    /// No children for downward routing
+    NoChildren,
+    /// Target node not found in topology
+    TargetNotFound,
+    /// No peers connected
+    NoPeers,
+    /// TTL expired
+    TtlExpired,
+    /// Message too large
+    MessageTooLarge,
+}
+
+/// Router for mesh messages
+///
+/// Determines where to send messages based on the current topology.
+#[derive(Debug, Clone)]
+pub struct MeshRouter {
+    /// Our node ID
+    pub node_id: NodeId,
+    /// Our hierarchy level
+    pub my_level: HierarchyLevel,
+}
+
+impl MeshRouter {
+    /// Create a new router
+    pub fn new(node_id: NodeId, my_level: HierarchyLevel) -> Self {
+        Self { node_id, my_level }
+    }
+
+    /// Route a message based on direction
+    pub fn route(&self, direction: RouteDirection, topology: &MeshTopology) -> RouteDecision {
+        match direction {
+            RouteDirection::Upward => self.route_upward(topology),
+            RouteDirection::Downward => self.route_downward(topology),
+            RouteDirection::Broadcast => self.route_broadcast(topology),
+            RouteDirection::Targeted(target_id) => {
+                self.route_targeted(&NodeId::new(target_id), topology)
+            }
+        }
+    }
+
+    /// Route upward to parent
+    fn route_upward(&self, topology: &MeshTopology) -> RouteDecision {
+        match &topology.parent {
+            Some(parent_id) => RouteDecision::success(vec![parent_id.clone()], true),
+            None => RouteDecision::failed(RouteFailure::NoParent),
+        }
+    }
+
+    /// Route downward to children
+    fn route_downward(&self, topology: &MeshTopology) -> RouteDecision {
+        if topology.children.is_empty() {
+            RouteDecision::failed(RouteFailure::NoChildren)
+        } else {
+            RouteDecision::success(topology.children.clone(), true)
+        }
+    }
+
+    /// Route to all connected peers (broadcast)
+    fn route_broadcast(&self, topology: &MeshTopology) -> RouteDecision {
+        let all = topology.all_connected();
+        if all.is_empty() {
+            RouteDecision::failed(RouteFailure::NoPeers)
+        } else {
+            RouteDecision::success(all, true)
+        }
+    }
+
+    /// Route to a specific target node
+    fn route_targeted(&self, target: &NodeId, topology: &MeshTopology) -> RouteDecision {
+        // Check if target is directly connected
+        if topology.is_connected(target) {
+            return RouteDecision::success(vec![target.clone()], false);
+        }
+
+        // Not directly connected - need to route through topology
+        // For now, use simple strategy:
+        // - If we have a parent, route upward (parent has broader view)
+        // - Otherwise, route to all children (flood downward)
+
+        if let Some(ref parent) = topology.parent {
+            // Route to parent, it will figure out where to send
+            RouteDecision::success(vec![parent.clone()], false)
+        } else if !topology.children.is_empty() {
+            // Flood to all children
+            RouteDecision::success(topology.children.clone(), false)
+        } else {
+            RouteDecision::failed(RouteFailure::TargetNotFound)
+        }
+    }
+
+    /// Determine routing for a received message
+    ///
+    /// Given the source and destination, decide what to do with a message.
+    pub fn handle_received(
+        &self,
+        source: &NodeId,
+        destination: Option<&NodeId>,
+        direction: RouteDirection,
+        topology: &MeshTopology,
+    ) -> RouteDecision {
+        // Check if we are the destination
+        if let Some(dest) = destination {
+            if dest == &self.node_id {
+                return RouteDecision::local_only();
+            }
+        }
+
+        // Determine role of source (may be useful for advanced routing)
+        let _source_role = topology.get_role(source);
+
+        match direction {
+            RouteDirection::Upward => {
+                // Message going upward - forward to parent
+                self.route_upward(topology)
+            }
+            RouteDirection::Downward => {
+                // Message going downward - forward to children
+                // Exclude the source if it's one of our children
+                let mut children = topology.children.clone();
+                children.retain(|c| c != source);
+                if children.is_empty() {
+                    RouteDecision::local_only()
+                } else {
+                    RouteDecision::success(children, true)
+                }
+            }
+            RouteDirection::Broadcast => {
+                // Broadcast - forward to all except source
+                let mut all = topology.all_connected();
+                all.retain(|n| n != source);
+                RouteDecision::success(all, true)
+            }
+            RouteDirection::Targeted(target_id) => {
+                let target = NodeId::new(target_id);
+                if target == self.node_id {
+                    RouteDecision::local_only()
+                } else {
+                    self.route_targeted(&target, topology)
+                }
+            }
+        }
+    }
+
+    /// Get the best route for aggregation (data flowing upward)
+    ///
+    /// For HIVE-Lite nodes, this is always the parent.
+    pub fn aggregation_route(&self, topology: &MeshTopology) -> Option<NodeId> {
+        topology.parent.clone()
+    }
+
+    /// Get routes for dissemination (data flowing downward)
+    ///
+    /// Returns all children that should receive the data.
+    pub fn dissemination_routes(&self, topology: &MeshTopology) -> Vec<NodeId> {
+        topology.children.clone()
+    }
+}
+
+/// Message hop tracking for loop prevention
+#[derive(Debug, Clone)]
+pub struct HopTracker {
+    /// Maximum allowed hops
+    pub max_hops: u8,
+    /// Nodes this message has visited
+    pub visited: Vec<NodeId>,
+}
+
+impl HopTracker {
+    /// Create a new hop tracker
+    pub fn new(max_hops: u8) -> Self {
+        Self {
+            max_hops,
+            visited: Vec::new(),
+        }
+    }
+
+    /// Record visiting a node
+    pub fn visit(&mut self, node_id: NodeId) -> bool {
+        if self.visited.contains(&node_id) {
+            return false; // Loop detected
+        }
+        if self.visited.len() >= self.max_hops as usize {
+            return false; // TTL expired
+        }
+        self.visited.push(node_id);
+        true
+    }
+
+    /// Check if we've visited a node
+    pub fn has_visited(&self, node_id: &NodeId) -> bool {
+        self.visited.contains(node_id)
+    }
+
+    /// Get remaining hops
+    pub fn remaining_hops(&self) -> u8 {
+        self.max_hops.saturating_sub(self.visited.len() as u8)
+    }
+
+    /// Check if TTL is expired
+    pub fn is_expired(&self) -> bool {
+        self.visited.len() >= self.max_hops as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_topology_with_parent() -> MeshTopology {
+        let mut topology = MeshTopology::new(HierarchyLevel::Platform, 3, 7);
+        topology.set_parent(NodeId::new(0x1000));
+        topology.add_child(NodeId::new(0x0001));
+        topology.add_child(NodeId::new(0x0002));
+        topology
+    }
+
+    #[test]
+    fn test_route_upward() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Platform);
+        let topology = create_topology_with_parent();
+
+        let decision = router.route(RouteDirection::Upward, &topology);
+        assert!(decision.routed);
+        assert_eq!(decision.next_hops.len(), 1);
+        assert_eq!(decision.next_hops[0].as_u32(), 0x1000);
+    }
+
+    #[test]
+    fn test_route_upward_no_parent() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Platform);
+        let topology = MeshTopology::new(HierarchyLevel::Platform, 3, 7);
+
+        let decision = router.route(RouteDirection::Upward, &topology);
+        assert!(!decision.routed);
+        assert_eq!(decision.failure_reason, Some(RouteFailure::NoParent));
+    }
+
+    #[test]
+    fn test_route_downward() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Squad);
+        let topology = create_topology_with_parent();
+
+        let decision = router.route(RouteDirection::Downward, &topology);
+        assert!(decision.routed);
+        assert_eq!(decision.next_hops.len(), 2);
+    }
+
+    #[test]
+    fn test_route_broadcast() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Platform);
+        let topology = create_topology_with_parent();
+
+        let decision = router.route(RouteDirection::Broadcast, &topology);
+        assert!(decision.routed);
+        assert_eq!(decision.next_hops.len(), 3); // Parent + 2 children
+    }
+
+    #[test]
+    fn test_route_targeted_direct() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Platform);
+        let topology = create_topology_with_parent();
+
+        // Target is a child (directly connected)
+        let decision = router.route(RouteDirection::Targeted(0x0001), &topology);
+        assert!(decision.routed);
+        assert_eq!(decision.next_hops.len(), 1);
+        assert_eq!(decision.next_hops[0].as_u32(), 0x0001);
+    }
+
+    #[test]
+    fn test_route_targeted_via_parent() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Platform);
+        let topology = create_topology_with_parent();
+
+        // Target is not directly connected - should route to parent
+        let decision = router.route(RouteDirection::Targeted(0x9999), &topology);
+        assert!(decision.routed);
+        assert_eq!(decision.next_hops.len(), 1);
+        assert_eq!(decision.next_hops[0].as_u32(), 0x1000); // Parent
+    }
+
+    #[test]
+    fn test_handle_received_for_us() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Platform);
+        let topology = create_topology_with_parent();
+
+        let decision = router.handle_received(
+            &NodeId::new(0x1000),
+            Some(&NodeId::new(0x1234)), // Destination is us
+            RouteDirection::Downward,
+            &topology,
+        );
+
+        assert!(decision.local_copy);
+        assert!(decision.next_hops.is_empty());
+    }
+
+    #[test]
+    fn test_hop_tracker() {
+        let mut tracker = HopTracker::new(3);
+
+        assert!(tracker.visit(NodeId::new(0x0001)));
+        assert!(tracker.visit(NodeId::new(0x0002)));
+        assert!(tracker.visit(NodeId::new(0x0003)));
+        assert!(!tracker.visit(NodeId::new(0x0004))); // TTL expired
+
+        assert!(tracker.has_visited(&NodeId::new(0x0001)));
+        assert!(!tracker.has_visited(&NodeId::new(0x0004)));
+    }
+
+    #[test]
+    fn test_hop_tracker_loop_detection() {
+        let mut tracker = HopTracker::new(10);
+
+        assert!(tracker.visit(NodeId::new(0x0001)));
+        assert!(tracker.visit(NodeId::new(0x0002)));
+        assert!(!tracker.visit(NodeId::new(0x0001))); // Loop detected
+    }
+
+    #[test]
+    fn test_aggregation_route() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Platform);
+        let topology = create_topology_with_parent();
+
+        let route = router.aggregation_route(&topology);
+        assert_eq!(route, Some(NodeId::new(0x1000)));
+    }
+
+    #[test]
+    fn test_dissemination_routes() {
+        let router = MeshRouter::new(NodeId::new(0x1234), HierarchyLevel::Squad);
+        let topology = create_topology_with_parent();
+
+        let routes = router.dissemination_routes(&topology);
+        assert_eq!(routes.len(), 2);
+    }
+}

--- a/hive-btle/src/mesh/topology.rs
+++ b/hive-btle/src/mesh/topology.rs
@@ -1,0 +1,592 @@
+//! Mesh topology tracking and events
+//!
+//! Tracks the mesh topology including parent/child/peer relationships
+//! and publishes events when the topology changes.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::{HierarchyLevel, NodeId};
+
+/// State of a connection to a peer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ConnectionState {
+    /// Not connected
+    #[default]
+    Disconnected,
+    /// Connection in progress
+    Connecting,
+    /// Connected and active
+    Connected,
+    /// Disconnecting
+    Disconnecting,
+}
+
+/// Role of a peer in the mesh topology
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerRole {
+    /// Our parent (we are a child of this node)
+    Parent,
+    /// Our child (this node is a child of us)
+    Child,
+    /// Peer at the same level (sibling)
+    Peer,
+}
+
+/// Information about a peer in the mesh
+#[derive(Debug, Clone)]
+pub struct PeerInfo {
+    /// Node ID of the peer
+    pub node_id: NodeId,
+    /// Role in the topology
+    pub role: PeerRole,
+    /// Connection state
+    pub state: ConnectionState,
+    /// Hierarchy level of the peer
+    pub hierarchy_level: HierarchyLevel,
+    /// Last known RSSI
+    pub rssi: Option<i8>,
+    /// Time since connection established
+    pub connected_at: Option<u64>,
+    /// Number of messages received
+    pub messages_received: u32,
+    /// Number of messages sent
+    pub messages_sent: u32,
+    /// Number of connection failures
+    pub failure_count: u8,
+    /// Last seen timestamp (monotonic ms)
+    pub last_seen_ms: u64,
+}
+
+impl PeerInfo {
+    /// Create new peer info
+    pub fn new(node_id: NodeId, role: PeerRole, hierarchy_level: HierarchyLevel) -> Self {
+        Self {
+            node_id,
+            role,
+            state: ConnectionState::Disconnected,
+            hierarchy_level,
+            rssi: None,
+            connected_at: None,
+            messages_received: 0,
+            messages_sent: 0,
+            failure_count: 0,
+            last_seen_ms: 0,
+        }
+    }
+
+    /// Check if this peer is connected
+    pub fn is_connected(&self) -> bool {
+        self.state == ConnectionState::Connected
+    }
+
+    /// Update RSSI value
+    pub fn update_rssi(&mut self, rssi: i8) {
+        self.rssi = Some(rssi);
+    }
+
+    /// Record a connection failure
+    pub fn record_failure(&mut self) {
+        self.failure_count = self.failure_count.saturating_add(1);
+    }
+
+    /// Reset failure count on successful connection
+    pub fn reset_failures(&mut self) {
+        self.failure_count = 0;
+    }
+}
+
+/// Current mesh topology state
+#[derive(Debug, Clone, Default)]
+pub struct MeshTopology {
+    /// Our parent node (if we have one)
+    pub parent: Option<NodeId>,
+    /// Our children nodes
+    pub children: Vec<NodeId>,
+    /// Peer nodes at our level
+    pub peers: Vec<NodeId>,
+    /// Our hierarchy level
+    pub my_level: HierarchyLevel,
+    /// Maximum children we can accept
+    pub max_children: u8,
+    /// Maximum total connections
+    pub max_connections: u8,
+}
+
+impl MeshTopology {
+    /// Create a new mesh topology
+    pub fn new(my_level: HierarchyLevel, max_children: u8, max_connections: u8) -> Self {
+        Self {
+            parent: None,
+            children: Vec::new(),
+            peers: Vec::new(),
+            my_level,
+            max_children,
+            max_connections,
+        }
+    }
+
+    /// Get total number of connections
+    pub fn connection_count(&self) -> usize {
+        let parent_count = if self.parent.is_some() { 1 } else { 0 };
+        parent_count + self.children.len() + self.peers.len()
+    }
+
+    /// Check if we can accept more connections
+    pub fn can_accept_connection(&self) -> bool {
+        self.connection_count() < self.max_connections as usize
+    }
+
+    /// Check if we can accept more children
+    pub fn can_accept_child(&self) -> bool {
+        self.children.len() < self.max_children as usize && self.can_accept_connection()
+    }
+
+    /// Check if we have a parent
+    pub fn has_parent(&self) -> bool {
+        self.parent.is_some()
+    }
+
+    /// Add a parent
+    pub fn set_parent(&mut self, node_id: NodeId) -> bool {
+        if self.parent.is_some() {
+            return false;
+        }
+        if !self.can_accept_connection() {
+            return false;
+        }
+        self.parent = Some(node_id);
+        true
+    }
+
+    /// Remove parent
+    pub fn clear_parent(&mut self) -> Option<NodeId> {
+        self.parent.take()
+    }
+
+    /// Add a child
+    pub fn add_child(&mut self, node_id: NodeId) -> bool {
+        if !self.can_accept_child() {
+            return false;
+        }
+        if self.children.contains(&node_id) {
+            return false;
+        }
+        self.children.push(node_id);
+        true
+    }
+
+    /// Remove a child
+    pub fn remove_child(&mut self, node_id: &NodeId) -> bool {
+        if let Some(pos) = self.children.iter().position(|n| n == node_id) {
+            self.children.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Add a peer
+    pub fn add_peer(&mut self, node_id: NodeId) -> bool {
+        if !self.can_accept_connection() {
+            return false;
+        }
+        if self.peers.contains(&node_id) {
+            return false;
+        }
+        self.peers.push(node_id);
+        true
+    }
+
+    /// Remove a peer
+    pub fn remove_peer(&mut self, node_id: &NodeId) -> bool {
+        if let Some(pos) = self.peers.iter().position(|n| n == node_id) {
+            self.peers.remove(pos);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get all connected node IDs
+    pub fn all_connected(&self) -> Vec<NodeId> {
+        let mut nodes = Vec::with_capacity(self.connection_count());
+        if let Some(ref parent) = self.parent {
+            nodes.push(parent.clone());
+        }
+        nodes.extend(self.children.iter().cloned());
+        nodes.extend(self.peers.iter().cloned());
+        nodes
+    }
+
+    /// Check if a node is connected in any role
+    pub fn is_connected(&self, node_id: &NodeId) -> bool {
+        self.parent.as_ref() == Some(node_id)
+            || self.children.contains(node_id)
+            || self.peers.contains(node_id)
+    }
+
+    /// Get the role of a connected node
+    pub fn get_role(&self, node_id: &NodeId) -> Option<PeerRole> {
+        if self.parent.as_ref() == Some(node_id) {
+            Some(PeerRole::Parent)
+        } else if self.children.contains(node_id) {
+            Some(PeerRole::Child)
+        } else if self.peers.contains(node_id) {
+            Some(PeerRole::Peer)
+        } else {
+            None
+        }
+    }
+}
+
+/// Events that occur when the mesh topology changes
+#[derive(Debug, Clone)]
+pub enum TopologyEvent {
+    /// Connected to a parent node
+    ParentConnected {
+        /// The parent's node ID
+        node_id: NodeId,
+        /// Parent's hierarchy level
+        level: HierarchyLevel,
+        /// Signal strength
+        rssi: Option<i8>,
+    },
+    /// Disconnected from parent
+    ParentDisconnected {
+        /// The parent's node ID
+        node_id: NodeId,
+        /// Reason for disconnect
+        reason: DisconnectReason,
+    },
+    /// A child connected to us
+    ChildConnected {
+        /// The child's node ID
+        node_id: NodeId,
+        /// Child's hierarchy level
+        level: HierarchyLevel,
+    },
+    /// A child disconnected
+    ChildDisconnected {
+        /// The child's node ID
+        node_id: NodeId,
+        /// Reason for disconnect
+        reason: DisconnectReason,
+    },
+    /// A peer connected
+    PeerConnected {
+        /// The peer's node ID
+        node_id: NodeId,
+    },
+    /// A peer disconnected
+    PeerDisconnected {
+        /// The peer's node ID
+        node_id: NodeId,
+        /// Reason for disconnect
+        reason: DisconnectReason,
+    },
+    /// Topology changed (general notification)
+    TopologyChanged {
+        /// Number of children
+        child_count: usize,
+        /// Number of peers
+        peer_count: usize,
+        /// Have parent
+        has_parent: bool,
+    },
+    /// Parent failover started
+    ParentFailoverStarted {
+        /// Previous parent
+        old_parent: NodeId,
+    },
+    /// Parent failover completed
+    ParentFailoverCompleted {
+        /// Previous parent
+        old_parent: NodeId,
+        /// New parent (if found)
+        new_parent: Option<NodeId>,
+    },
+    /// Connection quality changed
+    ConnectionQualityChanged {
+        /// Node ID
+        node_id: NodeId,
+        /// New RSSI
+        rssi: i8,
+    },
+}
+
+/// Reason for a disconnection
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DisconnectReason {
+    /// Normal disconnect requested
+    Requested,
+    /// Connection timed out
+    Timeout,
+    /// Remote device disconnected
+    RemoteDisconnect,
+    /// Connection supervision timeout
+    SupervisionTimeout,
+    /// Link loss
+    LinkLoss,
+    /// Local device error
+    LocalError,
+    /// Unknown reason
+    #[default]
+    Unknown,
+}
+
+/// Candidate for parent selection
+#[derive(Debug, Clone)]
+pub struct ParentCandidate {
+    /// Node ID
+    pub node_id: NodeId,
+    /// Hierarchy level
+    pub level: HierarchyLevel,
+    /// Signal strength
+    pub rssi: i8,
+    /// Time since last beacon (ms)
+    pub age_ms: u64,
+    /// Previous failure count
+    pub failure_count: u8,
+}
+
+impl ParentCandidate {
+    /// Calculate a score for this candidate (higher = better)
+    ///
+    /// Factors:
+    /// - RSSI (signal strength) - primary factor
+    /// - Age (freshness of beacon)
+    /// - Failure history
+    /// - Hierarchy level preference
+    pub fn score(&self, my_level: HierarchyLevel) -> i32 {
+        let mut score = 0i32;
+
+        // RSSI contributes -100 to 0 (typical range is -100 to -30 dBm)
+        // Scale to give strong signals a big boost
+        score += (self.rssi as i32 + 100) * 2; // 0-140 range
+
+        // Prefer fresh beacons (within last 5 seconds)
+        if self.age_ms < 1000 {
+            score += 20;
+        } else if self.age_ms < 3000 {
+            score += 10;
+        } else if self.age_ms < 5000 {
+            score += 5;
+        }
+        // Old beacons get no bonus
+
+        // Penalize previous failures
+        score -= (self.failure_count as i32) * 15;
+
+        // Prefer parents at the level above us
+        let ideal_level = match my_level {
+            HierarchyLevel::Platform => HierarchyLevel::Squad,
+            HierarchyLevel::Squad => HierarchyLevel::Platoon,
+            HierarchyLevel::Platoon => HierarchyLevel::Company,
+            HierarchyLevel::Company => HierarchyLevel::Company, // Company has no parent
+        };
+
+        if self.level == ideal_level {
+            score += 30;
+        } else if self.level > my_level {
+            score += 15;
+        }
+        // Same level or lower gets no hierarchy bonus
+
+        score
+    }
+}
+
+/// Configuration for topology management
+#[derive(Debug, Clone)]
+pub struct TopologyConfig {
+    /// Maximum children to accept
+    pub max_children: u8,
+    /// Maximum total connections
+    pub max_connections: u8,
+    /// Minimum RSSI to consider for parent (-100 to 0 dBm)
+    pub min_parent_rssi: i8,
+    /// Maximum beacon age to consider (ms)
+    pub max_beacon_age_ms: u64,
+    /// Parent supervision timeout (ms)
+    pub parent_timeout_ms: u64,
+    /// Connection attempt timeout (ms)
+    pub connect_timeout_ms: u64,
+    /// Maximum connection failures before blacklisting
+    pub max_failures: u8,
+    /// Failover delay after parent loss (ms)
+    pub failover_delay_ms: u64,
+    /// RSSI hysteresis for switching parents (dB)
+    pub rssi_hysteresis: u8,
+}
+
+impl Default for TopologyConfig {
+    fn default() -> Self {
+        Self {
+            max_children: 3,
+            max_connections: 7,
+            min_parent_rssi: -85,
+            max_beacon_age_ms: 10_000,
+            parent_timeout_ms: 5_000,
+            connect_timeout_ms: 10_000,
+            max_failures: 3,
+            failover_delay_ms: 1_000,
+            rssi_hysteresis: 6,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mesh_topology_new() {
+        let topology = MeshTopology::new(HierarchyLevel::Squad, 3, 7);
+        assert_eq!(topology.my_level, HierarchyLevel::Squad);
+        assert_eq!(topology.max_children, 3);
+        assert_eq!(topology.max_connections, 7);
+        assert!(topology.parent.is_none());
+        assert!(topology.children.is_empty());
+    }
+
+    #[test]
+    fn test_set_parent() {
+        let mut topology = MeshTopology::new(HierarchyLevel::Platform, 3, 7);
+        let parent_id = NodeId::new(0x1234);
+
+        assert!(topology.set_parent(parent_id.clone()));
+        assert_eq!(topology.parent, Some(parent_id.clone()));
+        assert_eq!(topology.connection_count(), 1);
+
+        // Can't set another parent
+        assert!(!topology.set_parent(NodeId::new(0x5678)));
+    }
+
+    #[test]
+    fn test_add_children() {
+        let mut topology = MeshTopology::new(HierarchyLevel::Squad, 2, 7);
+
+        assert!(topology.add_child(NodeId::new(0x1111)));
+        assert!(topology.add_child(NodeId::new(0x2222)));
+        // Max children reached
+        assert!(!topology.add_child(NodeId::new(0x3333)));
+
+        assert_eq!(topology.children.len(), 2);
+    }
+
+    #[test]
+    fn test_connection_limit() {
+        let mut topology = MeshTopology::new(HierarchyLevel::Squad, 5, 3);
+
+        assert!(topology.set_parent(NodeId::new(0x0001)));
+        assert!(topology.add_child(NodeId::new(0x0002)));
+        assert!(topology.add_peer(NodeId::new(0x0003)));
+        // Max connections reached
+        assert!(!topology.add_child(NodeId::new(0x0004)));
+        assert!(!topology.add_peer(NodeId::new(0x0005)));
+
+        assert_eq!(topology.connection_count(), 3);
+    }
+
+    #[test]
+    fn test_remove_child() {
+        let mut topology = MeshTopology::new(HierarchyLevel::Squad, 3, 7);
+        let child_id = NodeId::new(0x1111);
+
+        topology.add_child(child_id.clone());
+        assert!(topology.remove_child(&child_id));
+        assert!(!topology.remove_child(&child_id)); // Already removed
+        assert!(topology.children.is_empty());
+    }
+
+    #[test]
+    fn test_get_role() {
+        let mut topology = MeshTopology::new(HierarchyLevel::Squad, 3, 7);
+        let parent_id = NodeId::new(0x0001);
+        let child_id = NodeId::new(0x0002);
+        let peer_id = NodeId::new(0x0003);
+        let unknown_id = NodeId::new(0x9999);
+
+        topology.set_parent(parent_id.clone());
+        topology.add_child(child_id.clone());
+        topology.add_peer(peer_id.clone());
+
+        assert_eq!(topology.get_role(&parent_id), Some(PeerRole::Parent));
+        assert_eq!(topology.get_role(&child_id), Some(PeerRole::Child));
+        assert_eq!(topology.get_role(&peer_id), Some(PeerRole::Peer));
+        assert_eq!(topology.get_role(&unknown_id), None);
+    }
+
+    #[test]
+    fn test_all_connected() {
+        let mut topology = MeshTopology::new(HierarchyLevel::Squad, 3, 7);
+        topology.set_parent(NodeId::new(0x0001));
+        topology.add_child(NodeId::new(0x0002));
+        topology.add_peer(NodeId::new(0x0003));
+
+        let all = topology.all_connected();
+        assert_eq!(all.len(), 3);
+    }
+
+    #[test]
+    fn test_parent_candidate_score() {
+        let candidate = ParentCandidate {
+            node_id: NodeId::new(0x1234),
+            level: HierarchyLevel::Squad,
+            rssi: -50,
+            age_ms: 500,
+            failure_count: 0,
+        };
+
+        // Platform looking for Squad parent
+        let score = candidate.score(HierarchyLevel::Platform);
+        // RSSI: (-50 + 100) * 2 = 100
+        // Age: +20 (< 1000ms)
+        // Failures: 0
+        // Hierarchy: +30 (ideal level)
+        assert_eq!(score, 150);
+    }
+
+    #[test]
+    fn test_parent_candidate_score_with_failures() {
+        let candidate = ParentCandidate {
+            node_id: NodeId::new(0x1234),
+            level: HierarchyLevel::Squad,
+            rssi: -50,
+            age_ms: 500,
+            failure_count: 2,
+        };
+
+        let score = candidate.score(HierarchyLevel::Platform);
+        // Base: 150 - (2 * 15) = 120
+        assert_eq!(score, 120);
+    }
+
+    #[test]
+    fn test_peer_info() {
+        let mut peer = PeerInfo::new(
+            NodeId::new(0x1234),
+            PeerRole::Child,
+            HierarchyLevel::Platform,
+        );
+
+        assert!(!peer.is_connected());
+        assert_eq!(peer.failure_count, 0);
+
+        peer.record_failure();
+        peer.record_failure();
+        assert_eq!(peer.failure_count, 2);
+
+        peer.reset_failures();
+        assert_eq!(peer.failure_count, 0);
+    }
+
+    #[test]
+    fn test_topology_config_default() {
+        let config = TopologyConfig::default();
+        assert_eq!(config.max_children, 3);
+        assert_eq!(config.max_connections, 7);
+        assert_eq!(config.min_parent_rssi, -85);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 2 of HIVE-BTLE: Mesh Topology Management for parent/child/peer relationships in the BLE mesh.

### Topology Module (`topology.rs`)
- `MeshTopology`: Tracks parent/child/peer relationships with connection limits
- `TopologyEvent`: Events for topology changes (ParentConnected, ChildConnected, etc.)
- `PeerInfo`: Metadata for connected peers (RSSI, message counts, failure tracking)
- `ParentCandidate`: RSSI-based parent selection scoring with hierarchy awareness
- `TopologyConfig`: Configurable limits and thresholds

### Manager Module (`manager.rs`)
- `MeshManager`: Main coordinator for mesh operations
- Parent connection/disconnection with event callbacks
- Child connection acceptance with configurable limits
- Parent failover state machine (Running → Failover → Running)
- Beacon processing for candidate discovery
- RSSI-based best parent selection

### Routing Module (`routing.rs`)
- `MeshRouter`: Message routing decisions
- `RouteDirection`: Upward/Downward/Broadcast/Targeted
- `HopTracker`: TTL and loop prevention
- Aggregation/dissemination route helpers for HIVE-Lite

### Key Features
- Max 7 connections (configurable)
- Max 3 children per node (configurable)
- RSSI threshold filtering (-85 dBm default)
- Beacon age filtering (10s default)
- Failure count tracking with blacklisting
- RSSI hysteresis for parent switching (6 dB)

## Test Plan

- [x] 34 new unit tests (94 total for crate)
- [x] Topology state management tests
- [x] Parent/child connection flow tests
- [x] Failover scenario tests
- [x] Routing decision tests
- [x] Hop tracking tests
- [x] All clippy warnings resolved

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)