### PR TITLE
feat(esp32): Add multi-hop mesh gossip sync for M5Stack Core2 BLE CRDT demo

### DIFF
--- a/examples/m5stack-core2-hive/Cargo.toml
+++ b/examples/m5stack-core2-hive/Cargo.toml
@@ -22,6 +22,11 @@ log = "0.4"
 # Error handling
 anyhow = "1.0"
 
+# Display
+display-interface-spi = "0.5"
+mipidsi = "0.8"
+embedded-graphics = "0.8"
+
 # HIVE libraries (local)
 hive-btle = { path = "../../hive-btle", default-features = false, features = ["esp32"] }
 

--- a/examples/m5stack-core2-hive/Makefile
+++ b/examples/m5stack-core2-hive/Makefile
@@ -1,0 +1,57 @@
+# M5Stack Core2 HIVE Demo - Makefile
+#
+# Commands:
+#   make build      - Build the firmware
+#   make flash      - Flash to first available device
+#   make flash-all  - Flash to all three devices in parallel
+#   make monitor    - Monitor first device
+#   make clean      - Clean build artifacts
+
+# Device serial ports (update if your devices differ)
+DEV1 := /dev/cu.usbserial-02036C1A
+DEV2 := /dev/cu.usbserial-5A490605921
+DEV3 := /dev/cu.usbserial-5A490607481
+
+TARGET := target/xtensa-esp32-espidf/release/m5stack-core2-hive
+
+.PHONY: build flash flash-all flash1 flash2 flash3 monitor clean
+
+build:
+	@echo "Building firmware..."
+	@source ~/export-esp.sh && cargo build --release
+
+flash: build
+	@echo "Flashing to first available device..."
+	espflash flash $(TARGET)
+
+flash-all: build
+	@echo "Flashing to all three devices in parallel..."
+	@$(MAKE) -j3 flash1 flash2 flash3
+	@echo "All devices flashed!"
+
+flash1:
+	@echo "Flashing device 1: $(DEV1)"
+	@espflash flash --port $(DEV1) $(TARGET) 2>&1 | sed 's/^/[DEV1] /'
+
+flash2:
+	@echo "Flashing device 2: $(DEV2)"
+	@espflash flash --port $(DEV2) $(TARGET) 2>&1 | sed 's/^/[DEV2] /'
+
+flash3:
+	@echo "Flashing device 3: $(DEV3)"
+	@espflash flash --port $(DEV3) $(TARGET) 2>&1 | sed 's/^/[DEV3] /'
+
+monitor:
+	espflash monitor --port $(DEV1)
+
+monitor1:
+	espflash monitor --port $(DEV1)
+
+monitor2:
+	espflash monitor --port $(DEV2)
+
+monitor3:
+	espflash monitor --port $(DEV3)
+
+clean:
+	cargo clean

--- a/examples/m5stack-core2-hive/src/main.rs
+++ b/examples/m5stack-core2-hive/src/main.rs
@@ -1,24 +1,10 @@
-//! HIVE-Lite Counter Demo for M5Stack Core2
+//! HIVE-Lite BLE Document Sync Demo for M5Stack Core2
 //!
-//! Demonstrates CRDT document sync between two nodes:
-//! - Tap screen to increment your counter
-//! - Counter persists to NVS (survives power off)
-//! - When peer connects, full state exchange and merge
-//! - Eventually consistent: both nodes converge to same state
-//!
-//! ## Automerge-style Semantics
-//!
-//! Each node maintains a GCounter CRDT document:
-//! - Node tracks its own taps independently
-//! - Merge = take max of each node's count
-//! - Offline changes are preserved and sync later
-//!
-//! Example:
-//! ```text
-//! Node A: {A: 5, B: 3} = 8 total
-//! Node B offline, taps 4 times: {A: 2, B: 7}
-//! After sync: both have {A: 5, B: 7} = 12 total
-//! ```
+//! Two-device CRDT sync over BLE:
+//! - Tap screen to increment counter
+//! - State persists to NVS (survives power off)
+//! - Devices discover each other via BLE
+//! - Documents merge automatically (eventually consistent)
 //!
 //! ## Building
 //!
@@ -28,42 +14,48 @@
 //! espflash flash --monitor target/xtensa-esp32-espidf/release/m5stack-core2-hive
 //! ```
 
+mod nimble;
+
 use esp_idf_hal::delay::FreeRtos;
+use esp_idf_hal::gpio::PinDriver;
 use esp_idf_hal::i2c::{I2cConfig, I2cDriver};
 use esp_idf_hal::peripherals::Peripherals;
 use esp_idf_hal::prelude::*;
+use esp_idf_hal::spi::{SpiConfig, SpiDeviceDriver, SpiDriver, SpiDriverConfig};
 use esp_idf_svc::eventloop::EspSystemEventLoop;
 use esp_idf_svc::nvs::{EspDefaultNvsPartition, EspNvs, NvsDefault};
-use log::{info, warn, error, debug};
+use log::{error, info, warn};
 
-use hive_btle::discovery::HiveBeacon;
+use display_interface_spi::SPIInterface;
+use embedded_graphics::mono_font::ascii::FONT_10X20;
+use embedded_graphics::mono_font::MonoTextStyle;
+use embedded_graphics::pixelcolor::Rgb565;
+use embedded_graphics::prelude::*;
+use embedded_graphics::primitives::{Circle, PrimitiveStyle, Rectangle};
+use embedded_graphics::text::Text;
+use mipidsi::models::ILI9342CRgb565;
+use mipidsi::options::Orientation;
+use mipidsi::Builder;
+
 use hive_btle::sync::GCounter;
-use hive_btle::{HierarchyLevel, NodeId};
+use hive_btle::NodeId;
 
-// NVS namespace for storing CRDT state
+// NVS storage
 const NVS_NAMESPACE: &str = "hive";
 const NVS_KEY_COUNTER: &str = "counter";
 
-// FT6336U Touch controller
+// FT6336U Touch controller on M5Stack Core2
 const FT6336U_ADDR: u8 = 0x38;
 const FT6336U_REG_STATUS: u8 = 0x02;
-const FT6336U_REG_TOUCH1_XH: u8 = 0x03;
 
