### PR TITLE
feat(hive-btle): Implement HIVE-Lite sync protocol (#407)

### DIFF
--- a/hive-btle/src/lib.rs
+++ b/hive-btle/src/lib.rs
@@ -98,6 +98,7 @@ pub mod error;
 pub mod gatt;
 pub mod mesh;
 pub mod platform;
+pub mod sync;
 pub mod transport;
 
 // Re-exports for convenience
@@ -107,6 +108,7 @@ pub use error::{BleError, Result};
 pub use gatt::{HiveGattService, SyncProtocol};
 pub use mesh::{MeshManager, MeshRouter, MeshTopology, TopologyConfig, TopologyEvent};
 pub use platform::{BleAdapter, ConnectionEvent, DisconnectReason, DiscoveredDevice, StubAdapter};
+pub use sync::{GattSyncProtocol, SyncConfig, SyncState};
 pub use transport::{BleConnection, BluetoothLETransport, MeshTransport, TransportCapabilities};
 
 /// HIVE BLE Service UUID (128-bit)

--- a/hive-btle/src/sync/batch.rs
+++ b/hive-btle/src/sync/batch.rs
@@ -1,0 +1,429 @@
+//! Batch Accumulator for HIVE-Lite Sync
+//!
+//! Collects CRDT operations over a configurable time window or size limit,
+//! then emits them as a batch for efficient BLE transmission.
+//!
+//! This reduces radio activity and power consumption on constrained devices.
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use super::crdt::CrdtOperation;
+
+/// Configuration for batch accumulation
+#[derive(Debug, Clone)]
+pub struct BatchConfig {
+    /// Maximum time to wait before sending (milliseconds)
+    pub max_wait_ms: u64,
+    /// Maximum bytes to accumulate before sending
+    pub max_bytes: usize,
+    /// Maximum number of operations to accumulate
+    pub max_operations: usize,
+    /// Minimum time between syncs (milliseconds)
+    pub min_interval_ms: u64,
+}
+
+impl Default for BatchConfig {
+    fn default() -> Self {
+        Self {
+            max_wait_ms: 5000,     // 5 seconds
+            max_bytes: 512,        // Half a typical MTU-extended packet
+            max_operations: 20,    // Reasonable batch size
+            min_interval_ms: 1000, // At most 1 sync/second
+        }
+    }
+}
+
+impl BatchConfig {
+    /// Create a config optimized for power efficiency
+    pub fn low_power() -> Self {
+        Self {
+            max_wait_ms: 30_000, // 30 seconds
+            max_bytes: 1024,
+            max_operations: 50,
+            min_interval_ms: 10_000, // At most 1 sync every 10 seconds
+        }
+    }
+
+    /// Create a config for more responsive sync
+    pub fn responsive() -> Self {
+        Self {
+            max_wait_ms: 1000, // 1 second
+            max_bytes: 256,
+            max_operations: 10,
+            min_interval_ms: 500,
+        }
+    }
+}
+
+/// Batch of operations ready to send
+#[derive(Debug, Clone)]
+pub struct OperationBatch {
+    /// Operations in this batch
+    pub operations: Vec<CrdtOperation>,
+    /// Total size in bytes
+    pub total_bytes: usize,
+    /// Timestamp when batch was created
+    pub created_at: u64,
+}
+
+impl OperationBatch {
+    /// Check if batch is empty
+    pub fn is_empty(&self) -> bool {
+        self.operations.is_empty()
+    }
+
+    /// Get number of operations
+    pub fn len(&self) -> usize {
+        self.operations.len()
+    }
+
+    /// Encode all operations to bytes
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.total_bytes + 4);
+        // Operation count
+        buf.extend_from_slice(&(self.operations.len() as u16).to_le_bytes());
+        // Encode each operation
+        for op in &self.operations {
+            let encoded = op.encode();
+            buf.extend_from_slice(&(encoded.len() as u16).to_le_bytes());
+            buf.extend_from_slice(&encoded);
+        }
+        buf
+    }
+
+    /// Decode operations from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.len() < 2 {
+            return None;
+        }
+
+        let op_count = u16::from_le_bytes([data[0], data[1]]) as usize;
+        let mut operations = Vec::with_capacity(op_count);
+        let mut offset = 2;
+        let mut total_bytes = 0;
+
+        for _ in 0..op_count {
+            if offset + 2 > data.len() {
+                return None;
+            }
+            let op_len = u16::from_le_bytes([data[offset], data[offset + 1]]) as usize;
+            offset += 2;
+
+            if offset + op_len > data.len() {
+                return None;
+            }
+            let op = CrdtOperation::decode(&data[offset..offset + op_len])?;
+            total_bytes += op.size();
+            operations.push(op);
+            offset += op_len;
+        }
+
+        Some(Self {
+            operations,
+            total_bytes,
+            created_at: 0,
+        })
+    }
+}
+
+/// Accumulates CRDT operations for batched transmission
+#[derive(Debug)]
+pub struct BatchAccumulator {
+    /// Configuration
+    config: BatchConfig,
+    /// Pending operations
+    pending: Vec<CrdtOperation>,
+    /// Accumulated bytes
+    bytes_accumulated: usize,
+    /// Time of first pending operation
+    first_pending_time: Option<u64>,
+    /// Time of last sync
+    last_sync_time: u64,
+}
+
+impl BatchAccumulator {
+    /// Create a new accumulator with the given config
+    pub fn new(config: BatchConfig) -> Self {
+        Self {
+            config,
+            pending: Vec::new(),
+            bytes_accumulated: 0,
+            first_pending_time: None,
+            last_sync_time: 0,
+        }
+    }
+
+    /// Create with default config
+    pub fn with_defaults() -> Self {
+        Self::new(BatchConfig::default())
+    }
+
+    /// Add an operation to the batch
+    ///
+    /// Returns true if the operation was added, false if batch is full
+    pub fn add(&mut self, op: CrdtOperation, current_time_ms: u64) -> bool {
+        let op_size = op.size();
+
+        // Check if we have room
+        if self.bytes_accumulated + op_size > self.config.max_bytes && !self.pending.is_empty() {
+            return false;
+        }
+        if self.pending.len() >= self.config.max_operations {
+            return false;
+        }
+
+        // Record first pending time
+        if self.first_pending_time.is_none() {
+            self.first_pending_time = Some(current_time_ms);
+        }
+
+        self.pending.push(op);
+        self.bytes_accumulated += op_size;
+        true
+    }
+
+    /// Check if the batch should be flushed
+    pub fn should_flush(&self, current_time_ms: u64) -> bool {
+        if self.pending.is_empty() {
+            return false;
+        }
+
+        // Check if minimum interval has passed
+        if current_time_ms < self.last_sync_time + self.config.min_interval_ms {
+            return false;
+        }
+
+        // Check size limits
+        if self.bytes_accumulated >= self.config.max_bytes {
+            return true;
+        }
+        if self.pending.len() >= self.config.max_operations {
+            return true;
+        }
+
+        // Check time limit
+        if let Some(first_time) = self.first_pending_time {
+            if current_time_ms >= first_time + self.config.max_wait_ms {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Flush pending operations into a batch
+    pub fn flush(&mut self, current_time_ms: u64) -> Option<OperationBatch> {
+        if self.pending.is_empty() {
+            return None;
+        }
+
+        let batch = OperationBatch {
+            operations: core::mem::take(&mut self.pending),
+            total_bytes: self.bytes_accumulated,
+            created_at: current_time_ms,
+        };
+
+        self.bytes_accumulated = 0;
+        self.first_pending_time = None;
+        self.last_sync_time = current_time_ms;
+
+        Some(batch)
+    }
+
+    /// Force flush regardless of timing constraints
+    pub fn force_flush(&mut self, current_time_ms: u64) -> Option<OperationBatch> {
+        self.flush(current_time_ms)
+    }
+
+    /// Get number of pending operations
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
+    /// Get accumulated bytes
+    pub fn accumulated_bytes(&self) -> usize {
+        self.bytes_accumulated
+    }
+
+    /// Check if there are pending operations
+    pub fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    /// Clear all pending operations without flushing
+    pub fn clear(&mut self) {
+        self.pending.clear();
+        self.bytes_accumulated = 0;
+        self.first_pending_time = None;
+    }
+
+    /// Get the config
+    pub fn config(&self) -> &BatchConfig {
+        &self.config
+    }
+
+    /// Update the config
+    pub fn set_config(&mut self, config: BatchConfig) {
+        self.config = config;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::crdt::Position;
+    use crate::NodeId;
+
+    fn make_position_op(node_id: u32, timestamp: u64) -> CrdtOperation {
+        CrdtOperation::UpdatePosition {
+            node_id: NodeId::new(node_id),
+            position: Position::new(37.0, -122.0),
+            timestamp,
+        }
+    }
+
+    #[test]
+    fn test_batch_config_defaults() {
+        let config = BatchConfig::default();
+        assert_eq!(config.max_wait_ms, 5000);
+        assert_eq!(config.max_bytes, 512);
+    }
+
+    #[test]
+    fn test_accumulator_add() {
+        let mut acc = BatchAccumulator::with_defaults();
+
+        let op = make_position_op(1, 1000);
+        assert!(acc.add(op, 1000));
+        assert_eq!(acc.pending_count(), 1);
+        assert!(acc.has_pending());
+    }
+
+    #[test]
+    fn test_accumulator_max_operations() {
+        let config = BatchConfig {
+            max_operations: 2,
+            ..Default::default()
+        };
+        let mut acc = BatchAccumulator::new(config);
+
+        assert!(acc.add(make_position_op(1, 1000), 1000));
+        assert!(acc.add(make_position_op(2, 1001), 1001));
+        assert!(!acc.add(make_position_op(3, 1002), 1002)); // Should fail
+        assert_eq!(acc.pending_count(), 2);
+    }
+
+    #[test]
+    fn test_accumulator_flush() {
+        let mut acc = BatchAccumulator::with_defaults();
+
+        acc.add(make_position_op(1, 1000), 1000);
+        acc.add(make_position_op(2, 1001), 1001);
+
+        let batch = acc.flush(2000).unwrap();
+        assert_eq!(batch.len(), 2);
+        assert!(!acc.has_pending());
+    }
+
+    #[test]
+    fn test_should_flush_time() {
+        let config = BatchConfig {
+            max_wait_ms: 100,
+            min_interval_ms: 0,
+            ..Default::default()
+        };
+        let mut acc = BatchAccumulator::new(config);
+
+        acc.add(make_position_op(1, 1000), 1000);
+
+        // Not enough time passed
+        assert!(!acc.should_flush(1050));
+
+        // Time limit reached
+        assert!(acc.should_flush(1100));
+    }
+
+    #[test]
+    fn test_should_flush_size() {
+        let config = BatchConfig {
+            max_bytes: 20, // Small limit (each position op is ~21 bytes)
+            min_interval_ms: 0,
+            ..Default::default()
+        };
+        let mut acc = BatchAccumulator::new(config);
+
+        // First op (21 bytes) exceeds max_bytes (20), but allowed since batch is empty
+        assert!(acc.add(make_position_op(1, 1000), 1000));
+        // Should flush because we've exceeded max_bytes
+        assert!(acc.should_flush(1000));
+    }
+
+    #[test]
+    fn test_min_interval() {
+        let config = BatchConfig {
+            max_wait_ms: 100,
+            min_interval_ms: 1000,
+            ..Default::default()
+        };
+        let mut acc = BatchAccumulator::new(config);
+
+        acc.add(make_position_op(1, 0), 0);
+        acc.flush(0);
+
+        acc.add(make_position_op(2, 100), 100);
+
+        // Min interval not passed
+        assert!(!acc.should_flush(500));
+
+        // Min interval passed
+        assert!(acc.should_flush(1100));
+    }
+
+    #[test]
+    fn test_batch_encode_decode() {
+        let batch = OperationBatch {
+            operations: vec![make_position_op(1, 1000), make_position_op(2, 2000)],
+            total_bytes: 100,
+            created_at: 3000,
+        };
+
+        let encoded = batch.encode();
+        let decoded = OperationBatch::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.len(), 2);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut acc = BatchAccumulator::with_defaults();
+
+        acc.add(make_position_op(1, 1000), 1000);
+        acc.add(make_position_op(2, 1001), 1001);
+
+        acc.clear();
+        assert!(!acc.has_pending());
+        assert_eq!(acc.accumulated_bytes(), 0);
+    }
+
+    #[test]
+    fn test_force_flush() {
+        let config = BatchConfig {
+            min_interval_ms: 10000, // Long interval
+            ..Default::default()
+        };
+        let mut acc = BatchAccumulator::new(config);
+
+        acc.add(make_position_op(1, 0), 0);
+        acc.flush(0);
+
+        acc.add(make_position_op(2, 100), 100);
+
+        // Normal flush blocked by min_interval
+        assert!(!acc.should_flush(100));
+
+        // Force flush works anyway
+        let batch = acc.force_flush(100);
+        assert!(batch.is_some());
+    }
+}

--- a/hive-btle/src/sync/crdt.rs
+++ b/hive-btle/src/sync/crdt.rs
@@ -1,0 +1,785 @@
+//! CRDT (Conflict-free Replicated Data Types) for HIVE-Lite
+//!
+//! Provides lightweight CRDT implementations optimized for BLE sync:
+//! - LWW-Register: Last-Writer-Wins for single values
+//! - G-Counter: Grow-only counter for metrics
+//!
+//! These are designed for minimal memory footprint and efficient
+//! serialization over constrained BLE connections.
+
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
+
+use crate::NodeId;
+
+/// Timestamp for CRDT operations (milliseconds since epoch or monotonic)
+pub type Timestamp = u64;
+
+/// A Last-Writer-Wins Register
+///
+/// Stores a single value where concurrent writes are resolved by timestamp.
+/// Higher timestamp wins. In case of tie, higher node ID wins.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LwwRegister<T: Clone> {
+    /// Current value
+    value: T,
+    /// Timestamp when value was set
+    timestamp: Timestamp,
+    /// Node that set the value
+    node_id: NodeId,
+}
+
+impl<T: Clone + Default> Default for LwwRegister<T> {
+    fn default() -> Self {
+        Self {
+            value: T::default(),
+            timestamp: 0,
+            node_id: NodeId::default(),
+        }
+    }
+}
+
+impl<T: Clone> LwwRegister<T> {
+    /// Create a new register with an initial value
+    pub fn new(value: T, timestamp: Timestamp, node_id: NodeId) -> Self {
+        Self {
+            value,
+            timestamp,
+            node_id,
+        }
+    }
+
+    /// Get the current value
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+
+    /// Get the timestamp
+    pub fn timestamp(&self) -> Timestamp {
+        self.timestamp
+    }
+
+    /// Get the node that set the value
+    pub fn node_id(&self) -> &NodeId {
+        &self.node_id
+    }
+
+    /// Set a new value if it has a higher timestamp
+    ///
+    /// Returns true if the value was updated
+    pub fn set(&mut self, value: T, timestamp: Timestamp, node_id: NodeId) -> bool {
+        if self.should_update(timestamp, &node_id) {
+            self.value = value;
+            self.timestamp = timestamp;
+            self.node_id = node_id;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Merge with another register (LWW semantics)
+    ///
+    /// Returns true if our value was updated
+    pub fn merge(&mut self, other: &LwwRegister<T>) -> bool {
+        if self.should_update(other.timestamp, &other.node_id) {
+            self.value = other.value.clone();
+            self.timestamp = other.timestamp;
+            self.node_id = other.node_id.clone();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Check if we should update based on timestamp/node_id
+    fn should_update(&self, timestamp: Timestamp, node_id: &NodeId) -> bool {
+        timestamp > self.timestamp
+            || (timestamp == self.timestamp && node_id.as_u32() > self.node_id.as_u32())
+    }
+}
+
+/// A Grow-only Counter (G-Counter)
+///
+/// Each node maintains its own count, total is the sum of all counts.
+/// Only supports increment operations.
+#[derive(Debug, Clone, Default)]
+pub struct GCounter {
+    /// Per-node counts
+    counts: BTreeMap<u32, u64>,
+}
+
+impl GCounter {
+    /// Create a new empty counter
+    pub fn new() -> Self {
+        Self {
+            counts: BTreeMap::new(),
+        }
+    }
+
+    /// Get the total count
+    pub fn value(&self) -> u64 {
+        self.counts.values().sum()
+    }
+
+    /// Increment the counter for a node
+    pub fn increment(&mut self, node_id: &NodeId, amount: u64) {
+        let count = self.counts.entry(node_id.as_u32()).or_insert(0);
+        *count = count.saturating_add(amount);
+    }
+
+    /// Get the count for a specific node
+    pub fn node_count(&self, node_id: &NodeId) -> u64 {
+        self.counts.get(&node_id.as_u32()).copied().unwrap_or(0)
+    }
+
+    /// Merge with another counter
+    ///
+    /// Takes the max of each node's count
+    pub fn merge(&mut self, other: &GCounter) {
+        for (&node_id, &count) in &other.counts {
+            let our_count = self.counts.entry(node_id).or_insert(0);
+            *our_count = (*our_count).max(count);
+        }
+    }
+
+    /// Get the number of nodes that have contributed
+    pub fn node_count_total(&self) -> usize {
+        self.counts.len()
+    }
+
+    /// Encode to bytes for transmission
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(4 + self.counts.len() * 12);
+        // Number of entries
+        buf.extend_from_slice(&(self.counts.len() as u32).to_le_bytes());
+        // Each entry: node_id (4 bytes) + count (8 bytes)
+        for (&node_id, &count) in &self.counts {
+            buf.extend_from_slice(&node_id.to_le_bytes());
+            buf.extend_from_slice(&count.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Decode from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.len() < 4 {
+            return None;
+        }
+        let num_entries = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
+        if data.len() < 4 + num_entries * 12 {
+            return None;
+        }
+
+        let mut counts = BTreeMap::new();
+        let mut offset = 4;
+        for _ in 0..num_entries {
+            let node_id = u32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]);
+            let count = u64::from_le_bytes([
+                data[offset + 4],
+                data[offset + 5],
+                data[offset + 6],
+                data[offset + 7],
+                data[offset + 8],
+                data[offset + 9],
+                data[offset + 10],
+                data[offset + 11],
+            ]);
+            counts.insert(node_id, count);
+            offset += 12;
+        }
+
+        Some(Self { counts })
+    }
+}
+
+/// Position data with LWW semantics
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Position {
+    /// Latitude in degrees
+    pub latitude: f32,
+    /// Longitude in degrees
+    pub longitude: f32,
+    /// Altitude in meters (optional)
+    pub altitude: Option<f32>,
+    /// Accuracy in meters (optional)
+    pub accuracy: Option<f32>,
+}
+
+impl Position {
+    /// Create a new position
+    pub fn new(latitude: f32, longitude: f32) -> Self {
+        Self {
+            latitude,
+            longitude,
+            altitude: None,
+            accuracy: None,
+        }
+    }
+
+    /// Create with altitude
+    pub fn with_altitude(mut self, altitude: f32) -> Self {
+        self.altitude = Some(altitude);
+        self
+    }
+
+    /// Create with accuracy
+    pub fn with_accuracy(mut self, accuracy: f32) -> Self {
+        self.accuracy = Some(accuracy);
+        self
+    }
+
+    /// Encode to bytes (12-20 bytes)
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(20);
+        buf.extend_from_slice(&self.latitude.to_le_bytes());
+        buf.extend_from_slice(&self.longitude.to_le_bytes());
+
+        // Flags byte: bit 0 = has altitude, bit 1 = has accuracy
+        let mut flags = 0u8;
+        if self.altitude.is_some() {
+            flags |= 0x01;
+        }
+        if self.accuracy.is_some() {
+            flags |= 0x02;
+        }
+        buf.push(flags);
+
+        if let Some(alt) = self.altitude {
+            buf.extend_from_slice(&alt.to_le_bytes());
+        }
+        if let Some(acc) = self.accuracy {
+            buf.extend_from_slice(&acc.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Decode from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.len() < 9 {
+            return None;
+        }
+
+        let latitude = f32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let longitude = f32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+        let flags = data[8];
+
+        let mut pos = Self::new(latitude, longitude);
+        let mut offset = 9;
+
+        if flags & 0x01 != 0 {
+            if data.len() < offset + 4 {
+                return None;
+            }
+            pos.altitude = Some(f32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]));
+            offset += 4;
+        }
+
+        if flags & 0x02 != 0 {
+            if data.len() < offset + 4 {
+                return None;
+            }
+            pos.accuracy = Some(f32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]));
+        }
+
+        Some(pos)
+    }
+}
+
+/// Health status data with LWW semantics
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct HealthStatus {
+    /// Battery percentage (0-100)
+    pub battery_percent: u8,
+    /// Heart rate BPM (optional)
+    pub heart_rate: Option<u8>,
+    /// Activity level (0=still, 1=walking, 2=running, 3=vehicle)
+    pub activity: u8,
+    /// Alert status flags
+    pub alerts: u8,
+}
+
+impl HealthStatus {
+    /// Alert flag: Man down
+    pub const ALERT_MAN_DOWN: u8 = 0x01;
+    /// Alert flag: Low battery
+    pub const ALERT_LOW_BATTERY: u8 = 0x02;
+    /// Alert flag: Out of range
+    pub const ALERT_OUT_OF_RANGE: u8 = 0x04;
+    /// Alert flag: Custom alert 1
+    pub const ALERT_CUSTOM_1: u8 = 0x08;
+
+    /// Create a new health status
+    pub fn new(battery_percent: u8) -> Self {
+        Self {
+            battery_percent,
+            heart_rate: None,
+            activity: 0,
+            alerts: 0,
+        }
+    }
+
+    /// Set heart rate
+    pub fn with_heart_rate(mut self, hr: u8) -> Self {
+        self.heart_rate = Some(hr);
+        self
+    }
+
+    /// Set activity level
+    pub fn with_activity(mut self, activity: u8) -> Self {
+        self.activity = activity;
+        self
+    }
+
+    /// Set alert flag
+    pub fn set_alert(&mut self, flag: u8) {
+        self.alerts |= flag;
+    }
+
+    /// Clear alert flag
+    pub fn clear_alert(&mut self, flag: u8) {
+        self.alerts &= !flag;
+    }
+
+    /// Check if alert is set
+    pub fn has_alert(&self, flag: u8) -> bool {
+        self.alerts & flag != 0
+    }
+
+    /// Encode to bytes (3-4 bytes)
+    pub fn encode(&self) -> Vec<u8> {
+        vec![
+            self.battery_percent,
+            self.activity,
+            self.alerts,
+            // Heart rate: 0 means not present, otherwise value
+            self.heart_rate.unwrap_or(0),
+        ]
+    }
+
+    /// Decode from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.len() < 4 {
+            return None;
+        }
+        let mut status = Self::new(data[0]);
+        status.activity = data[1];
+        status.alerts = data[2];
+        if data[3] > 0 {
+            status.heart_rate = Some(data[3]);
+        }
+        Some(status)
+    }
+}
+
+/// CRDT operation types for sync
+#[derive(Debug, Clone)]
+pub enum CrdtOperation {
+    /// Update a position register
+    UpdatePosition {
+        /// Node ID that owns this position
+        node_id: NodeId,
+        /// Position data
+        position: Position,
+        /// Timestamp of the update
+        timestamp: Timestamp,
+    },
+    /// Update health status register
+    UpdateHealth {
+        /// Node ID that owns this status
+        node_id: NodeId,
+        /// Health status data
+        status: HealthStatus,
+        /// Timestamp of the update
+        timestamp: Timestamp,
+    },
+    /// Increment a counter
+    IncrementCounter {
+        /// Counter identifier
+        counter_id: u8,
+        /// Node performing the increment
+        node_id: NodeId,
+        /// Amount to increment
+        amount: u64,
+    },
+    /// Generic LWW update (key-value)
+    UpdateRegister {
+        /// Key for the register
+        key: String,
+        /// Value data
+        value: Vec<u8>,
+        /// Timestamp of the update
+        timestamp: Timestamp,
+        /// Node that set the value
+        node_id: NodeId,
+    },
+}
+
+impl CrdtOperation {
+    /// Get the approximate size in bytes
+    pub fn size(&self) -> usize {
+        match self {
+            CrdtOperation::UpdatePosition { position, .. } => 4 + 8 + position.encode().len(),
+            CrdtOperation::UpdateHealth { status, .. } => 4 + 8 + status.encode().len(),
+            CrdtOperation::IncrementCounter { .. } => 1 + 4 + 8,
+            CrdtOperation::UpdateRegister { key, value, .. } => 4 + 8 + key.len() + value.len(),
+        }
+    }
+
+    /// Encode to bytes
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::new();
+        match self {
+            CrdtOperation::UpdatePosition {
+                node_id,
+                position,
+                timestamp,
+            } => {
+                buf.push(0x01); // Type tag
+                buf.extend_from_slice(&node_id.as_u32().to_le_bytes());
+                buf.extend_from_slice(&timestamp.to_le_bytes());
+                buf.extend_from_slice(&position.encode());
+            }
+            CrdtOperation::UpdateHealth {
+                node_id,
+                status,
+                timestamp,
+            } => {
+                buf.push(0x02); // Type tag
+                buf.extend_from_slice(&node_id.as_u32().to_le_bytes());
+                buf.extend_from_slice(&timestamp.to_le_bytes());
+                buf.extend_from_slice(&status.encode());
+            }
+            CrdtOperation::IncrementCounter {
+                counter_id,
+                node_id,
+                amount,
+            } => {
+                buf.push(0x03); // Type tag
+                buf.push(*counter_id);
+                buf.extend_from_slice(&node_id.as_u32().to_le_bytes());
+                buf.extend_from_slice(&amount.to_le_bytes());
+            }
+            CrdtOperation::UpdateRegister {
+                key,
+                value,
+                timestamp,
+                node_id,
+            } => {
+                buf.push(0x04); // Type tag
+                buf.extend_from_slice(&node_id.as_u32().to_le_bytes());
+                buf.extend_from_slice(&timestamp.to_le_bytes());
+                buf.push(key.len() as u8);
+                buf.extend_from_slice(key.as_bytes());
+                buf.extend_from_slice(&(value.len() as u16).to_le_bytes());
+                buf.extend_from_slice(value);
+            }
+        }
+        buf
+    }
+
+    /// Decode from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.is_empty() {
+            return None;
+        }
+
+        match data[0] {
+            0x01 => {
+                // UpdatePosition
+                if data.len() < 13 {
+                    return None;
+                }
+                let node_id = NodeId::new(u32::from_le_bytes([data[1], data[2], data[3], data[4]]));
+                let timestamp = u64::from_le_bytes([
+                    data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12],
+                ]);
+                let position = Position::decode(&data[13..])?;
+                Some(CrdtOperation::UpdatePosition {
+                    node_id,
+                    position,
+                    timestamp,
+                })
+            }
+            0x02 => {
+                // UpdateHealth
+                if data.len() < 13 {
+                    return None;
+                }
+                let node_id = NodeId::new(u32::from_le_bytes([data[1], data[2], data[3], data[4]]));
+                let timestamp = u64::from_le_bytes([
+                    data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12],
+                ]);
+                let status = HealthStatus::decode(&data[13..])?;
+                Some(CrdtOperation::UpdateHealth {
+                    node_id,
+                    status,
+                    timestamp,
+                })
+            }
+            0x03 => {
+                // IncrementCounter
+                if data.len() < 14 {
+                    return None;
+                }
+                let counter_id = data[1];
+                let node_id = NodeId::new(u32::from_le_bytes([data[2], data[3], data[4], data[5]]));
+                let amount = u64::from_le_bytes([
+                    data[6], data[7], data[8], data[9], data[10], data[11], data[12], data[13],
+                ]);
+                Some(CrdtOperation::IncrementCounter {
+                    counter_id,
+                    node_id,
+                    amount,
+                })
+            }
+            0x04 => {
+                // UpdateRegister
+                if data.len() < 14 {
+                    return None;
+                }
+                let node_id = NodeId::new(u32::from_le_bytes([data[1], data[2], data[3], data[4]]));
+                let timestamp = u64::from_le_bytes([
+                    data[5], data[6], data[7], data[8], data[9], data[10], data[11], data[12],
+                ]);
+                let key_len = data[13] as usize;
+                if data.len() < 14 + key_len + 2 {
+                    return None;
+                }
+                let key = core::str::from_utf8(&data[14..14 + key_len])
+                    .ok()?
+                    .to_string();
+                let value_len =
+                    u16::from_le_bytes([data[14 + key_len], data[15 + key_len]]) as usize;
+                if data.len() < 16 + key_len + value_len {
+                    return None;
+                }
+                let value = data[16 + key_len..16 + key_len + value_len].to_vec();
+                Some(CrdtOperation::UpdateRegister {
+                    key,
+                    value,
+                    timestamp,
+                    node_id,
+                })
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lww_register_basic() {
+        let mut reg = LwwRegister::new(42u32, 100, NodeId::new(1));
+        assert_eq!(*reg.get(), 42);
+        assert_eq!(reg.timestamp(), 100);
+
+        // Higher timestamp wins
+        assert!(reg.set(99, 200, NodeId::new(2)));
+        assert_eq!(*reg.get(), 99);
+
+        // Lower timestamp loses
+        assert!(!reg.set(50, 150, NodeId::new(3)));
+        assert_eq!(*reg.get(), 99);
+    }
+
+    #[test]
+    fn test_lww_register_tiebreak() {
+        let mut reg = LwwRegister::new(1u32, 100, NodeId::new(1));
+
+        // Same timestamp, higher node_id wins
+        assert!(reg.set(2, 100, NodeId::new(2)));
+        assert_eq!(*reg.get(), 2);
+
+        // Same timestamp, lower node_id loses
+        assert!(!reg.set(3, 100, NodeId::new(1)));
+        assert_eq!(*reg.get(), 2);
+    }
+
+    #[test]
+    fn test_lww_register_merge() {
+        let mut reg1 = LwwRegister::new(1u32, 100, NodeId::new(1));
+        let reg2 = LwwRegister::new(2u32, 200, NodeId::new(2));
+
+        assert!(reg1.merge(&reg2));
+        assert_eq!(*reg1.get(), 2);
+    }
+
+    #[test]
+    fn test_gcounter_basic() {
+        let mut counter = GCounter::new();
+        let node1 = NodeId::new(1);
+        let node2 = NodeId::new(2);
+
+        counter.increment(&node1, 5);
+        counter.increment(&node2, 3);
+        counter.increment(&node1, 2);
+
+        assert_eq!(counter.value(), 10);
+        assert_eq!(counter.node_count(&node1), 7);
+        assert_eq!(counter.node_count(&node2), 3);
+    }
+
+    #[test]
+    fn test_gcounter_merge() {
+        let mut counter1 = GCounter::new();
+        let mut counter2 = GCounter::new();
+        let node1 = NodeId::new(1);
+        let node2 = NodeId::new(2);
+
+        counter1.increment(&node1, 5);
+        counter2.increment(&node1, 3);
+        counter2.increment(&node2, 4);
+
+        counter1.merge(&counter2);
+
+        assert_eq!(counter1.value(), 9); // max(5,3) + 4
+        assert_eq!(counter1.node_count(&node1), 5);
+        assert_eq!(counter1.node_count(&node2), 4);
+    }
+
+    #[test]
+    fn test_gcounter_encode_decode() {
+        let mut counter = GCounter::new();
+        counter.increment(&NodeId::new(1), 5);
+        counter.increment(&NodeId::new(2), 10);
+
+        let encoded = counter.encode();
+        let decoded = GCounter::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.value(), counter.value());
+        assert_eq!(decoded.node_count(&NodeId::new(1)), 5);
+        assert_eq!(decoded.node_count(&NodeId::new(2)), 10);
+    }
+
+    #[test]
+    fn test_position_encode_decode() {
+        let pos = Position::new(37.7749, -122.4194)
+            .with_altitude(100.0)
+            .with_accuracy(5.0);
+
+        let encoded = pos.encode();
+        let decoded = Position::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.latitude, pos.latitude);
+        assert_eq!(decoded.longitude, pos.longitude);
+        assert_eq!(decoded.altitude, pos.altitude);
+        assert_eq!(decoded.accuracy, pos.accuracy);
+    }
+
+    #[test]
+    fn test_position_minimal_encode() {
+        let pos = Position::new(0.0, 0.0);
+        let encoded = pos.encode();
+        assert_eq!(encoded.len(), 9); // lat + lon + flags
+
+        let pos_with_alt = Position::new(0.0, 0.0).with_altitude(0.0);
+        let encoded_alt = pos_with_alt.encode();
+        assert_eq!(encoded_alt.len(), 13);
+    }
+
+    #[test]
+    fn test_health_status() {
+        let mut status = HealthStatus::new(85).with_heart_rate(72).with_activity(1);
+
+        assert_eq!(status.battery_percent, 85);
+        assert_eq!(status.heart_rate, Some(72));
+        assert!(!status.has_alert(HealthStatus::ALERT_MAN_DOWN));
+
+        status.set_alert(HealthStatus::ALERT_MAN_DOWN);
+        assert!(status.has_alert(HealthStatus::ALERT_MAN_DOWN));
+
+        let encoded = status.encode();
+        let decoded = HealthStatus::decode(&encoded).unwrap();
+        assert_eq!(decoded.battery_percent, 85);
+        assert_eq!(decoded.heart_rate, Some(72));
+        assert!(decoded.has_alert(HealthStatus::ALERT_MAN_DOWN));
+    }
+
+    #[test]
+    fn test_crdt_operation_position() {
+        let op = CrdtOperation::UpdatePosition {
+            node_id: NodeId::new(0x1234),
+            position: Position::new(37.0, -122.0),
+            timestamp: 1000,
+        };
+
+        let encoded = op.encode();
+        let decoded = CrdtOperation::decode(&encoded).unwrap();
+
+        if let CrdtOperation::UpdatePosition {
+            node_id,
+            position,
+            timestamp,
+        } = decoded
+        {
+            assert_eq!(node_id.as_u32(), 0x1234);
+            assert_eq!(timestamp, 1000);
+            assert_eq!(position.latitude, 37.0);
+        } else {
+            panic!("Wrong operation type");
+        }
+    }
+
+    #[test]
+    fn test_crdt_operation_counter() {
+        let op = CrdtOperation::IncrementCounter {
+            counter_id: 1,
+            node_id: NodeId::new(0x5678),
+            amount: 42,
+        };
+
+        let encoded = op.encode();
+        let decoded = CrdtOperation::decode(&encoded).unwrap();
+
+        if let CrdtOperation::IncrementCounter {
+            counter_id,
+            node_id,
+            amount,
+        } = decoded
+        {
+            assert_eq!(counter_id, 1);
+            assert_eq!(node_id.as_u32(), 0x5678);
+            assert_eq!(amount, 42);
+        } else {
+            panic!("Wrong operation type");
+        }
+    }
+
+    #[test]
+    fn test_crdt_operation_size() {
+        let pos_op = CrdtOperation::UpdatePosition {
+            node_id: NodeId::new(1),
+            position: Position::new(0.0, 0.0),
+            timestamp: 0,
+        };
+        assert!(pos_op.size() > 0);
+
+        let counter_op = CrdtOperation::IncrementCounter {
+            counter_id: 0,
+            node_id: NodeId::new(1),
+            amount: 1,
+        };
+        assert_eq!(counter_op.size(), 13);
+    }
+}

