### PR TITLE
fix(sim): Suppress expected conflict resolution log noise

### DIFF
--- a/hive-sim/src/main.rs
+++ b/hive-sim/src/main.rs
@@ -1657,10 +1657,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     )
                                     .await
                                     {
-                                        eprintln!(
-                                            "[{}] Command issuance error: {}",
-                                            cmd_node_id, e
-                                        );
+                                        let err_str = e.to_string();
+                                        if !err_str.contains("conflict resolution") {
+                                            // Only log unexpected errors, not conflict rejections
+                                            eprintln!(
+                                                "[{}] Command issuance error: {}",
+                                                cmd_node_id, e
+                                            );
+                                        }
                                     }
                                     sleep(Duration::from_secs(30)).await;
                                 }
@@ -1786,10 +1790,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     )
                                     .await
                                     {
-                                        eprintln!(
-                                            "[{}] Command issuance error: {}",
-                                            cmd_node_id, e
-                                        );
+                                        let err_str = e.to_string();
+                                        if !err_str.contains("conflict resolution") {
+                                            // Only log unexpected errors, not conflict rejections
+                                            eprintln!(
+                                                "[{}] Command issuance error: {}",
+                                                cmd_node_id, e
+                                            );
+                                        }
                                     }
                                     sleep(Duration::from_secs(30)).await;
                                 }


### PR DESCRIPTION
## Summary

- Conflict resolution rejections are expected behavior when demo commands overlap
- Only log actual unexpected errors, not normal conflict rejections

## Problem

Squad leaders issue demo commands every 30 seconds. When a previous command is still active, the conflict resolver correctly rejects the new command. This was being logged as an error, creating noise in the logs.

## Solution

Check if the error message contains "conflict resolution" and suppress those expected rejections from the error log.

## Test plan

- [x] `cargo test -p hive-sim` passes
- [x] Verified in 96-node lab that error noise is reduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)