-/// CRDT Document - holds all synced state
-///
-/// This is our "Automerge document" - a collection of CRDTs
-/// that can be synced as a unit.
+/// CRDT Document with persistence
 struct HiveDocument {
-    /// The tap counter (G-Counter CRDT)
     pub counter: GCounter,
-    /// Our node ID
     node_id: NodeId,
-    /// Document version (increments on any local change)
-    version: u64,
+    version: u32,
 }
 
 impl HiveDocument {
-    /// Create new empty document
     fn new(node_id: NodeId) -> Self {
         Self {
             counter: GCounter::new(),
@@ -72,54 +64,77 @@ impl HiveDocument {
         }
     }
 
-    /// Increment our tap counter
     fn tap(&mut self) {
+        info!(">>> TAP: incrementing node {:08X}", self.node_id.as_u32());
+        self.debug_dump("BEFORE TAP");
         self.counter.increment(&self.node_id, 1);
         self.version += 1;
+        self.debug_dump("AFTER TAP");
     }
 
-    /// Get our tap count
-    fn our_taps(&self) -> u64 {
-        self.counter.node_count(&self.node_id)
-    }
-
-    /// Get peer tap count (everyone else)
-    fn peer_taps(&self) -> u64 {
-        self.counter.value() - self.our_taps()
-    }
-
-    /// Get total taps
     fn total_taps(&self) -> u64 {
         self.counter.value()
     }
 
-    /// Merge with another document (Automerge-style)
-    ///
-    /// After merge, both documents will have the same state
-    /// (max of each node's contribution).
-    fn merge(&mut self, other: &HiveDocument) {
-        self.counter.merge(&other.counter);
-        self.version += 1;
+    fn num_nodes(&self) -> usize {
+        self.counter.node_count_total()
     }
 
-    /// Encode document for sync/storage
+    /// Debug dump the GCounter state
+    fn debug_dump(&self, prefix: &str) {
+        let encoded = self.counter.encode();
+        if encoded.len() >= 4 {
+            let num_entries = u32::from_le_bytes([encoded[0], encoded[1], encoded[2], encoded[3]]);
+            info!("{}: {} entries, total={}, v{}", prefix, num_entries, self.total_taps(), self.version);
+            let mut offset = 4;
+            for i in 0..num_entries as usize {
+                if offset + 12 <= encoded.len() {
+                    let node = u32::from_le_bytes([
+                        encoded[offset], encoded[offset+1], encoded[offset+2], encoded[offset+3]
+                    ]);
+                    let count = u64::from_le_bytes([
+                        encoded[offset+4], encoded[offset+5], encoded[offset+6], encoded[offset+7],
+                        encoded[offset+8], encoded[offset+9], encoded[offset+10], encoded[offset+11]
+                    ]);
+                    info!("{}:   [{}] node={:08X} count={}", prefix, i, node, count);
+                    offset += 12;
+                }
+            }
+        }
+    }
+
+    /// Merge another document into this one
+    fn merge(&mut self, other: &HiveDocument) -> bool {
+        info!("=== MERGE START ===");
+        self.debug_dump("OURS BEFORE");
+        other.debug_dump("THEIRS");
+
+        let old_value = self.counter.value();
+        self.counter.merge(&other.counter);
+        let changed = self.counter.value() != old_value;
+        if changed {
+            self.version += 1;
+        }
+
+        self.debug_dump("OURS AFTER");
+        info!("=== MERGE END (changed={}) ===", changed);
+        changed
+    }
+
     fn encode(&self) -> Vec<u8> {
-        // Format: [version: 8 bytes] [counter_data]
         let mut buf = Vec::new();
         buf.extend_from_slice(&self.version.to_le_bytes());
+        buf.extend_from_slice(&self.node_id.as_u32().to_le_bytes());
         buf.extend_from_slice(&self.counter.encode());
         buf
     }
 
-    /// Decode document from sync/storage
-    fn decode(data: &[u8], node_id: NodeId) -> Option<Self> {
+    fn decode(data: &[u8]) -> Option<Self> {
         if data.len() < 8 {
             return None;
         }
-        let version = u64::from_le_bytes([
-            data[0], data[1], data[2], data[3],
-            data[4], data[5], data[6], data[7],
-        ]);
+        let version = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let node_id = NodeId::new(u32::from_le_bytes([data[4], data[5], data[6], data[7]]));
         let counter = GCounter::decode(&data[8..])?;
         Some(Self {
             counter,
@@ -129,106 +144,287 @@ impl HiveDocument {
     }
 }
 
-/// Persistent storage for CRDT document
-struct DocumentStore<'a> {
+/// Document store with NVS persistence
+struct DocumentStore {
     nvs: EspNvs<NvsDefault>,
-    node_id: NodeId,
-    _phantom: std::marker::PhantomData<&'a ()>,
 }
 
-impl<'a> DocumentStore<'a> {
-    /// Open or create the document store
-    fn new(nvs_partition: EspDefaultNvsPartition, node_id: NodeId) -> anyhow::Result<Self> {
+impl DocumentStore {
+    fn new(nvs_partition: EspDefaultNvsPartition) -> anyhow::Result<Self> {
         let nvs = EspNvs::new(nvs_partition, NVS_NAMESPACE, true)?;
-        Ok(Self {
-            nvs,
-            node_id,
-            _phantom: std::marker::PhantomData,
-        })
+        Ok(Self { nvs })
     }
 
-    /// Load document from NVS (or create new if not found)
-    fn load(&self) -> HiveDocument {
+    fn load(&self, node_id: NodeId) -> HiveDocument {
         let mut buf = [0u8; 256];
         match self.nvs.get_raw(NVS_KEY_COUNTER, &mut buf) {
             Ok(Some(data)) => {
-                if let Some(doc) = HiveDocument::decode(data, self.node_id) {
-                    info!("Loaded document from NVS: {} taps, version {}",
-                          doc.total_taps(), doc.version);
+                info!("NVS: loaded {} raw bytes", data.len());
+                if let Some(mut doc) = HiveDocument::decode(data) {
+                    // Update node_id to our own (in case it was from a merge)
+                    doc.node_id = node_id;
+                    info!("Loaded document:");
+                    doc.debug_dump("  LOADED");
                     return doc;
+                } else {
+                    warn!("Failed to decode NVS data!");
                 }
             }
-            Ok(None) => {
-                info!("No saved document, starting fresh");
-            }
-            Err(e) => {
-                warn!("Failed to load from NVS: {:?}, starting fresh", e);
-            }
+            Ok(None) => info!("No saved document, starting fresh"),
+            Err(e) => warn!("NVS load error: {:?}", e),
         }
-        HiveDocument::new(self.node_id)
+        info!("Creating fresh document for node {:08X}", node_id.as_u32());
+        HiveDocument::new(node_id)
     }
 
-    /// Save document to NVS
     fn save(&mut self, doc: &HiveDocument) -> anyhow::Result<()> {
         let data = doc.encode();
         self.nvs.set_raw(NVS_KEY_COUNTER, &data)?;
-        debug!("Saved document to NVS: {} bytes", data.len());
         Ok(())
     }
 }
 
-/// Touch detection
-#[derive(Debug, Clone, Copy, PartialEq)]
-enum TouchState {
+/// Touch state
+#[derive(PartialEq, Clone, Copy)]
+enum Touch {
     None,
     Touched,
 }
 
-fn read_touch(i2c: &mut I2cDriver) -> TouchState {
+fn read_touch(i2c: &mut I2cDriver) -> Touch {
     let mut buf = [0u8; 1];
-    if i2c.write_read(FT6336U_ADDR, &[FT6336U_REG_STATUS], &mut buf).is_err() {
-        return TouchState::None;
+    if i2c
+        .write_read(FT6336U_ADDR, &[FT6336U_REG_STATUS], &mut buf, 100)
+        .is_ok()
+    {
+        if buf[0] & 0x0F > 0 {
+            return Touch::Touched;
+        }
     }
-    let num_touches = buf[0] & 0x0F;
-    if num_touches > 0 {
-        TouchState::Touched
-    } else {
-        TouchState::None
-    }
+    Touch::None
 }
 
-/// Get unique Node ID from ESP32 MAC address
 fn get_node_id_from_mac() -> NodeId {
     let mut mac = [0u8; 6];
     unsafe {
         esp_idf_svc::sys::esp_efuse_mac_get_default(mac.as_mut_ptr());
     }
-    info!("MAC: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
-          mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+    info!(
+        "MAC: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+    );
+    // Use last 4 bytes of MAC as node ID
     NodeId::new(u32::from_be_bytes([mac[2], mac[3], mac[4], mac[5]]))
 }
 
-/// Display state to serial (LCD driver to come)
-fn update_display(doc: &HiveDocument, peer_id: Option<NodeId>, connected: bool, status: &str) {
-    info!("┌────────────────────────────────┐");
-    info!("│  HIVE-Lite Document Sync       │");
-    info!("├────────────────────────────────┤");
-    info!("│  My ID: {:08X}  v{}          │", doc.node_id.as_u32(), doc.version);
-    if let Some(peer) = peer_id {
-        info!("│  Peer:  {:08X} {}           │", peer.as_u32(),
-              if connected { "●" } else { "○" });
-    } else {
-        info!("│  Peer:  (scanning...)          │");
+fn print_status(doc: &HiveDocument, connected: bool, status: &str) {
+    let conn_sym = if connected { "●" } else { "○" };
+    info!("========================================");
+    info!("  HIVE-Lite BLE Sync Demo");
+    info!("----------------------------------------");
+    info!(
+        "  Node: {:08X}  v{}  BLE:{}",
+        doc.node_id.as_u32(),
+        doc.version,
+        conn_sym
+    );
+    info!("----------------------------------------");
+    info!("  Taps: {}", doc.total_taps());
+    info!("----------------------------------------");
+    info!("  {}", status);
+    info!("========================================");
+}
+
+/// AXP192 power management IC (controls backlight and power)
+const AXP192_ADDR: u8 = 0x34;
+
+fn axp192_init(i2c: &mut I2cDriver) -> anyhow::Result<()> {
+    let mut buf = [0u8; 1];
+
+    // Read current ADC config
+    if i2c.write_read(AXP192_ADDR, &[0x82], &mut buf, 100).is_ok() {
+        info!("AXP192: ADC config=0x{:02X} (need bit7 set for battery)", buf[0]);
+
+        // Enable battery voltage ADC (bit 7) if not already set
+        if (buf[0] & 0x80) == 0 {
+            let new_val = buf[0] | 0x80; // Set only bit 7, preserve others
+            info!("AXP192: Enabling battery ADC: 0x{:02X} -> 0x{:02X}", buf[0], new_val);
+            // Write register address and value
+            let write_result = i2c.write(AXP192_ADDR, &[0x82, new_val], 1000);
+            match write_result {
+                Ok(_) => {
+                    info!("AXP192: Write succeeded");
+                    FreeRtos::delay_ms(10); // Small delay after write
+                }
+                Err(e) => {
+                    warn!("AXP192: Write failed: {:?}", e);
+                }
+            }
+            // Wait for ADC to stabilize
+            FreeRtos::delay_ms(100);
+            // Verify it took effect
+            if i2c.write_read(AXP192_ADDR, &[0x82], &mut buf, 100).is_ok() {
+                info!("AXP192: ADC config after enable=0x{:02X}", buf[0]);
+                if (buf[0] & 0x80) == 0 {
+                    warn!("AXP192: Battery ADC enable did NOT take effect!");
+                }
+            }
+        }
     }
-    info!("├────────────────────────────────┤");
-    info!("│  My taps:   {:>4}               │", doc.our_taps());
-    info!("│  Peer taps: {:>4}               │", doc.peer_taps());
-    info!("│  ──────────────                │");
-    info!("│  TOTAL:     {:>4}               │", doc.total_taps());
-    info!("├────────────────────────────────┤");
-    info!("│  TAP SCREEN = +1 (persisted)   │");
-    info!("│  Status: {:<20} │", status);
-    info!("└────────────────────────────────┘");
+
+    if i2c.write_read(AXP192_ADDR, &[0x00], &mut buf, 100).is_ok() {
+        info!("AXP192: Power status=0x{:02X}", buf[0]);
+    }
+    Ok(())
+}
+
+/// Read battery voltage from AXP192 (returns millivolts)
+fn axp192_read_battery_voltage(i2c: &mut I2cDriver) -> Option<u16> {
+    let mut buf = [0u8; 2];
+    // Register 0x78-0x79: Battery voltage ADC (12-bit, 1.1mV/step)
+    // High 8 bits in 0x78, low 4 bits in upper nibble of 0x79
+    if i2c.write_read(AXP192_ADDR, &[0x78], &mut buf, 100).is_ok() {
+        let raw = ((buf[0] as u16) << 4) | ((buf[1] as u16) >> 4);
+        let mv = (raw as u32 * 1100 / 1000) as u16; // 1.1mV per step
+        info!("Battery ADC: raw=0x{:03X} ({}) => {}mV [0x78=0x{:02X}, 0x79=0x{:02X}]",
+              raw, raw, mv, buf[0], buf[1]);
+        Some(mv)
+    } else {
+        None
+    }
+}
+
+/// Estimate battery percentage from voltage (rough approximation)
+fn battery_percent_from_voltage(mv: u16) -> u8 {
+    // M5Stack Core2 battery: 3.7V nominal, ~4.2V full, ~3.0V empty
+    if mv >= 4150 {
+        100
+    } else if mv <= 3000 {
+        0
+    } else {
+        // Linear interpolation between 3.0V and 4.15V
+        ((mv - 3000) as u32 * 100 / 1150) as u8
+    }
+}
+
+/// Check if running on battery (no USB power)
+fn axp192_on_battery(i2c: &mut I2cDriver) -> bool {
+    let mut buf = [0u8; 1];
+    if i2c.write_read(AXP192_ADDR, &[0x00], &mut buf, 100).is_ok() {
+        // Bit 7: ACIN exists, Bit 5: VBUS exists
+        let acin = (buf[0] & 0x80) != 0;
+        let vbus = (buf[0] & 0x20) != 0;
+        !acin && !vbus
+    } else {
+        false
+    }
+}
+
+/// Build number for tracking firmware versions
+const BUILD_NUM: u32 = 11;
+
+/// Draw initial static UI elements (call once at startup)
+fn draw_static_ui<D>(display: &mut D, node_id: u32)
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let _ = display.clear(Rgb565::BLACK);
+
+    let white = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
+    let cyan = MonoTextStyle::new(&FONT_10X20, Rgb565::CYAN);
+
+    // Title with build number
+    let title = format!("HIVE-Lite BLE Sync  b{}", BUILD_NUM);
+    let _ = Text::new(&title, Point::new(30, 25), white).draw(display);
+
+    // Node ID (static)
+    let node_str = format!("Node: {:08X}", node_id);
+    let _ = Text::new(&node_str, Point::new(20, 60), cyan).draw(display);
+
+    // Separators
+    let _ = Rectangle::new(Point::new(10, 75), Size::new(300, 2))
+        .into_styled(PrimitiveStyle::with_fill(Rgb565::CSS_GRAY))
+        .draw(display);
+    let _ = Rectangle::new(Point::new(10, 200), Size::new(300, 2))
+        .into_styled(PrimitiveStyle::with_fill(Rgb565::CSS_GRAY))
+        .draw(display);
+
+    // Static label
+    let _ = Text::new("taps", Point::new(115, 175), cyan).draw(display);
+}
+
+/// Compute a simple hash for visual state comparison
+fn state_hash(doc: &HiveDocument) -> u16 {
+    let encoded = doc.encode();
+    let mut hash: u16 = 0;
+    for byte in &encoded {
+        hash = hash.wrapping_add(*byte as u16);
+        hash = hash.wrapping_mul(31);
+    }
+    hash
+}
+
+/// Update only the dynamic parts of the display (no flicker)
+fn update_display<D>(
+    display: &mut D,
+    doc: &HiveDocument,
+    connected: bool,
+    battery_pct: Option<u8>,
+    status: &str,
+) where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let black = PrimitiveStyle::with_fill(Rgb565::BLACK);
+    let white = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
+    let green = MonoTextStyle::new(&FONT_10X20, Rgb565::GREEN);
+    let yellow = MonoTextStyle::new(&FONT_10X20, Rgb565::YELLOW);
+
+    // Connection indicator (top right) - show number of connections
+    let num_conns = nimble::connection_count();
+    let conn_color = if num_conns > 0 { Rgb565::GREEN } else { Rgb565::RED };
+    let _ = Circle::new(Point::new(280, 10), 20)
+        .into_styled(PrimitiveStyle::with_fill(conn_color))
+        .draw(display);
+    // Show connection count inside circle
+    if num_conns > 0 {
+        let conn_str = format!("{}", num_conns);
+        let black_text = MonoTextStyle::new(&FONT_10X20, Rgb565::BLACK);
+        let _ = Text::new(&conn_str, Point::new(285, 25), black_text).draw(display);
+    }
+
+    // Battery indicator (top left) - clear area then draw
+    // Hide if 0% (ADC not enabled on some modules)
+    let _ = Rectangle::new(Point::new(5, 5), Size::new(45, 25))
+        .into_styled(black)
+        .draw(display);
+    if let Some(pct) = battery_pct {
+        if pct > 0 {
+            let batt_color = if pct > 20 { Rgb565::GREEN } else { Rgb565::RED };
+            let batt_style = MonoTextStyle::new(&FONT_10X20, batt_color);
+            let batt_str = format!("{}%", pct);
+            let _ = Text::new(&batt_str, Point::new(10, 25), batt_style).draw(display);
+        }
+    }
+
+    // Tap count - clear area then draw large total
+    let _ = Rectangle::new(Point::new(30, 90), Size::new(260, 100))
+        .into_styled(black)
+        .draw(display);
+
+    // Large total count - this should be identical on all devices after sync!
+    let total_str = format!("{}", doc.total_taps());
+    let _ = Text::new(&total_str, Point::new(130, 140), green).draw(display);
+
+    // Show state hash and node count for visual convergence check
+    let hash = state_hash(doc);
+    let hash_str = format!("{:04X} v{} n{}", hash, doc.version, doc.num_nodes());
+    let _ = Text::new(&hash_str, Point::new(80, 180), white).draw(display);
+
+    // Status - clear area then draw
+    let _ = Rectangle::new(Point::new(10, 210), Size::new(300, 25))
+        .into_styled(black)
+        .draw(display);
+    let _ = Text::new(status, Point::new(20, 230), yellow).draw(display);
 }
 
 fn main() -> anyhow::Result<()> {
@@ -236,92 +432,247 @@ fn main() -> anyhow::Result<()> {
     esp_idf_svc::sys::link_patches();
     esp_idf_svc::log::EspLogger::initialize_default();
 
+    info!("");
     info!("=========================================");
-    info!("  HIVE-Lite Document Sync Demo");
+    info!("  HIVE-Lite BLE Sync - M5Stack Core2");
     info!("=========================================");
+    info!("");
 
     // Take peripherals
     let peripherals = Peripherals::take()?;
+    info!("Peripherals taken");
+
     let _sys_loop = EspSystemEventLoop::take()?;
+    info!("Event loop taken");
+
     let nvs_partition = EspDefaultNvsPartition::take()?;
+    info!("NVS partition taken");
 
-    // Get unique Node ID from MAC
+    // Get node ID from MAC address
     let node_id = get_node_id_from_mac();
-    info!("Node ID: {:08X}", node_id.as_u32());
+    info!("");
+    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    info!("!!! THIS DEVICE NODE ID: {:08X} !!!", node_id.as_u32());
+    info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+    info!("");
 
-    // Initialize persistent document store
-    let mut store = DocumentStore::new(nvs_partition, node_id)?;
-
-    // Load document from NVS (or create new)
-    let mut doc = store.load();
-    info!("Document loaded: {} total taps", doc.total_taps());
-
-    // Initialize I2C for touch controller
+    // Initialize I2C for touch controller and AXP192
+    info!("Initializing I2C...");
     let i2c_config = I2cConfig::new().baudrate(400.kHz().into());
     let mut i2c = I2cDriver::new(
         peripherals.i2c0,
-        peripherals.pins.gpio21,
-        peripherals.pins.gpio22,
+        peripherals.pins.gpio21, // SDA
+        peripherals.pins.gpio22, // SCL
         &i2c_config,
     )?;
-    info!("Touch controller initialized");
+    info!("I2C initialized");
 
-    // Create HIVE beacon
-    let mut beacon = HiveBeacon::new(node_id);
-    beacon.set_hierarchy_level(HierarchyLevel::Leaf);
-    beacon.set_battery_level(100);
-    info!("HIVE beacon ready: {} bytes", beacon.encode_compact().len());
+    // Initialize AXP192 (enable LCD power/backlight)
+    info!("Initializing AXP192...");
+    if let Err(e) = axp192_init(&mut i2c) {
+        warn!("AXP192 init failed: {:?}", e);
+    }
 
-    // TODO: Initialize NimBLE
-    // - Advertise with beacon + document hash in service data
-    // - Scan for peer HIVE beacons
-    // - On connect: exchange full document, merge, save
+    // Initialize SPI for display
+    info!("Initializing SPI...");
+    // M5Stack Core2: MOSI=23, SCLK=18, CS=5, DC=15
+    let spi_driver = SpiDriver::new(
+        peripherals.spi2,
+        peripherals.pins.gpio18, // SCLK
+        peripherals.pins.gpio23, // MOSI
+        None::<esp_idf_hal::gpio::AnyIOPin>, // MISO not used
+        &SpiDriverConfig::default(),
+    )?;
+    info!("SPI driver created");
 
-    // Initial display
-    let mut status = "Tap screen!";
-    update_display(&doc, None, false, status);
+    let spi_config = SpiConfig::default()
+        .baudrate(26.MHz().into()); // Lower speed for stability
+
+    let spi_device = SpiDeviceDriver::new(
+        spi_driver,
+        Some(peripherals.pins.gpio5), // CS
+        &spi_config,
+    )?;
+    info!("SPI device created");
+
+    let dc = PinDriver::output(peripherals.pins.gpio15)?;
+    info!("DC pin configured");
+
+    let spi_iface = SPIInterface::new(spi_device, dc);
+    info!("SPI interface created");
+
+    // Initialize display (ILI9341 compatible, 320x240)
+    info!("Initializing display...");
+    let mut display = Builder::new(ILI9342CRgb565, spi_iface)
+        .orientation(Orientation::new())
+        .color_order(mipidsi::options::ColorOrder::Bgr)
+        .invert_colors(mipidsi::options::ColorInversion::Inverted)
+        .init(&mut FreeRtos)
+        .map_err(|e| anyhow::anyhow!("Display init failed: {:?}", e))?;
+
+    info!("Display initialized");
+
+    // Clear display to show we're alive
+    let _ = display.clear(Rgb565::BLUE);
+    info!("Display cleared to blue");
+
+    // Initialize document store and load state
+    info!("Initializing document store...");
+    let mut store = DocumentStore::new(nvs_partition)?;
+    let mut doc = store.load(node_id);
+    info!("Loaded document: {} total taps", doc.total_taps());
+
+    // Initialize BLE
+    info!("Initializing BLE...");
+    if let Err(e) = nimble::init(node_id) {
+        error!("Failed to initialize BLE: {}", e);
+        // Continue without BLE for testing
+    }
+
+    // Update BLE with initial document
+    let encoded = doc.encode();
+    nimble::set_document(&encoded);
+
+    info!("All initialization complete!");
+
+    // Read initial battery status
+    let battery_mv = axp192_read_battery_voltage(&mut i2c);
+    let mut battery_pct = battery_mv.map(battery_percent_from_voltage);
+    if let Some(mv) = battery_mv {
+        info!("Battery: {}mV ({}%)", mv, battery_pct.unwrap_or(0));
+    }
+
+    // Draw static UI once, then update dynamic parts
+    draw_static_ui(&mut display, node_id.as_u32());
+    update_display(&mut display, &doc, false, battery_pct, "Tap screen to increment!");
+    print_status(&doc, false, "Tap screen to increment!");
 
     // Main loop
-    let mut last_touch = TouchState::None;
+    let mut last_touch = Touch::None;
     let mut loop_count: u32 = 0;
+    let mut needs_redraw = false;
+    let mut touch_start_time: u32 = 0;  // For long-press detection
+    const LONG_PRESS_MS: u32 = 3000;  // 3 seconds to reset
 
     loop {
-        // Check for touch
         let touch = read_touch(&mut i2c);
+        let connected = nimble::is_connected();
 
-        // Detect rising edge (new touch)
-        if touch == TouchState::Touched && last_touch == TouchState::None {
-            info!(">>> TAP! Incrementing and saving...");
-
-            // Increment counter
-            doc.tap();
-
-            // Persist to NVS immediately
-            if let Err(e) = store.save(&doc) {
-                error!("Failed to save: {:?}", e);
-                status = "Save failed!";
+        // Check for connection state changes
+        if nimble::take_connection_changed() {
+            if connected {
+                info!(">>> PEER CONNECTED!");
             } else {
-                status = "Saved!";
+                info!(">>> PEER DISCONNECTED");
             }
+            needs_redraw = true;
+        }
 
-            update_display(&doc, None, false, status);
+        // Handle touch - detect tap vs long-press
+        let now_ms = unsafe { esp_idf_svc::sys::esp_timer_get_time() as u32 / 1000 };
 
-            // TODO: If connected to peer, trigger sync
+        if touch == Touch::Touched && last_touch == Touch::None {
+            // Touch started
+            touch_start_time = now_ms;
+        } else if touch == Touch::Touched && last_touch == Touch::Touched {
+            // Still touching - check for long press
+            let held_ms = now_ms.saturating_sub(touch_start_time);
+            if held_ms >= LONG_PRESS_MS && touch_start_time != 0 {
+                // Long press detected - RESET counter
+                info!(">>> LONG PRESS - RESETTING COUNTER!");
+                doc = HiveDocument::new(node_id);
+                if let Err(e) = store.save(&doc) {
+                    error!("Failed to save reset: {:?}", e);
+                }
+                let encoded = doc.encode();
+                nimble::set_document(&encoded);
+                touch_start_time = 0; // Prevent repeated resets
+                needs_redraw = true;
+                update_display(&mut display, &doc, connected, battery_pct, "RESET!");
+            }
+        } else if touch == Touch::None && last_touch == Touch::Touched {
+            // Touch released - check if it was a tap (short press)
+            let held_ms = now_ms.saturating_sub(touch_start_time);
+            if held_ms < LONG_PRESS_MS && touch_start_time != 0 {
+                // Short tap - increment
+                doc.tap();
+
+                // Save to NVS
+                if let Err(e) = store.save(&doc) {
+                    error!("Failed to save: {:?}", e);
+                }
+
+                // Gossip to ALL connected peers (multi-hop mesh)
+                let encoded = doc.encode();
+                let sent = nimble::gossip_document(&encoded);
+                info!(">>> Gossiped tap to {} peers", sent);
+
+                needs_redraw = true;
+                print_status(&doc, connected, "Tap saved!");
+            }
         }
         last_touch = touch;
 
-        // Periodic status update
-        if loop_count % 50 == 0 {
-            status = "Tap screen!";
-            update_display(&doc, None, false, status);
+        // Handle pending document from BLE
+        if let Some(data) = nimble::take_pending_document() {
+            info!("");
+            info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+            info!("!!! RECEIVED {} BYTES FROM BLE !!!", data.len());
+            info!("!!! Raw: {:02X?}", &data[..data.len().min(32)]);
+            info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+            if let Some(peer_doc) = HiveDocument::decode(&data) {
+                info!("Decoded peer doc from node {:08X}:", peer_doc.node_id.as_u32());
+                peer_doc.debug_dump("  PEER");
+                if doc.merge(&peer_doc) {
+                    info!(">>> MERGED! New total: {}", doc.total_taps());
+
+                    // Save merged state
+                    if let Err(e) = store.save(&doc) {
+                        error!("Failed to save merged doc: {:?}", e);
+                    }
+
+                    // GOSSIP: Forward merged state to ALL other peers (multi-hop!)
+                    let encoded = doc.encode();
+                    let sent = nimble::gossip_document(&encoded);
+                    info!(">>> Forwarded merged doc to {} peers (multi-hop)", sent);
+
+                    needs_redraw = true;
+                    print_status(&doc, connected, "Merged & forwarded!");
+                } else {
+                    info!("No changes from merge (peer had same or less data)");
+                }
+            } else {
+                warn!("Failed to decode peer document ({} bytes)", data.len());
+            }
         }
 
-        // TODO: BLE sync loop
-        // - Check for new peer connections
-        // - Exchange document state
-        // - Merge and save
+        // Redraw display when needed
+        if needs_redraw {
+            let status = if connected { "Connected!" } else { "Advertising..." };
+            update_display(&mut display, &doc, connected, battery_pct, status);
+            needs_redraw = false;
+        }
 
-        FreeRtos::delay_ms(100);
-        loop_count += 1;
+        // Check if we should rotate to find other peers (mesh behavior)
+        nimble::check_rotation();
+
+        // Periodic status update (every 5 seconds = 100 * 50ms)
+        if loop_count % 100 == 0 {
+            // Update battery reading
+            if let Some(mv) = axp192_read_battery_voltage(&mut i2c) {
+                battery_pct = Some(battery_percent_from_voltage(mv));
+            }
+
+            let status = if connected {
+                "Connected - tap to sync!"
+            } else {
+                "Advertising..."
+            };
+            update_display(&mut display, &doc, connected, battery_pct, status);
+            print_status(&doc, connected, status);
+        }
+
+        FreeRtos::delay_ms(50);
+        loop_count = loop_count.wrapping_add(1);
     }
 }

--- a/examples/m5stack-core2-hive/src/nimble.rs
+++ b/examples/m5stack-core2-hive/src/nimble.rs
@@ -1,0 +1,926 @@
+//! NimBLE BLE wrapper for ESP32
+//!
+//! Provides safe Rust wrappers around ESP-IDF NimBLE APIs for:
+//! - GAP advertising and scanning
+//! - GATT server with custom service
+//! - Document exchange between peers
+
+use core::ffi::{c_int, c_void};
+use core::ptr;
+use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::Mutex;
+
+use esp_idf_svc::sys::*;
+use ::log::{debug, error, info, warn};
+
+/// BLE_HS_FOREVER constant (INT32_MAX - advertise/scan forever)
+const BLE_HS_FOREVER: i32 = i32::MAX;
+
+use hive_btle::NodeId;
+
+/// HIVE Service UUID (16-bit)
+pub const HIVE_SERVICE_UUID: u16 = 0xF47A;
+
+/// Document characteristic UUID (16-bit)
+pub const DOC_CHAR_UUID: u16 = 0xF47B;
+
+/// Maximum document size
+const MAX_DOC_SIZE: usize = 256;
+
+/// Maximum simultaneous connections (for mesh gossip)
+const MAX_CONNECTIONS: usize = 4;
+
+/// Connection info for each peer
+#[derive(Clone, Copy, Default)]
+struct PeerConnection {
+    handle: u16,
+    peer_doc_handle: u16,  // Their document characteristic (for writing)
+    active: bool,
+}
+
+/// Multi-connection state
+static CONNECTIONS: Mutex<[PeerConnection; MAX_CONNECTIONS]> = Mutex::new([PeerConnection { handle: 0xFFFF, peer_doc_handle: 0, active: false }; MAX_CONNECTIONS]);
+static NUM_CONNECTIONS: AtomicU16 = AtomicU16::new(0);
+
+/// Legacy single-connection state (for compatibility)
+static CONNECTED: AtomicBool = AtomicBool::new(false);
+static CONN_HANDLE: AtomicU16 = AtomicU16::new(0xFFFF);
+
+/// Track when we connected (for rotation timeout)
+static CONNECT_TIME: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+/// Sync completed flag
+static SYNC_COMPLETE: AtomicBool = AtomicBool::new(false);
+
+/// Document characteristic value handle (set during registration)
+static DOC_CHAR_HANDLE: AtomicU16 = AtomicU16::new(0);
+
+/// Peer's document characteristic handle (discovered via GATT) - for current discovery
+static PEER_DOC_HANDLE: AtomicU16 = AtomicU16::new(0);
+
+/// Connection currently being discovered
+static DISCOVERING_CONN: AtomicU16 = AtomicU16::new(0xFFFF);
+
+/// Shared document buffer for GATT access
+static DOC_BUFFER: Mutex<[u8; MAX_DOC_SIZE]> = Mutex::new([0u8; MAX_DOC_SIZE]);
+static DOC_LEN: AtomicU16 = AtomicU16::new(0);
+
+/// Pending received document (set by GATT callback, read by main loop)
+static PENDING_DOC: Mutex<Option<Vec<u8>>> = Mutex::new(None);
+
+/// Connection state change flag
+static CONNECTION_CHANGED: AtomicBool = AtomicBool::new(false);
+
+/// Flag to track if we're currently connecting (to avoid multiple connection attempts)
+static CONNECTING: AtomicBool = AtomicBool::new(false);
+
+/// Our MAC address (for connection arbitration - only connect to higher MACs)
+static OUR_MAC: Mutex<[u8; 6]> = Mutex::new([0u8; 6]);
+
+/// Peer sync tracking - MAC address -> last sync timestamp
+/// Max 8 peers tracked
+const MAX_TRACKED_PEERS: usize = 8;
+static PEER_SYNC_TIMES: Mutex<[([u8; 6], u32); MAX_TRACKED_PEERS]> = Mutex::new([([0u8; 6], 0); MAX_TRACKED_PEERS]);
+
+/// Current peer MAC (the one we're connected/connecting to)
+static CURRENT_PEER_MAC: Mutex<[u8; 6]> = Mutex::new([0u8; 6]);
+
+/// Our document version when we last sent (to avoid redundant sends)
+static LAST_SENT_VERSION: AtomicU16 = AtomicU16::new(0);
+
+/// Record when we synced with a peer
+fn record_peer_sync(mac: &[u8; 6], timestamp: u32) {
+    if let Ok(mut peers) = PEER_SYNC_TIMES.lock() {
+        // Find existing entry or oldest slot
+        let mut oldest_idx = 0;
+        let mut oldest_time = u32::MAX;
+        for (i, (peer_mac, sync_time)) in peers.iter().enumerate() {
+            if peer_mac == mac {
+                // Update existing
+                peers[i].1 = timestamp;
+                return;
+            }
+            if *sync_time < oldest_time {
+                oldest_time = *sync_time;
+                oldest_idx = i;
+            }
+        }
+        // Use oldest slot for new peer
+        peers[oldest_idx] = (*mac, timestamp);
+    }
+}
+
+/// Get last sync time for a peer (0 if never synced)
+fn get_peer_last_sync(mac: &[u8; 6]) -> u32 {
+    if let Ok(peers) = PEER_SYNC_TIMES.lock() {
+        for (peer_mac, sync_time) in peers.iter() {
+            if peer_mac == mac {
+                return *sync_time;
+            }
+        }
+    }
+    0
+}
+
+/// Check if advertising data contains HIVE service UUID
+unsafe fn has_hive_service(data: *const u8, len: u8) -> bool {
+    if data.is_null() || len < 4 {
+        return false;
+    }
+
+    let mut i = 0usize;
+    while i < len as usize {
+        let field_len = *data.add(i) as usize;
+        if field_len == 0 || i + field_len >= len as usize {
+            break;
+        }
+        let field_type = *data.add(i + 1);
+
+        // Check for Complete or Incomplete 16-bit Service UUIDs (0x03 or 0x02)
+        if (field_type == 0x02 || field_type == 0x03) && field_len >= 3 {
+            // Parse 16-bit UUIDs
+            let mut j = 2usize;
+            while j + 1 < field_len + 1 {
+                let uuid = u16::from_le_bytes([*data.add(i + j), *data.add(i + j + 1)]);
+                if uuid == HIVE_SERVICE_UUID {
+                    return true;
+                }
+                j += 2;
+            }
+        }
+        i += field_len + 1;
+    }
+    false
+}
+
+/// GAP event callback
+unsafe extern "C" fn gap_event_handler(event: *mut ble_gap_event, _arg: *mut c_void) -> c_int {
+    let event = &*event;
+
+    match event.type_ as u32 {
+        BLE_GAP_EVENT_CONNECT => {
+            let connect = &event.__bindgen_anon_1.connect;
+            CONNECTING.store(false, Ordering::SeqCst);
+            if connect.status == 0 {
+                info!("BLE: Connected, handle={}", connect.conn_handle);
+
+                // Add to multi-connection list
+                if let Ok(mut conns) = CONNECTIONS.lock() {
+                    for conn in conns.iter_mut() {
+                        if !conn.active {
+                            conn.handle = connect.conn_handle;
+                            conn.peer_doc_handle = 0;
+                            conn.active = true;
+                            NUM_CONNECTIONS.fetch_add(1, Ordering::SeqCst);
+                            break;
+                        }
+                    }
+                }
+
+                // Legacy single-connection tracking
+                CONNECTED.store(true, Ordering::SeqCst);
+                CONN_HANDLE.store(connect.conn_handle, Ordering::SeqCst);
+                CONNECTION_CHANGED.store(true, Ordering::SeqCst);
+                SYNC_COMPLETE.store(false, Ordering::SeqCst);
+                CONNECT_TIME.store(esp_idf_svc::sys::esp_timer_get_time() as u32 / 1_000_000, Ordering::SeqCst);
+
+                // Track which connection we're discovering
+                DISCOVERING_CONN.store(connect.conn_handle, Ordering::SeqCst);
+
+                // Request MTU exchange for larger payloads
+                let ret = ble_gattc_exchange_mtu(connect.conn_handle, Some(mtu_exchange_cb), ptr::null_mut());
+                if ret != 0 {
+                    warn!("BLE: MTU exchange failed to start: {}", ret);
+                    let ret = ble_gattc_disc_all_svcs(connect.conn_handle, Some(gatt_disc_svc_cb), ptr::null_mut());
+                    if ret != 0 {
+                        warn!("BLE: Failed to start service discovery: {}", ret);
+                    }
+                }
+
+                // Keep scanning for more peers (mesh!)
+                let _ = start_scanning();
+            } else {
+                warn!("BLE: Connection failed, status={}", connect.status);
+                let _ = start_scanning();
+            }
+        }
+        BLE_GAP_EVENT_DISCONNECT => {
+            let disconnect = &event.__bindgen_anon_1.disconnect;
+            let disc_handle = disconnect.conn.conn_handle;
+            info!("BLE: Disconnected, handle={}", disc_handle);
+
+            // Remove from multi-connection list
+            if let Ok(mut conns) = CONNECTIONS.lock() {
+                for conn in conns.iter_mut() {
+                    if conn.active && conn.handle == disc_handle {
+                        conn.active = false;
+                        conn.handle = 0xFFFF;
+                        conn.peer_doc_handle = 0;
+                        NUM_CONNECTIONS.fetch_sub(1, Ordering::SeqCst);
+                        break;
+                    }
+                }
+            }
+
+            // Update legacy tracking
+            let remaining = NUM_CONNECTIONS.load(Ordering::SeqCst);
+            CONNECTED.store(remaining > 0, Ordering::SeqCst);
+            if remaining == 0 {
+                CONN_HANDLE.store(0xFFFF, Ordering::SeqCst);
+            }
+            CONNECTION_CHANGED.store(true, Ordering::SeqCst);
+            LAST_SENT_VERSION.store(0, Ordering::SeqCst);
+
+            // Keep advertising and scanning
+            let _ = start_advertising();
+            let _ = start_scanning();
+        }
+        BLE_GAP_EVENT_ADV_COMPLETE => {
+            debug!("BLE: Advertising complete");
+            // Restart advertising if not connected
+            if !CONNECTED.load(Ordering::SeqCst) {
+                let _ = start_advertising();
+            }
+        }
+        BLE_GAP_EVENT_DISC => {
+            let disc = &event.__bindgen_anon_1.disc;
+
+            // Check if this device advertises HIVE service
+            if has_hive_service(disc.data, disc.length_data) {
+                // Get peer MAC address
+                let peer_mac = disc.addr.val;
+
+                // Check cooldown - prefer peers we haven't synced with recently
+                let now = esp_idf_svc::sys::esp_timer_get_time() as u32 / 1_000_000;
+                let last_sync = get_peer_last_sync(&peer_mac);
+                let since_sync = now.saturating_sub(last_sync);
+
+                // 30 second cooldown per peer - prevents thrashing
+                let in_cooldown = last_sync > 0 && since_sync < 30;
+
+                if in_cooldown {
+                    debug!("BLE: Peer in cooldown (synced {}s ago)", since_sync);
+                } else if !CONNECTED.load(Ordering::SeqCst) && !CONNECTING.load(Ordering::SeqCst) {
+                    info!("BLE: Found HIVE peer (last sync {}s ago), connecting...", since_sync);
+                    CONNECTING.store(true, Ordering::SeqCst);
+
+                    // Store current peer MAC
+                    if let Ok(mut current) = CURRENT_PEER_MAC.lock() {
+                        *current = peer_mac;
+                    }
+
+                    // Stop scanning before connecting
+                    ble_gap_disc_cancel();
+
+                    let ret = ble_gap_connect(
+                        BLE_OWN_ADDR_PUBLIC as u8,
+                        &disc.addr,
+                        10000, // 10 second timeout
+                        ptr::null(),
+                        Some(gap_event_handler),
+                        ptr::null_mut(),
+                    );
+                    if ret != 0 {
+                        // Error 14 = BLE_HS_EBUSY (already connecting/connected) - not critical
+                        if ret != 14 {
+                            warn!("BLE: ble_gap_connect failed: {}", ret);
+                        }
+                        CONNECTING.store(false, Ordering::SeqCst);
+                        let _ = start_scanning();
+                    }
+                }
+            }
+        }
+        BLE_GAP_EVENT_DISC_COMPLETE => {
+            debug!("BLE: Discovery complete");
+            // Restart scanning if not connected
+            if !CONNECTED.load(Ordering::SeqCst) && !CONNECTING.load(Ordering::SeqCst) {
+                let _ = start_scanning();
+            }
+        }
+        BLE_GAP_EVENT_NOTIFY_RX => {
+            // Received notification from peer
+            let notify = &event.__bindgen_anon_1.notify_rx;
+            info!("BLE: Received notification, attr_handle={}", notify.attr_handle);
+            let om = notify.om;
+            if !om.is_null() {
+                let len = os_mbuf_len(om) as usize;
+                if len > 0 && len <= MAX_DOC_SIZE {
+                    let mut buf = vec![0u8; len];
+                    let ret = os_mbuf_copydata(om, 0, len as i32, buf.as_mut_ptr() as *mut c_void);
+                    if ret == 0 {
+                        info!("BLE: Notification data, {} bytes", len);
+                        if let Ok(mut pending) = PENDING_DOC.lock() {
+                            *pending = Some(buf);
+                        }
+                    }
+                }
+            }
+        }
+        _ => {
+            debug!("BLE: GAP event {}", event.type_);
+        }
+    }
+    0
+}
+
+/// GATT service discovery callback
+unsafe extern "C" fn gatt_disc_svc_cb(
+    conn_handle: u16,
+    error: *const ble_gatt_error,
+    service: *const ble_gatt_svc,
+    _arg: *mut c_void,
+) -> c_int {
+    if error.is_null() {
+        return 0;
+    }
+
+    let err = &*error;
+    if err.status == BLE_HS_EDONE as u16 {
+        // Service discovery complete - now discover characteristics
+        info!("BLE: Service discovery complete, discovering characteristics...");
+        // Discover all characteristics
+        let ret = ble_gattc_disc_all_chrs(
+            conn_handle,
+            1, 0xFFFF, // All handles
+            Some(gatt_disc_chr_cb),
+            ptr::null_mut(),
+        );
+        if ret != 0 {
+            warn!("BLE: Failed to start characteristic discovery: {}", ret);
+        }
+        return 0;
+    }
+
+    if err.status != 0 {
+        warn!("BLE: Service discovery error: {}", err.status);
+        return 0;
+    }
+
+    if !service.is_null() {
+        let svc = &*service;
+        debug!("BLE: Found service, handles {}-{}", svc.start_handle, svc.end_handle);
+    }
+
+    0
+}
+
+/// GATT characteristic discovery callback
+unsafe extern "C" fn gatt_disc_chr_cb(
+    conn_handle: u16,
+    error: *const ble_gatt_error,
+    chr: *const ble_gatt_chr,
+    _arg: *mut c_void,
+) -> c_int {
+    if error.is_null() {
+        return 0;
+    }
+
+    let err = &*error;
+    if err.status == BLE_HS_EDONE as u16 {
+        info!("BLE: Characteristic discovery complete");
+        // Subscribe to notifications first
+        let peer_handle = PEER_DOC_HANDLE.load(Ordering::SeqCst);
+        if peer_handle != 0 {
+            // Subscribe to notifications (CCCD is handle + 1 typically)
+            let cccd_handle = peer_handle + 1;
+            let notify_enable: [u8; 2] = [0x01, 0x00]; // Enable notifications
+            info!("BLE: Subscribing to notifications on handle {}", cccd_handle);
+            let om = ble_hs_mbuf_from_flat(notify_enable.as_ptr() as *const c_void, 2);
+            if !om.is_null() {
+                let ret = ble_gattc_write_flat(conn_handle, cccd_handle, notify_enable.as_ptr() as *const c_void, 2, Some(gatt_write_cb), ptr::null_mut());
+                if ret != 0 {
+                    warn!("BLE: Failed to subscribe to notifications: {}", ret);
+                    os_mbuf_free_chain(om);
+                }
+            }
+
+            // Read the peer's document
+            info!("BLE: Reading peer document from handle {}", peer_handle);
+            let ret = ble_gattc_read(conn_handle, peer_handle, Some(gatt_read_cb), ptr::null_mut());
+            if ret != 0 {
+                warn!("BLE: Failed to read peer document: {}", ret);
+            }
+        }
+        return 0;
+    }
+
+    if err.status != 0 {
+        warn!("BLE: Characteristic discovery error: {}", err.status);
+        return 0;
+    }
+
+    if !chr.is_null() {
+        let c = &*chr;
+        // Check if this is the HIVE document characteristic
+        if c.uuid.u.type_ == BLE_UUID_TYPE_16 as u8 {
+            let uuid16 = &*((&c.uuid) as *const ble_uuid_any_t as *const ble_uuid16_t);
+            if uuid16.value == DOC_CHAR_UUID {
+                info!("BLE: Found HIVE document characteristic, handle={}", c.val_handle);
+                PEER_DOC_HANDLE.store(c.val_handle, Ordering::SeqCst);
+
+                // Store in the connection struct
+                let disc_conn = DISCOVERING_CONN.load(Ordering::SeqCst);
+                if let Ok(mut conns) = CONNECTIONS.lock() {
+                    for conn in conns.iter_mut() {
+                        if conn.active && conn.handle == disc_conn {
+                            conn.peer_doc_handle = c.val_handle;
+                            info!("BLE: Stored peer doc handle {} for conn {}", c.val_handle, disc_conn);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    0
+}
+
+/// MTU exchange callback
+unsafe extern "C" fn mtu_exchange_cb(
+    conn_handle: u16,
+    error: *const ble_gatt_error,
+    mtu: u16,
+    _arg: *mut c_void,
+) -> c_int {
+    if !error.is_null() {
+        let err = &*error;
+        if err.status == 0 {
+            info!("BLE: MTU exchange complete, MTU={}", mtu);
+        } else {
+            warn!("BLE: MTU exchange failed: {}", err.status);
+        }
+    }
+
+    // Now start service discovery regardless of MTU result
+    let ret = ble_gattc_disc_all_svcs(conn_handle, Some(gatt_disc_svc_cb), ptr::null_mut());
+    if ret != 0 {
+        warn!("BLE: Failed to start service discovery after MTU exchange: {}", ret);
+    }
+    0
+}
+
+/// GATT write callback (for subscription confirmation)
+unsafe extern "C" fn gatt_write_cb(
+    _conn_handle: u16,
+    error: *const ble_gatt_error,
+    _attr: *mut ble_gatt_attr,
+    _arg: *mut c_void,
+) -> c_int {
+    if !error.is_null() {
+        let err = &*error;
+        if err.status == 0 {
+            info!("BLE: Subscribed to notifications successfully");
+        } else {
+            warn!("BLE: Subscription failed: {}", err.status);
+        }
+    }
+    0
+}
+
+/// GATT read callback
+unsafe extern "C" fn gatt_read_cb(
+    conn_handle: u16,
+    error: *const ble_gatt_error,
+    attr: *mut ble_gatt_attr,
+    _arg: *mut c_void,
+) -> c_int {
+    if error.is_null() {
+        return 0;
+    }
+
+    let err = &*error;
+    if err.status != 0 {
+        warn!("BLE: Read error: {}", err.status);
+        return 0;
+    }
+
+    if !attr.is_null() {
+        let a = &*attr;
+        let om = a.om;
+        if !om.is_null() {
+            let len = os_mbuf_len(om) as usize;
+            if len > 0 && len <= MAX_DOC_SIZE {
+                let mut buf = vec![0u8; len];
+                let ret = os_mbuf_copydata(om, 0, len as i32, buf.as_mut_ptr() as *mut c_void);
+                if ret == 0 {
+                    info!("BLE: Read peer document, {} bytes", len);
+                    if let Ok(mut pending) = PENDING_DOC.lock() {
+                        *pending = Some(buf);
+                    }
+                }
+            }
+        }
+    }
+
+    // After reading peer's document, write our document to peer (only if we have newer data)
+    let peer_handle = PEER_DOC_HANDLE.load(Ordering::SeqCst);
+    if peer_handle != 0 {
+        if let Ok(doc) = DOC_BUFFER.lock() {
+            let len = DOC_LEN.load(Ordering::SeqCst) as usize;
+            // Get version from our doc (first 4 bytes are version)
+            let our_version = if len >= 4 {
+                u32::from_le_bytes([doc[0], doc[1], doc[2], doc[3]])
+            } else {
+                0
+            };
+            let last_sent = LAST_SENT_VERSION.load(Ordering::SeqCst) as u32;
+
+            if len > 0 && our_version > last_sent {
+                let om = ble_hs_mbuf_from_flat(doc.as_ptr() as *const c_void, len as u16);
+                if !om.is_null() {
+                    info!("BLE: Sending doc v{} to peer ({} bytes)", our_version, len);
+                    let ret = ble_gattc_write_no_rsp(conn_handle, peer_handle, om);
+                    if ret != 0 {
+                        warn!("BLE: Write failed: {}", ret);
+                        os_mbuf_free_chain(om);
+                    } else {
+                        LAST_SENT_VERSION.store(our_version as u16, Ordering::SeqCst);
+                        info!("BLE: Sync complete");
+                        SYNC_COMPLETE.store(true, Ordering::SeqCst);
+                        if let Ok(current) = CURRENT_PEER_MAC.lock() {
+                            let now = esp_idf_svc::sys::esp_timer_get_time() as u32 / 1_000_000;
+                            record_peer_sync(&*current, now);
+                        }
+                    }
+                }
+            } else {
+                // Nothing new to send, but still mark sync complete
+                debug!("BLE: No new data to send (v{} <= last sent v{})", our_version, last_sent);
+                SYNC_COMPLETE.store(true, Ordering::SeqCst);
+                if let Ok(current) = CURRENT_PEER_MAC.lock() {
+                    let now = esp_idf_svc::sys::esp_timer_get_time() as u32 / 1_000_000;
+                    record_peer_sync(&*current, now);
+                }
+            }
+        }
+    }
+
+    0
+}
+
+/// GATT access callback for document characteristic
+unsafe extern "C" fn gatt_access_cb(
+    _conn_handle: u16,
+    _attr_handle: u16,
+    ctxt: *mut ble_gatt_access_ctxt,
+    _arg: *mut c_void,
+) -> c_int {
+    let ctxt = &*ctxt;
+
+    match ctxt.op as u32 {
+        BLE_GATT_ACCESS_OP_READ_CHR => {
+            // Peer is reading our document
+            info!("BLE: GATT read request");
+            if let Ok(doc) = DOC_BUFFER.lock() {
+                let len = DOC_LEN.load(Ordering::SeqCst) as usize;
+                if len > 0 {
+                    os_mbuf_append(ctxt.om, doc.as_ptr() as *const c_void, len as u16);
+                }
+            }
+        }
+        BLE_GATT_ACCESS_OP_WRITE_CHR => {
+            // Peer is sending their document (write from central)
+            info!("BLE: GATT write request received");
+            let om = ctxt.om;
+            if !om.is_null() {
+                // Get total length across all mbuf segments using OS_MBUF_PKTLEN
+                let len = os_mbuf_len(om) as usize;
+                info!("BLE: Write total data length: {}", len);
+                if len > 0 && len <= MAX_DOC_SIZE {
+                    let mut buf = vec![0u8; len];
+                    // Copy all data from mbuf chain
+                    let ret = os_mbuf_copydata(om, 0, len as i32, buf.as_mut_ptr() as *mut c_void);
+                    if ret == 0 {
+                        info!("BLE: Received document via write, {} bytes", len);
+                        // Store in pending queue
+                        if let Ok(mut pending) = PENDING_DOC.lock() {
+                            *pending = Some(buf);
+                        }
+                    } else {
+                        warn!("BLE: Failed to copy mbuf data: {}", ret);
+                    }
+                }
+            } else {
+                warn!("BLE: Write request with null om");
+            }
+        }
+        _ => {}
+    }
+    0
+}
+
+/// GATT service definition (must be static)
+static mut GATT_SVCS: [ble_gatt_svc_def; 2] = unsafe { core::mem::zeroed() };
+static mut GATT_CHARS: [ble_gatt_chr_def; 2] = unsafe { core::mem::zeroed() };
+static mut SVC_UUID: ble_uuid16_t = unsafe { core::mem::zeroed() };
+static mut CHR_UUID: ble_uuid16_t = unsafe { core::mem::zeroed() };
+
+/// Initialize NimBLE stack
+pub fn init(_node_id: NodeId) -> Result<(), i32> {
+    unsafe {
+        info!("BLE: Initializing NimBLE");
+
+        // Store our MAC for connection arbitration
+        let mut mac = [0u8; 6];
+        esp_idf_svc::sys::esp_efuse_mac_get_default(mac.as_mut_ptr());
+        if let Ok(mut our_mac) = OUR_MAC.lock() {
+            *our_mac = mac;
+        }
+        info!("BLE: Our MAC: {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+              mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+        // Initialize NimBLE
+        let ret = nimble_port_init();
+        if ret != ESP_OK {
+            error!("BLE: nimble_port_init failed: {}", ret);
+            return Err(ret);
+        }
+
+        // Configure host
+        ble_hs_cfg.sync_cb = Some(on_sync);
+        ble_hs_cfg.reset_cb = Some(on_reset);
+
+        // Set preferred ATT MTU to 64 bytes (enough for our 24-byte documents + overhead)
+        let ret = ble_att_set_preferred_mtu(64);
+        if ret != 0 {
+            warn!("BLE: Failed to set preferred MTU: {}", ret);
+        } else {
+            info!("BLE: Preferred MTU set to 64");
+        }
+
+        // Set up service UUID
+        SVC_UUID.u.type_ = BLE_UUID_TYPE_16 as u8;
+        SVC_UUID.value = HIVE_SERVICE_UUID;
+
+        // Set up characteristic UUID
+        CHR_UUID.u.type_ = BLE_UUID_TYPE_16 as u8;
+        CHR_UUID.value = DOC_CHAR_UUID;
+
+        // Configure document characteristic
+        GATT_CHARS[0].uuid = &raw const CHR_UUID.u as *const _;
+        GATT_CHARS[0].access_cb = Some(gatt_access_cb);
+        GATT_CHARS[0].flags =
+            (BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_WRITE | BLE_GATT_CHR_F_NOTIFY) as ble_gatt_chr_flags;
+        GATT_CHARS[0].val_handle = &DOC_CHAR_HANDLE as *const _ as *mut u16;
+        // Null terminator
+        GATT_CHARS[1] = core::mem::zeroed();
+
+        // Configure service
+        GATT_SVCS[0].type_ = BLE_GATT_SVC_TYPE_PRIMARY as u8;
+        GATT_SVCS[0].uuid = &raw const SVC_UUID.u as *const _;
+        GATT_SVCS[0].characteristics = &raw const GATT_CHARS as *const _ as *mut _;
+        // Null terminator
+        GATT_SVCS[1] = core::mem::zeroed();
+
+        // Register services
+        let ret = ble_gatts_count_cfg(&raw const GATT_SVCS as *const _);
+        if ret != 0 {
+            error!("BLE: ble_gatts_count_cfg failed: {}", ret);
+            return Err(ret);
+        }
+
+        let ret = ble_gatts_add_svcs(&raw const GATT_SVCS as *const _);
+        if ret != 0 {
+            error!("BLE: ble_gatts_add_svcs failed: {}", ret);
+            return Err(ret);
+        }
+
+        // Start NimBLE task
+        nimble_port_freertos_init(Some(nimble_host_task));
+
+        info!("BLE: NimBLE initialized");
+        Ok(())
+    }
+}
+
+/// NimBLE host task (runs in FreeRTOS)
+unsafe extern "C" fn nimble_host_task(_param: *mut c_void) {
+    info!("BLE: Host task started");
+    nimble_port_run();
+}
+
+/// Called when BLE stack syncs
+unsafe extern "C" fn on_sync() {
+    info!("BLE: Stack synced");
+
+    // Start advertising
+    if let Err(e) = start_advertising() {
+        error!("BLE: Failed to start advertising: {}", e);
+    }
+
+    // Start scanning for peers
+    if let Err(e) = start_scanning() {
+        error!("BLE: Failed to start scanning: {}", e);
+    }
+}
+
+/// Called when BLE stack resets
+unsafe extern "C" fn on_reset(reason: c_int) {
+    warn!("BLE: Stack reset, reason={}", reason);
+}
+
+/// Start BLE advertising
+pub fn start_advertising() -> Result<(), i32> {
+    unsafe {
+        let mut adv_params: ble_gap_adv_params = core::mem::zeroed();
+        adv_params.conn_mode = BLE_GAP_CONN_MODE_UND as u8;
+        adv_params.disc_mode = BLE_GAP_DISC_MODE_GEN as u8;
+        adv_params.itvl_min = 160; // 100ms
+        adv_params.itvl_max = 320; // 200ms
+
+        // Build advertising data
+        let mut fields: ble_hs_adv_fields = core::mem::zeroed();
+        fields.flags = (BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP) as u8;
+        fields.uuids16 = &raw const SVC_UUID as *const _ as *mut ble_uuid16_t;
+        fields.num_uuids16 = 1;
+        fields.set_uuids16_is_complete(1);
+
+        let ret = ble_gap_adv_set_fields(&fields);
+        if ret != 0 {
+            error!("BLE: ble_gap_adv_set_fields failed: {}", ret);
+            return Err(ret);
+        }
+
+        let ret = ble_gap_adv_start(
+            BLE_OWN_ADDR_PUBLIC as u8,
+            ptr::null(),
+            BLE_HS_FOREVER,
+            &adv_params,
+            Some(gap_event_handler),
+            ptr::null_mut(),
+        );
+        if ret != 0 && ret != BLE_HS_EALREADY as i32 {
+            error!("BLE: ble_gap_adv_start failed: {}", ret);
+            return Err(ret);
+        }
+
+        info!("BLE: Advertising started");
+        Ok(())
+    }
+}
+
+/// Start BLE scanning for peers
+pub fn start_scanning() -> Result<(), i32> {
+    unsafe {
+        let mut params: ble_gap_disc_params = core::mem::zeroed();
+        params.itvl = 160; // 100ms
+        params.window = 80; // 50ms
+        params.filter_policy = BLE_HCI_SCAN_FILT_NO_WL as u8;
+        params.set_limited(0);
+        params.set_passive(0);
+        params.set_filter_duplicates(1);
+
+        let ret = ble_gap_disc(
+            BLE_OWN_ADDR_PUBLIC as u8,
+            10000, // 10 seconds
+            &params,
+            Some(gap_event_handler),
+            ptr::null_mut(),
+        );
+        if ret != 0 && ret != 2 {
+            // Ignore error 2 (BLE_HS_EALREADY - already scanning)
+            error!("BLE: ble_gap_disc failed: {}", ret);
+            return Err(ret);
+        }
+
+        info!("BLE: Scanning started");
+        Ok(())
+    }
+}
+
+/// Update local document (for GATT reads)
+pub fn set_document(data: &[u8]) {
+    if data.len() <= MAX_DOC_SIZE {
+        if let Ok(mut doc) = DOC_BUFFER.lock() {
+            doc[..data.len()].copy_from_slice(data);
+            DOC_LEN.store(data.len() as u16, Ordering::SeqCst);
+        }
+    }
+}
+
+/// Send document to connected peer via notification (as peripheral) and write (as central)
+pub fn notify_document(data: &[u8]) -> Result<(), i32> {
+    let conn = CONN_HANDLE.load(Ordering::SeqCst);
+    if conn == 0xFFFF {
+        info!("BLE: notify_document - not connected");
+        return Err(-1); // Not connected
+    }
+
+    // Update local buffer first
+    set_document(data);
+
+    let our_handle = DOC_CHAR_HANDLE.load(Ordering::SeqCst);
+    let peer_handle = PEER_DOC_HANDLE.load(Ordering::SeqCst);
+    info!("BLE: notify_document - conn={}, our_handle={}, peer_handle={}, len={}",
+          conn, our_handle, peer_handle, data.len());
+
+    // Try to notify (works if we're the peripheral)
+    if our_handle != 0 {
+        unsafe {
+            let ret = ble_gatts_notify(conn, our_handle);
+            if ret == 0 {
+                info!("BLE: Notified via GATT");
+            } else {
+                warn!("BLE: Notify failed: {}", ret);
+            }
+        }
+    }
+
+    // Also write to peer (works if we're the central and discovered their characteristic)
+    if peer_handle != 0 {
+        unsafe {
+            let om = ble_hs_mbuf_from_flat(data.as_ptr() as *const c_void, data.len() as u16);
+            if !om.is_null() {
+                let ret = ble_gattc_write_no_rsp(conn, peer_handle, om);
+                if ret == 0 {
+                    info!("BLE: Wrote to peer via GATT");
+                } else {
+                    warn!("BLE: Write to peer failed: {}", ret);
+                    os_mbuf_free_chain(om);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Take pending received document (returns None if no document waiting)
+pub fn take_pending_document() -> Option<Vec<u8>> {
+    if let Ok(mut pending) = PENDING_DOC.lock() {
+        pending.take()
+    } else {
+        None
+    }
+}
+
+/// Check if connection state changed (and clear the flag)
+pub fn take_connection_changed() -> bool {
+    CONNECTION_CHANGED.swap(false, Ordering::SeqCst)
+}
+
+/// Check if connected to a peer
+pub fn is_connected() -> bool {
+    CONNECTED.load(Ordering::SeqCst)
+}
+
+/// Check if we should rotate to find other peers (call this periodically)
+pub fn check_rotation() -> bool {
+    false // No rotation needed - using multi-connection gossip instead
+}
+
+/// Gossip document to ALL connected peers (multi-hop mesh sync)
+pub fn gossip_document(data: &[u8]) -> usize {
+    let mut sent_count = 0;
+
+    // Update local buffer
+    set_document(data);
+
+    // Send via notification to all peers (we're peripheral)
+    let our_handle = DOC_CHAR_HANDLE.load(Ordering::SeqCst);
+    if our_handle != 0 {
+        if let Ok(conns) = CONNECTIONS.lock() {
+            for conn in conns.iter() {
+                if conn.active {
+                    unsafe {
+                        let ret = ble_gatts_notify(conn.handle, our_handle);
+                        if ret == 0 {
+                            info!("BLE: Gossiped via notify to conn {}", conn.handle);
+                            sent_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Also write to peers where we're the central
+    if let Ok(conns) = CONNECTIONS.lock() {
+        for conn in conns.iter() {
+            if conn.active && conn.peer_doc_handle != 0 {
+                unsafe {
+                    let om = ble_hs_mbuf_from_flat(data.as_ptr() as *const c_void, data.len() as u16);
+                    if !om.is_null() {
+                        let ret = ble_gattc_write_no_rsp(conn.handle, conn.peer_doc_handle, om);
+                        if ret == 0 {
+                            info!("BLE: Gossiped via write to conn {} handle {}", conn.handle, conn.peer_doc_handle);
+                            sent_count += 1;
+                        } else {
+                            os_mbuf_free_chain(om);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    info!("BLE: Gossiped to {} peers", sent_count);
+    sent_count
+}
+
+/// Get number of active connections
+pub fn connection_count() -> usize {
+    NUM_CONNECTIONS.load(Ordering::SeqCst) as usize
+}


### PR DESCRIPTION
## Summary
- Implements true mesh sync between 3+ M5Stack Core2 devices using gossip-based document forwarding
- Multi-connection BLE support (up to 4 simultaneous peers)
- When a device receives CRDT data, it forwards to all other connected peers for multi-hop propagation
- Added Makefile for parallel flashing all devices (`make flash-all`)

## Key Features
- **NimBLE Wrapper** (`nimble.rs`): Complete BLE GAP/GATT implementation for ESP32
- **Gossip Protocol**: `gossip_document()` forwards merged CRDT state to ALL connected peers
- **Multi-Connection**: Devices continue scanning after connecting to build mesh topology
- **Debug Tools**: State hash, node count, and detailed merge logging for troubleshooting
- **UX**: Long-press reset, build number display, connection count indicator

## How Multi-Hop Works
```
A taps → gossips to B → B merges → B forwards to C → C merges
Result: All 3 devices converge to same CRDT state
```

## Test plan
- [ ] Flash all 3 M5Stack Core2 devices with `make flash-all`
- [ ] Long-press each device (3 sec) to reset counters
- [ ] Wait for connections (number shown in green circle)
- [ ] Tap on one device
- [ ] Verify all 3 devices converge to same total, hash, and node count (n)

🤖 Generated with [Claude Code](https://claude.com/claude-code)