--- a/hive-btle/src/sync/delta.rs
+++ b/hive-btle/src/sync/delta.rs
@@ -1,0 +1,538 @@
+//! Delta Encoder for HIVE-Lite Sync
+//!
+//! Tracks what state has been sent to each peer and only sends
+//! the changes (deltas) since the last sync. This dramatically
+//! reduces bandwidth over BLE.
+
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::collections::HashMap;
+
+use super::crdt::{CrdtOperation, Timestamp};
+use crate::NodeId;
+
+/// Tracks the sync state with a specific peer
+#[derive(Debug, Clone, Default)]
+pub struct PeerSyncState {
+    /// Last timestamp we synced each key
+    #[cfg(feature = "std")]
+    last_sent: HashMap<String, Timestamp>,
+    #[cfg(not(feature = "std"))]
+    last_sent: BTreeMap<String, Timestamp>,
+
+    /// Last timestamp we received from this peer
+    pub last_received_timestamp: Timestamp,
+
+    /// Number of successful syncs
+    pub sync_count: u32,
+
+    /// Bytes sent to this peer
+    pub bytes_sent: u64,
+
+    /// Bytes received from this peer
+    pub bytes_received: u64,
+}
+
+impl PeerSyncState {
+    /// Create new peer sync state
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that we sent a key at a timestamp
+    pub fn mark_sent(&mut self, key: &str, timestamp: Timestamp) {
+        self.last_sent.insert(key.to_string(), timestamp);
+    }
+
+    /// Get the last sent timestamp for a key
+    pub fn last_sent_timestamp(&self, key: &str) -> Option<Timestamp> {
+        self.last_sent.get(key).copied()
+    }
+
+    /// Check if we need to send this key (has newer timestamp)
+    pub fn needs_send(&self, key: &str, timestamp: Timestamp) -> bool {
+        match self.last_sent.get(key) {
+            Some(&last) => timestamp > last,
+            None => true,
+        }
+    }
+
+    /// Clear all tracking (for reconnection)
+    pub fn reset(&mut self) {
+        self.last_sent.clear();
+    }
+}
+
+/// Manages delta encoding for all peers
+#[derive(Debug)]
+pub struct DeltaEncoder {
+    /// Our node ID (for future use in operations)
+    #[allow(dead_code)]
+    node_id: NodeId,
+
+    /// Sync state per peer
+    #[cfg(feature = "std")]
+    peers: HashMap<u32, PeerSyncState>,
+    #[cfg(not(feature = "std"))]
+    peers: BTreeMap<u32, PeerSyncState>,
+
+    /// Current state (key -> (value_hash, timestamp))
+    #[cfg(feature = "std")]
+    current_state: HashMap<String, (u64, Timestamp)>,
+    #[cfg(not(feature = "std"))]
+    current_state: BTreeMap<String, (u64, Timestamp)>,
+}
+
+impl DeltaEncoder {
+    /// Create a new delta encoder
+    pub fn new(node_id: NodeId) -> Self {
+        Self {
+            node_id,
+            #[cfg(feature = "std")]
+            peers: HashMap::new(),
+            #[cfg(not(feature = "std"))]
+            peers: BTreeMap::new(),
+            #[cfg(feature = "std")]
+            current_state: HashMap::new(),
+            #[cfg(not(feature = "std"))]
+            current_state: BTreeMap::new(),
+        }
+    }
+
+    /// Register a peer for delta tracking
+    pub fn add_peer(&mut self, peer_id: &NodeId) {
+        self.peers.entry(peer_id.as_u32()).or_default();
+    }
+
+    /// Remove a peer
+    pub fn remove_peer(&mut self, peer_id: &NodeId) {
+        self.peers.remove(&peer_id.as_u32());
+    }
+
+    /// Get peer sync state
+    pub fn get_peer_state(&self, peer_id: &NodeId) -> Option<&PeerSyncState> {
+        self.peers.get(&peer_id.as_u32())
+    }
+
+    /// Get mutable peer sync state
+    pub fn get_peer_state_mut(&mut self, peer_id: &NodeId) -> Option<&mut PeerSyncState> {
+        self.peers.get_mut(&peer_id.as_u32())
+    }
+
+    /// Update our current state with an operation
+    pub fn update_state(&mut self, key: &str, value_hash: u64, timestamp: Timestamp) {
+        self.current_state
+            .insert(key.to_string(), (value_hash, timestamp));
+    }
+
+    /// Filter operations to only those that need to be sent to a peer
+    pub fn filter_for_peer(
+        &self,
+        peer_id: &NodeId,
+        operations: &[CrdtOperation],
+    ) -> Vec<CrdtOperation> {
+        let peer_state = match self.peers.get(&peer_id.as_u32()) {
+            Some(state) => state,
+            None => return operations.to_vec(), // Unknown peer, send all
+        };
+
+        operations
+            .iter()
+            .filter(|op| {
+                let (key, timestamp) = Self::operation_key_timestamp(op);
+                peer_state.needs_send(&key, timestamp)
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Mark operations as sent to a peer
+    pub fn mark_sent(&mut self, peer_id: &NodeId, operations: &[CrdtOperation]) {
+        let peer_state = match self.peers.get_mut(&peer_id.as_u32()) {
+            Some(state) => state,
+            None => return,
+        };
+
+        for op in operations {
+            let (key, timestamp) = Self::operation_key_timestamp(op);
+            peer_state.mark_sent(&key, timestamp);
+        }
+    }
+
+    /// Record bytes sent to peer
+    pub fn record_sent(&mut self, peer_id: &NodeId, bytes: usize) {
+        if let Some(state) = self.peers.get_mut(&peer_id.as_u32()) {
+            state.bytes_sent += bytes as u64;
+            state.sync_count += 1;
+        }
+    }
+
+    /// Record bytes received from peer
+    pub fn record_received(&mut self, peer_id: &NodeId, bytes: usize, timestamp: Timestamp) {
+        if let Some(state) = self.peers.get_mut(&peer_id.as_u32()) {
+            state.bytes_received += bytes as u64;
+            state.last_received_timestamp = timestamp;
+        }
+    }
+
+    /// Reset sync state for a peer (e.g., on reconnection)
+    pub fn reset_peer(&mut self, peer_id: &NodeId) {
+        if let Some(state) = self.peers.get_mut(&peer_id.as_u32()) {
+            state.reset();
+        }
+    }
+
+    /// Get sync statistics
+    pub fn stats(&self) -> DeltaStats {
+        let mut total_sent = 0u64;
+        let mut total_received = 0u64;
+        let mut total_syncs = 0u32;
+
+        for state in self.peers.values() {
+            total_sent += state.bytes_sent;
+            total_received += state.bytes_received;
+            total_syncs += state.sync_count;
+        }
+
+        DeltaStats {
+            peer_count: self.peers.len(),
+            total_bytes_sent: total_sent,
+            total_bytes_received: total_received,
+            total_syncs,
+            tracked_keys: self.current_state.len(),
+        }
+    }
+
+    /// Extract key and timestamp from an operation
+    fn operation_key_timestamp(op: &CrdtOperation) -> (String, Timestamp) {
+        match op {
+            CrdtOperation::UpdatePosition {
+                node_id, timestamp, ..
+            } => (format!("pos:{}", node_id), *timestamp),
+            CrdtOperation::UpdateHealth {
+                node_id, timestamp, ..
+            } => (format!("health:{}", node_id), *timestamp),
+            CrdtOperation::IncrementCounter {
+                counter_id,
+                node_id,
+                ..
+            } => {
+                // Counters always need to be synced (they accumulate)
+                (format!("counter:{}:{}", counter_id, node_id), u64::MAX)
+            }
+            CrdtOperation::UpdateRegister {
+                key,
+                timestamp,
+                node_id,
+                ..
+            } => (format!("reg:{}:{}", key, node_id), *timestamp),
+        }
+    }
+}
+
+/// Statistics about delta encoding
+#[derive(Debug, Clone, Default)]
+pub struct DeltaStats {
+    /// Number of peers being tracked
+    pub peer_count: usize,
+    /// Total bytes sent across all peers
+    pub total_bytes_sent: u64,
+    /// Total bytes received across all peers
+    pub total_bytes_received: u64,
+    /// Total number of sync operations
+    pub total_syncs: u32,
+    /// Number of keys being tracked
+    pub tracked_keys: usize,
+}
+
+/// Vector clock for causality tracking
+#[derive(Debug, Clone, Default)]
+pub struct VectorClock {
+    /// Per-node logical clocks
+    #[cfg(feature = "std")]
+    clocks: HashMap<u32, u64>,
+    #[cfg(not(feature = "std"))]
+    clocks: BTreeMap<u32, u64>,
+}
+
+impl VectorClock {
+    /// Create a new empty vector clock
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Increment the clock for a node
+    pub fn increment(&mut self, node_id: &NodeId) -> u64 {
+        let clock = self.clocks.entry(node_id.as_u32()).or_insert(0);
+        *clock += 1;
+        *clock
+    }
+
+    /// Get the clock value for a node
+    pub fn get(&self, node_id: &NodeId) -> u64 {
+        self.clocks.get(&node_id.as_u32()).copied().unwrap_or(0)
+    }
+
+    /// Update clock for a node (take max)
+    pub fn update(&mut self, node_id: &NodeId, value: u64) {
+        let clock = self.clocks.entry(node_id.as_u32()).or_insert(0);
+        *clock = (*clock).max(value);
+    }
+
+    /// Merge with another vector clock (take component-wise max)
+    pub fn merge(&mut self, other: &VectorClock) {
+        for (&node_id, &value) in &other.clocks {
+            let clock = self.clocks.entry(node_id).or_insert(0);
+            *clock = (*clock).max(value);
+        }
+    }
+
+    /// Check if this clock happens-before another
+    pub fn happens_before(&self, other: &VectorClock) -> bool {
+        let mut dominated = false;
+
+        // All our clocks must be <= other's
+        for (&node_id, &our_val) in &self.clocks {
+            let their_val = other.clocks.get(&node_id).copied().unwrap_or(0);
+            if our_val > their_val {
+                return false;
+            }
+            if our_val < their_val {
+                dominated = true;
+            }
+        }
+
+        // Check for clocks they have that we don't
+        for (&node_id, &their_val) in &other.clocks {
+            if !self.clocks.contains_key(&node_id) && their_val > 0 {
+                dominated = true;
+            }
+        }
+
+        dominated
+    }
+
+    /// Check if clocks are concurrent (neither happens-before the other)
+    pub fn concurrent_with(&self, other: &VectorClock) -> bool {
+        !self.happens_before(other) && !other.happens_before(self)
+    }
+
+    /// Encode to bytes
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(4 + self.clocks.len() * 12);
+        buf.extend_from_slice(&(self.clocks.len() as u32).to_le_bytes());
+        for (&node_id, &value) in &self.clocks {
+            buf.extend_from_slice(&node_id.to_le_bytes());
+            buf.extend_from_slice(&value.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Decode from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.len() < 4 {
+            return None;
+        }
+
+        let count = u32::from_le_bytes([data[0], data[1], data[2], data[3]]) as usize;
+        if data.len() < 4 + count * 12 {
+            return None;
+        }
+
+        #[cfg(feature = "std")]
+        let mut clocks = HashMap::with_capacity(count);
+        #[cfg(not(feature = "std"))]
+        let mut clocks = BTreeMap::new();
+
+        let mut offset = 4;
+        for _ in 0..count {
+            let node_id = u32::from_le_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]);
+            let value = u64::from_le_bytes([
+                data[offset + 4],
+                data[offset + 5],
+                data[offset + 6],
+                data[offset + 7],
+                data[offset + 8],
+                data[offset + 9],
+                data[offset + 10],
+                data[offset + 11],
+            ]);
+            clocks.insert(node_id, value);
+            offset += 12;
+        }
+
+        Some(Self { clocks })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::crdt::Position;
+
+    fn make_position_op(node_id: u32, timestamp: u64) -> CrdtOperation {
+        CrdtOperation::UpdatePosition {
+            node_id: NodeId::new(node_id),
+            position: Position::new(37.0, -122.0),
+            timestamp,
+        }
+    }
+
+    #[test]
+    fn test_peer_sync_state() {
+        let mut state = PeerSyncState::new();
+
+        assert!(state.needs_send("key1", 100));
+
+        state.mark_sent("key1", 100);
+
+        assert!(!state.needs_send("key1", 100));
+        assert!(!state.needs_send("key1", 50));
+        assert!(state.needs_send("key1", 101));
+    }
+
+    #[test]
+    fn test_delta_encoder_filter() {
+        let mut encoder = DeltaEncoder::new(NodeId::new(1));
+        let peer = NodeId::new(2);
+
+        encoder.add_peer(&peer);
+
+        let ops = vec![make_position_op(1, 100), make_position_op(2, 200)];
+
+        // First time, all ops should be sent
+        let filtered = encoder.filter_for_peer(&peer, &ops);
+        assert_eq!(filtered.len(), 2);
+
+        // Mark as sent
+        encoder.mark_sent(&peer, &filtered);
+
+        // Same ops should not be sent again
+        let filtered2 = encoder.filter_for_peer(&peer, &ops);
+        assert_eq!(filtered2.len(), 0);
+
+        // Newer ops should be sent
+        let new_ops = vec![make_position_op(1, 101)];
+        let filtered3 = encoder.filter_for_peer(&peer, &new_ops);
+        assert_eq!(filtered3.len(), 1);
+    }
+
+    #[test]
+    fn test_delta_encoder_stats() {
+        let mut encoder = DeltaEncoder::new(NodeId::new(1));
+
+        encoder.add_peer(&NodeId::new(2));
+        encoder.add_peer(&NodeId::new(3));
+
+        encoder.record_sent(&NodeId::new(2), 100);
+        encoder.record_sent(&NodeId::new(3), 50);
+        encoder.record_received(&NodeId::new(2), 75, 1000);
+
+        let stats = encoder.stats();
+        assert_eq!(stats.peer_count, 2);
+        assert_eq!(stats.total_bytes_sent, 150);
+        assert_eq!(stats.total_bytes_received, 75);
+        assert_eq!(stats.total_syncs, 2);
+    }
+
+    #[test]
+    fn test_vector_clock_increment() {
+        let mut clock = VectorClock::new();
+        let node = NodeId::new(1);
+
+        assert_eq!(clock.get(&node), 0);
+
+        clock.increment(&node);
+        assert_eq!(clock.get(&node), 1);
+
+        clock.increment(&node);
+        assert_eq!(clock.get(&node), 2);
+    }
+
+    #[test]
+    fn test_vector_clock_merge() {
+        let mut clock1 = VectorClock::new();
+        let mut clock2 = VectorClock::new();
+
+        let node1 = NodeId::new(1);
+        let node2 = NodeId::new(2);
+
+        clock1.update(&node1, 5);
+        clock1.update(&node2, 3);
+
+        clock2.update(&node1, 3);
+        clock2.update(&node2, 7);
+
+        clock1.merge(&clock2);
+
+        assert_eq!(clock1.get(&node1), 5); // max(5, 3)
+        assert_eq!(clock1.get(&node2), 7); // max(3, 7)
+    }
+
+    #[test]
+    fn test_vector_clock_happens_before() {
+        let mut clock1 = VectorClock::new();
+        let mut clock2 = VectorClock::new();
+
+        let node = NodeId::new(1);
+
+        clock1.update(&node, 1);
+        clock2.update(&node, 2);
+
+        assert!(clock1.happens_before(&clock2));
+        assert!(!clock2.happens_before(&clock1));
+    }
+
+    #[test]
+    fn test_vector_clock_concurrent() {
+        let mut clock1 = VectorClock::new();
+        let mut clock2 = VectorClock::new();
+
+        let node1 = NodeId::new(1);
+        let node2 = NodeId::new(2);
+
+        clock1.update(&node1, 2);
+        clock1.update(&node2, 1);
+
+        clock2.update(&node1, 1);
+        clock2.update(&node2, 2);
+
+        // Neither dominates the other
+        assert!(clock1.concurrent_with(&clock2));
+    }
+
+    #[test]
+    fn test_vector_clock_encode_decode() {
+        let mut clock = VectorClock::new();
+        clock.update(&NodeId::new(1), 5);
+        clock.update(&NodeId::new(2), 10);
+
+        let encoded = clock.encode();
+        let decoded = VectorClock::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.get(&NodeId::new(1)), 5);
+        assert_eq!(decoded.get(&NodeId::new(2)), 10);
+    }
+
+    #[test]
+    fn test_reset_peer() {
+        let mut encoder = DeltaEncoder::new(NodeId::new(1));
+        let peer = NodeId::new(2);
+
+        encoder.add_peer(&peer);
+        encoder.mark_sent(&peer, &[make_position_op(1, 100)]);
+
+        // After reset, should need to send again
+        encoder.reset_peer(&peer);
+
+        let ops = vec![make_position_op(1, 100)];
+        let filtered = encoder.filter_for_peer(&peer, &ops);
+        assert_eq!(filtered.len(), 1);
+    }
+}

--- a/hive-btle/src/sync/mod.rs
+++ b/hive-btle/src/sync/mod.rs
@@ -1,0 +1,113 @@
+//! HIVE-Lite Sync Protocol
+//!
+//! Efficient CRDT synchronization over BLE GATT characteristics.
+//!
+//! ## Overview
+//!
+//! This module provides the sync layer for HIVE-Lite nodes, enabling
+//! efficient state synchronization over bandwidth-constrained BLE links.
+//!
+//! ## Key Components
+//!
+//! - **CRDTs**: Conflict-free replicated data types (LWW-Register, G-Counter)
+//! - **Batching**: Accumulates changes to reduce radio activity
+//! - **Delta Encoding**: Only sends changes since last sync
+//! - **Chunking**: Splits large messages across MTU boundaries
+//!
+//! ## Architecture
+//!
+//! ```text
+//! ┌────────────────────────────────────────────────────┐
+//! │                  Application                        │
+//! │    (position updates, health status, alerts)       │
+//! └─────────────────────┬──────────────────────────────┘
+//!                       │
+//!                       ▼
+//! ┌────────────────────────────────────────────────────┐
+//! │              GattSyncProtocol                       │
+//! │  ┌──────────────┐  ┌────────────┐  ┌────────────┐  │
+//! │  │    Batch     │  │   Delta    │  │  Chunked   │  │
+//! │  │ Accumulator  │─▶│  Encoder   │─▶│  Transfer  │  │
+//! │  └──────────────┘  └────────────┘  └────────────┘  │
+//! └─────────────────────┬──────────────────────────────┘
+//!                       │
+//!                       ▼
+//! ┌────────────────────────────────────────────────────┐
+//! │              GATT Characteristics                   │
+//! │           (Sync Data, Sync State)                  │
+//! └────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_btle::sync::{GattSyncProtocol, SyncConfig, CrdtOperation, Position};
+//! use hive_btle::NodeId;
+//!
+//! // Create sync protocol
+//! let mut sync = GattSyncProtocol::new(
+//!     NodeId::new(0x12345678),
+//!     SyncConfig::default(),
+//! );
+//!
+//! // Add a peer
+//! sync.add_peer(&peer_id);
+//!
+//! // Queue position update
+//! sync.queue_operation(CrdtOperation::UpdatePosition {
+//!     node_id: my_node_id,
+//!     position: Position::new(37.7749, -122.4194),
+//!     timestamp: current_time_ms,
+//! });
+//!
+//! // Check if time to sync
+//! if sync.should_sync() {
+//!     let chunks = sync.prepare_sync(&peer_id);
+//!     for chunk in chunks {
+//!         // Write chunk to GATT characteristic
+//!         gatt.write_sync_data(&chunk.encode());
+//!     }
+//! }
+//!
+//! // Process received data
+//! if let Some(ops) = sync.process_received(chunk, &peer_id) {
+//!     for op in ops {
+//!         // Apply CRDT operation to local state
+//!         apply_operation(op);
+//!     }
+//! }
+//! ```
+//!
+//! ## Power Efficiency
+//!
+//! The sync protocol is designed for constrained devices:
+//!
+//! | Feature | Benefit |
+//! |---------|---------|
+//! | Batching | Reduces sync frequency (less radio time) |
+//! | Delta Encoding | Sends only changes (less bytes) |
+//! | Configurable Intervals | Trade freshness for battery |
+//! | Compact CRDT Encoding | Minimal overhead |
+//!
+//! ## Sync Profiles
+//!
+//! ```ignore
+//! // For smartwatch (battery critical)
+//! let config = SyncConfig::low_power();
+//!
+//! // For tablet (responsiveness preferred)
+//! let config = SyncConfig::responsive();
+//! ```
+
+pub mod batch;
+pub mod crdt;
+pub mod delta;
+pub mod protocol;
+
+pub use batch::{BatchAccumulator, BatchConfig, OperationBatch};
+pub use crdt::{CrdtOperation, GCounter, HealthStatus, LwwRegister, Position, Timestamp};
+pub use delta::{DeltaEncoder, DeltaStats, PeerSyncState, VectorClock};
+pub use protocol::{
+    chunk_data, ChunkHeader, ChunkReassembler, GattSyncProtocol, SyncChunk, SyncConfig, SyncState,
+    SyncStats, CHUNK_HEADER_SIZE, DEFAULT_MTU, MAX_MTU,
+};

--- a/hive-btle/src/sync/protocol.rs
+++ b/hive-btle/src/sync/protocol.rs
@@ -1,0 +1,750 @@
+//! GATT Sync Protocol for HIVE-Lite
+//!
+//! Coordinates batching, delta encoding, and chunked transfer over GATT
+//! characteristics for efficient BLE sync.
+
+#[cfg(not(feature = "std"))]
+use alloc::{collections::BTreeMap, collections::VecDeque, vec::Vec};
+#[cfg(feature = "std")]
+use std::collections::{HashMap, VecDeque};
+
+use super::batch::{BatchAccumulator, BatchConfig, OperationBatch};
+use super::crdt::CrdtOperation;
+use super::delta::{DeltaEncoder, VectorClock};
+use crate::NodeId;
+
+/// Default MTU for BLE
+pub const DEFAULT_MTU: usize = 23;
+
+/// Maximum MTU for BLE 5.0+
+pub const MAX_MTU: usize = 517;
+
+/// Header size for chunks
+pub const CHUNK_HEADER_SIZE: usize = 8;
+
+/// Chunk header for multi-MTU messages
+#[derive(Debug, Clone, Copy)]
+pub struct ChunkHeader {
+    /// Unique message ID
+    pub message_id: u32,
+    /// Index of this chunk (0-based)
+    pub chunk_index: u16,
+    /// Total number of chunks
+    pub total_chunks: u16,
+}
+
+impl ChunkHeader {
+    /// Encode header to bytes
+    pub fn encode(&self) -> [u8; CHUNK_HEADER_SIZE] {
+        let mut buf = [0u8; CHUNK_HEADER_SIZE];
+        buf[0..4].copy_from_slice(&self.message_id.to_le_bytes());
+        buf[4..6].copy_from_slice(&self.chunk_index.to_le_bytes());
+        buf[6..8].copy_from_slice(&self.total_chunks.to_le_bytes());
+        buf
+    }
+
+    /// Decode header from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.len() < CHUNK_HEADER_SIZE {
+            return None;
+        }
+        Some(Self {
+            message_id: u32::from_le_bytes([data[0], data[1], data[2], data[3]]),
+            chunk_index: u16::from_le_bytes([data[4], data[5]]),
+            total_chunks: u16::from_le_bytes([data[6], data[7]]),
+        })
+    }
+}
+
+/// A chunk of data to send
+#[derive(Debug, Clone)]
+pub struct SyncChunk {
+    /// Header
+    pub header: ChunkHeader,
+    /// Payload data
+    pub payload: Vec<u8>,
+}
+
+impl SyncChunk {
+    /// Encode chunk to bytes
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(CHUNK_HEADER_SIZE + self.payload.len());
+        buf.extend_from_slice(&self.header.encode());
+        buf.extend_from_slice(&self.payload);
+        buf
+    }
+
+    /// Decode chunk from bytes
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        let header = ChunkHeader::decode(data)?;
+        let payload = data[CHUNK_HEADER_SIZE..].to_vec();
+        Some(Self { header, payload })
+    }
+
+    /// Get total encoded size
+    pub fn encoded_size(&self) -> usize {
+        CHUNK_HEADER_SIZE + self.payload.len()
+    }
+}
+
+/// Reassembles chunks into complete messages
+#[derive(Debug)]
+pub struct ChunkReassembler {
+    /// Partial messages being assembled
+    #[cfg(feature = "std")]
+    partials: HashMap<u32, PartialMessage>,
+    #[cfg(not(feature = "std"))]
+    partials: BTreeMap<u32, PartialMessage>,
+
+    /// Maximum number of partial messages to track (for future use)
+    #[allow(dead_code)]
+    max_partials: usize,
+
+    /// Timeout for partial messages (ms)
+    partial_timeout_ms: u64,
+}
+
+/// A message being reassembled
+#[derive(Debug, Clone)]
+struct PartialMessage {
+    /// Total expected chunks
+    total_chunks: u16,
+    /// Received chunks (index -> data)
+    #[cfg(feature = "std")]
+    chunks: HashMap<u16, Vec<u8>>,
+    #[cfg(not(feature = "std"))]
+    chunks: BTreeMap<u16, Vec<u8>>,
+    /// Time first chunk was received
+    started_at: u64,
+}
+
+impl ChunkReassembler {
+    /// Create a new reassembler
+    pub fn new() -> Self {
+        Self {
+            #[cfg(feature = "std")]
+            partials: HashMap::new(),
+            #[cfg(not(feature = "std"))]
+            partials: BTreeMap::new(),
+            max_partials: 8,
+            partial_timeout_ms: 30_000,
+        }
+    }
+
+    /// Process a received chunk
+    ///
+    /// Returns the complete message if all chunks received
+    pub fn process(&mut self, chunk: SyncChunk, current_time_ms: u64) -> Option<Vec<u8>> {
+        let msg_id = chunk.header.message_id;
+
+        // Single-chunk message
+        if chunk.header.total_chunks == 1 {
+            return Some(chunk.payload);
+        }
+
+        // Get or create partial
+        let partial = self
+            .partials
+            .entry(msg_id)
+            .or_insert_with(|| PartialMessage {
+                total_chunks: chunk.header.total_chunks,
+                #[cfg(feature = "std")]
+                chunks: HashMap::new(),
+                #[cfg(not(feature = "std"))]
+                chunks: BTreeMap::new(),
+                started_at: current_time_ms,
+            });
+
+        // Insert chunk
+        partial
+            .chunks
+            .insert(chunk.header.chunk_index, chunk.payload);
+
+        // Check if complete
+        if partial.chunks.len() == partial.total_chunks as usize {
+            let partial = self.partials.remove(&msg_id)?;
+
+            // Reassemble in order
+            let mut result = Vec::new();
+            for i in 0..partial.total_chunks {
+                if let Some(data) = partial.chunks.get(&i) {
+                    result.extend_from_slice(data);
+                } else {
+                    // Missing chunk - shouldn't happen
+                    return None;
+                }
+            }
+            return Some(result);
+        }
+
+        None
+    }
+
+    /// Clean up timed-out partial messages
+    pub fn cleanup(&mut self, current_time_ms: u64) {
+        self.partials
+            .retain(|_, partial| current_time_ms - partial.started_at < self.partial_timeout_ms);
+    }
+
+    /// Get number of messages being assembled
+    pub fn pending_count(&self) -> usize {
+        self.partials.len()
+    }
+}
+
+impl Default for ChunkReassembler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Split data into MTU-sized chunks
+pub fn chunk_data(data: &[u8], mtu: usize, message_id: u32) -> Vec<SyncChunk> {
+    let payload_size = mtu.saturating_sub(CHUNK_HEADER_SIZE);
+    if payload_size == 0 {
+        return Vec::new();
+    }
+
+    let total_chunks = (data.len() + payload_size - 1) / payload_size;
+    let total_chunks = total_chunks.max(1) as u16;
+
+    let mut chunks = Vec::with_capacity(total_chunks as usize);
+
+    for (i, chunk_data) in data.chunks(payload_size).enumerate() {
+        chunks.push(SyncChunk {
+            header: ChunkHeader {
+                message_id,
+                chunk_index: i as u16,
+                total_chunks,
+            },
+            payload: chunk_data.to_vec(),
+        });
+    }
+
+    // Handle empty data
+    if chunks.is_empty() {
+        chunks.push(SyncChunk {
+            header: ChunkHeader {
+                message_id,
+                chunk_index: 0,
+                total_chunks: 1,
+            },
+            payload: Vec::new(),
+        });
+    }
+
+    chunks
+}
+
+/// State of the sync protocol
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SyncState {
+    /// Idle, not syncing
+    #[default]
+    Idle,
+    /// Sending data to peer
+    Sending,
+    /// Receiving data from peer
+    Receiving,
+    /// Waiting for acknowledgment
+    WaitingAck,
+}
+
+/// Configuration for the sync protocol
+#[derive(Debug, Clone)]
+pub struct SyncConfig {
+    /// Negotiated MTU
+    pub mtu: usize,
+    /// Batch configuration
+    pub batch: BatchConfig,
+    /// Sync interval in milliseconds
+    pub sync_interval_ms: u64,
+    /// Enable delta encoding
+    pub enable_delta: bool,
+    /// Maximum retries per chunk
+    pub max_retries: u8,
+}
+
+impl Default for SyncConfig {
+    fn default() -> Self {
+        Self {
+            mtu: DEFAULT_MTU,
+            batch: BatchConfig::default(),
+            sync_interval_ms: 5000,
+            enable_delta: true,
+            max_retries: 3,
+        }
+    }
+}
+
+impl SyncConfig {
+    /// Config for low-power operation
+    pub fn low_power() -> Self {
+        Self {
+            mtu: DEFAULT_MTU,
+            batch: BatchConfig::low_power(),
+            sync_interval_ms: 30_000,
+            enable_delta: true,
+            max_retries: 2,
+        }
+    }
+
+    /// Config for responsive operation
+    pub fn responsive() -> Self {
+        Self {
+            mtu: MAX_MTU,
+            batch: BatchConfig::responsive(),
+            sync_interval_ms: 1000,
+            enable_delta: true,
+            max_retries: 3,
+        }
+    }
+}
+
+/// GATT Sync Protocol coordinator
+///
+/// Ties together batching, delta encoding, and chunked transfer
+/// for efficient CRDT sync over BLE.
+pub struct GattSyncProtocol {
+    /// Our node ID
+    node_id: NodeId,
+
+    /// Configuration
+    config: SyncConfig,
+
+    /// Current state
+    state: SyncState,
+
+    /// Batch accumulator
+    batch: BatchAccumulator,
+
+    /// Delta encoder
+    delta: DeltaEncoder,
+
+    /// Vector clock
+    vector_clock: VectorClock,
+
+    /// Outgoing chunk queue
+    tx_queue: VecDeque<SyncChunk>,
+
+    /// Chunk reassembler for incoming data
+    rx_reassembler: ChunkReassembler,
+
+    /// Next message ID
+    next_message_id: u32,
+
+    /// Current time (set externally)
+    current_time_ms: u64,
+
+    /// Last sync time
+    last_sync_time_ms: u64,
+}
+
+impl GattSyncProtocol {
+    /// Create a new sync protocol instance
+    pub fn new(node_id: NodeId, config: SyncConfig) -> Self {
+        Self {
+            node_id: node_id.clone(),
+            batch: BatchAccumulator::new(config.batch.clone()),
+            delta: DeltaEncoder::new(node_id),
+            vector_clock: VectorClock::new(),
+            config,
+            state: SyncState::Idle,
+            tx_queue: VecDeque::new(),
+            rx_reassembler: ChunkReassembler::new(),
+            next_message_id: 1,
+            current_time_ms: 0,
+            last_sync_time_ms: 0,
+        }
+    }
+
+    /// Create with default config
+    pub fn with_defaults(node_id: NodeId) -> Self {
+        Self::new(node_id, SyncConfig::default())
+    }
+
+    /// Set the current time
+    pub fn set_time(&mut self, time_ms: u64) {
+        self.current_time_ms = time_ms;
+    }
+
+    /// Set the MTU (after negotiation)
+    pub fn set_mtu(&mut self, mtu: usize) {
+        self.config.mtu = mtu;
+    }
+
+    /// Get current state
+    pub fn state(&self) -> SyncState {
+        self.state
+    }
+
+    /// Get the vector clock
+    pub fn vector_clock(&self) -> &VectorClock {
+        &self.vector_clock
+    }
+
+    /// Add a peer for sync
+    pub fn add_peer(&mut self, peer_id: &NodeId) {
+        self.delta.add_peer(peer_id);
+    }
+
+    /// Remove a peer
+    pub fn remove_peer(&mut self, peer_id: &NodeId) {
+        self.delta.remove_peer(peer_id);
+    }
+
+    /// Queue a CRDT operation for sync
+    pub fn queue_operation(&mut self, op: CrdtOperation) -> bool {
+        // Update vector clock
+        self.vector_clock.increment(&self.node_id);
+
+        // Add to batch
+        self.batch.add(op, self.current_time_ms)
+    }
+
+    /// Check if we should sync now
+    pub fn should_sync(&self) -> bool {
+        self.batch.should_flush(self.current_time_ms)
+    }
+
+    /// Prepare a sync to a peer
+    ///
+    /// Returns the chunks to send
+    pub fn prepare_sync(&mut self, peer_id: &NodeId) -> Vec<SyncChunk> {
+        // Flush the batch
+        let batch = match self.batch.flush(self.current_time_ms) {
+            Some(b) => b,
+            None => return Vec::new(),
+        };
+
+        // Filter with delta encoding
+        let operations = if self.config.enable_delta {
+            self.delta.filter_for_peer(peer_id, &batch.operations)
+        } else {
+            batch.operations.clone()
+        };
+
+        if operations.is_empty() {
+            return Vec::new();
+        }
+
+        // Create a batch with filtered operations
+        let filtered_batch = OperationBatch {
+            operations: operations.clone(),
+            total_bytes: operations.iter().map(|o| o.size()).sum(),
+            created_at: batch.created_at,
+        };
+
+        // Encode the batch
+        let encoded = filtered_batch.encode();
+
+        // Chunk it
+        let msg_id = self.next_message_id;
+        self.next_message_id = self.next_message_id.wrapping_add(1);
+
+        let chunks = chunk_data(&encoded, self.config.mtu, msg_id);
+
+        // Mark as sent (after we have the filtered list)
+        self.delta.mark_sent(peer_id, &operations);
+        self.delta.record_sent(peer_id, encoded.len());
+
+        self.state = SyncState::Sending;
+        self.last_sync_time_ms = self.current_time_ms;
+
+        chunks
+    }
+
+    /// Get next chunk to send (if any)
+    pub fn next_tx_chunk(&mut self) -> Option<SyncChunk> {
+        self.tx_queue.pop_front()
+    }
+
+    /// Queue chunks for sending
+    pub fn queue_chunks(&mut self, chunks: Vec<SyncChunk>) {
+        self.tx_queue.extend(chunks);
+    }
+
+    /// Check if there are chunks to send
+    pub fn has_pending_tx(&self) -> bool {
+        !self.tx_queue.is_empty()
+    }
+
+    /// Process a received chunk
+    ///
+    /// Returns decoded operations if message is complete
+    pub fn process_received(
+        &mut self,
+        chunk: SyncChunk,
+        peer_id: &NodeId,
+    ) -> Option<Vec<CrdtOperation>> {
+        self.state = SyncState::Receiving;
+
+        // Reassemble
+        let complete = self.rx_reassembler.process(chunk, self.current_time_ms)?;
+
+        // Decode batch
+        let batch = OperationBatch::decode(&complete)?;
+
+        // Record stats
+        self.delta
+            .record_received(peer_id, complete.len(), self.current_time_ms);
+
+        // Update vector clock with received operations
+        for op in &batch.operations {
+            let timestamp = match op {
+                CrdtOperation::UpdatePosition { timestamp, .. } => *timestamp,
+                CrdtOperation::UpdateHealth { timestamp, .. } => *timestamp,
+                CrdtOperation::UpdateRegister { timestamp, .. } => *timestamp,
+                CrdtOperation::IncrementCounter { .. } => 0,
+            };
+            if timestamp > 0 {
+                self.vector_clock.update(peer_id, timestamp);
+            }
+        }
+
+        self.state = SyncState::Idle;
+        Some(batch.operations)
+    }
+
+    /// Acknowledge completion of send
+    pub fn ack_send(&mut self) {
+        if self.tx_queue.is_empty() {
+            self.state = SyncState::Idle;
+        }
+    }
+
+    /// Reset protocol state (e.g., on reconnection)
+    pub fn reset(&mut self) {
+        self.state = SyncState::Idle;
+        self.tx_queue.clear();
+        self.rx_reassembler = ChunkReassembler::new();
+    }
+
+    /// Reset sync state for a specific peer
+    pub fn reset_peer(&mut self, peer_id: &NodeId) {
+        self.delta.reset_peer(peer_id);
+    }
+
+    /// Run periodic maintenance
+    pub fn tick(&mut self) {
+        self.rx_reassembler.cleanup(self.current_time_ms);
+    }
+
+    /// Get sync statistics
+    pub fn stats(&self) -> SyncStats {
+        let delta_stats = self.delta.stats();
+        SyncStats {
+            bytes_sent: delta_stats.total_bytes_sent,
+            bytes_received: delta_stats.total_bytes_received,
+            syncs_completed: delta_stats.total_syncs,
+            pending_operations: self.batch.pending_count(),
+            pending_tx_chunks: self.tx_queue.len(),
+            pending_rx_messages: self.rx_reassembler.pending_count(),
+        }
+    }
+}
+
+/// Sync statistics
+#[derive(Debug, Clone, Default)]
+pub struct SyncStats {
+    /// Total bytes sent
+    pub bytes_sent: u64,
+    /// Total bytes received
+    pub bytes_received: u64,
+    /// Number of completed syncs
+    pub syncs_completed: u32,
+    /// Pending operations in batch
+    pub pending_operations: usize,
+    /// Pending TX chunks
+    pub pending_tx_chunks: usize,
+    /// Pending RX messages being reassembled
+    pub pending_rx_messages: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::crdt::Position;
+
+    fn make_position_op(node_id: u32, timestamp: u64) -> CrdtOperation {
+        CrdtOperation::UpdatePosition {
+            node_id: NodeId::new(node_id),
+            position: Position::new(37.0, -122.0),
+            timestamp,
+        }
+    }
+
+    #[test]
+    fn test_chunk_header_encode_decode() {
+        let header = ChunkHeader {
+            message_id: 0x12345678,
+            chunk_index: 5,
+            total_chunks: 10,
+        };
+
+        let encoded = header.encode();
+        let decoded = ChunkHeader::decode(&encoded).unwrap();
+
+        assert_eq!(decoded.message_id, 0x12345678);
+        assert_eq!(decoded.chunk_index, 5);
+        assert_eq!(decoded.total_chunks, 10);
+    }
+
+    #[test]
+    fn test_chunk_data_single() {
+        let data = vec![1, 2, 3, 4, 5];
+        let chunks = chunk_data(&data, 100, 1);
+
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].header.total_chunks, 1);
+        assert_eq!(chunks[0].payload, data);
+    }
+
+    #[test]
+    fn test_chunk_data_multiple() {
+        let data = vec![0u8; 100];
+        let mtu = 20; // 8 header + 12 payload
+        let chunks = chunk_data(&data, mtu, 1);
+
+        // 100 bytes / 12 per chunk = 9 chunks
+        assert_eq!(chunks.len(), 9);
+        assert_eq!(chunks[0].header.total_chunks, 9);
+
+        // Verify payload sizes
+        for (i, chunk) in chunks.iter().enumerate() {
+            assert_eq!(chunk.header.chunk_index, i as u16);
+            if i < 8 {
+                assert_eq!(chunk.payload.len(), 12);
+            } else {
+                assert_eq!(chunk.payload.len(), 4); // Last chunk
+            }
+        }
+    }
+
+    #[test]
+    fn test_chunk_reassembler_single() {
+        let mut reassembler = ChunkReassembler::new();
+
+        let chunk = SyncChunk {
+            header: ChunkHeader {
+                message_id: 1,
+                chunk_index: 0,
+                total_chunks: 1,
+            },
+            payload: vec![1, 2, 3],
+        };
+
+        let result = reassembler.process(chunk, 0).unwrap();
+        assert_eq!(result, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_chunk_reassembler_multiple() {
+        let mut reassembler = ChunkReassembler::new();
+
+        // Send chunks out of order
+        let chunk2 = SyncChunk {
+            header: ChunkHeader {
+                message_id: 1,
+                chunk_index: 1,
+                total_chunks: 3,
+            },
+            payload: vec![4, 5, 6],
+        };
+
+        let chunk1 = SyncChunk {
+            header: ChunkHeader {
+                message_id: 1,
+                chunk_index: 0,
+                total_chunks: 3,
+            },
+            payload: vec![1, 2, 3],
+        };
+
+        let chunk3 = SyncChunk {
+            header: ChunkHeader {
+                message_id: 1,
+                chunk_index: 2,
+                total_chunks: 3,
+            },
+            payload: vec![7, 8, 9],
+        };
+
+        assert!(reassembler.process(chunk2, 0).is_none());
+        assert!(reassembler.process(chunk1, 0).is_none());
+
+        let result = reassembler.process(chunk3, 0).unwrap();
+        assert_eq!(result, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn test_sync_protocol_basic() {
+        let node1 = NodeId::new(1);
+        let node2 = NodeId::new(2);
+
+        let mut proto1 = GattSyncProtocol::with_defaults(node1.clone());
+        proto1.add_peer(&node2);
+        proto1.set_mtu(100);
+
+        // Queue some operations
+        proto1.queue_operation(make_position_op(1, 1000));
+        proto1.queue_operation(make_position_op(1, 1001));
+
+        // Force batch to be ready
+        proto1.set_time(10000);
+
+        // Prepare sync
+        let chunks = proto1.prepare_sync(&node2);
+        assert!(!chunks.is_empty());
+    }
+
+    #[test]
+    fn test_sync_protocol_round_trip() {
+        let node1 = NodeId::new(1);
+        let node2 = NodeId::new(2);
+
+        let mut proto1 = GattSyncProtocol::with_defaults(node1.clone());
+        let mut proto2 = GattSyncProtocol::with_defaults(node2.clone());
+
+        proto1.add_peer(&node2);
+        proto2.add_peer(&node1);
+
+        proto1.set_mtu(100);
+        proto2.set_mtu(100);
+
+        // Node 1 queues operation
+        proto1.queue_operation(make_position_op(1, 1000));
+        proto1.set_time(10000);
+
+        // Node 1 prepares sync
+        let chunks = proto1.prepare_sync(&node2);
+
+        // Node 2 receives chunks
+        let mut ops = None;
+        for chunk in chunks {
+            ops = proto2.process_received(chunk, &node1);
+        }
+
+        // Verify operation received
+        let ops = ops.unwrap();
+        assert_eq!(ops.len(), 1);
+    }
+
+    #[test]
+    fn test_sync_config_profiles() {
+        let low_power = SyncConfig::low_power();
+        assert_eq!(low_power.sync_interval_ms, 30_000);
+
+        let responsive = SyncConfig::responsive();
+        assert_eq!(responsive.sync_interval_ms, 1000);
+    }
+
+    #[test]
+    fn test_sync_stats() {
+        let proto = GattSyncProtocol::with_defaults(NodeId::new(1));
+        let stats = proto.stats();
+
+        assert_eq!(stats.bytes_sent, 0);
+        assert_eq!(stats.pending_operations, 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements efficient CRDT synchronization over BLE GATT characteristics
- Adds LWW-Register and G-Counter CRDTs for conflict-free state management
- Provides batch accumulation, delta encoding, and chunked transfer for bandwidth efficiency

## Implementation Details

### CRDTs (`sync/crdt.rs`)
- `LwwRegister<T>`: Last-writer-wins register with timestamp + node_id tiebreaking
- `GCounter`: Grow-only counter with per-node counts
- `Position`: GPS coordinates (lat/lon/alt/accuracy)
- `HealthStatus`: Battery, heart rate, activity, alerts
- `CrdtOperation`: Enum for all sync operations with encode/decode

### Batch Accumulator (`sync/batch.rs`)
- Configurable time/size/count limits
- Power profiles: `low_power()` (30s window) and `responsive()` (1s window)
- Reduces radio activity on constrained devices

### Delta Encoding (`sync/delta.rs`)
- Tracks per-peer sync state with vector clocks
- Only sends changes since last sync
- Causality tracking for proper ordering

### Sync Protocol (`sync/protocol.rs`)
- `GattSyncProtocol`: Main coordinator
- Chunked transfer for messages exceeding MTU
- Configurable MTU (23-512 bytes)
- State machine: Idle → Syncing → WaitingAck → Idle

## Test Results
- 40 new unit tests (134 total in hive-btle)
- All tests passing ✅

## Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)