### PR TITLE
fix(sync): Reset SyncState on convergence to prevent accumulation (Issue #435)

### DIFF
--- a/hive-protocol/src/storage/automerge_sync.rs
+++ b/hive-protocol/src/storage/automerge_sync.rs
@@ -998,8 +998,12 @@ impl AutomergeSyncCoordinator {
             self.send_sync_message_for_doc(peer_id, doc_key, &response)
                 .await?;
         } else {
-            // Store sync state even if no response needed
-            self.update_sync_state(doc_key, peer_id, sync_state);
+            // Sync converged - reset state to prevent memory accumulation (Issue #435)
+            // Only preserve shared_heads (what both peers have), discard session data
+            // like sent_hashes which accumulates unboundedly during sync rounds.
+            let mut fresh_state = SyncState::new();
+            fresh_state.shared_heads = sync_state.shared_heads;
+            self.update_sync_state(doc_key, peer_id, fresh_state);
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Fixes remaining memory growth (~0.2 MiB/s) from Automerge SyncState accumulation identified in Issue #435 investigation.

## Problem

Automerge's `SyncState` contains a `sent_hashes: BTreeSet<ChangeHash>` field that grows with every change hash sent during a session. When sync converges, we were storing the full accumulated state instead of resetting it.

## Solution

When `generate_sync_message()` returns `None` (sync converged), reset the SyncState to only preserve `shared_heads`:

```rust
// Before: stored accumulated state
} else {
    self.update_sync_state(doc_key, peer_id, sync_state);
}

// After: reset, only preserve shared_heads
} else {
    let mut fresh_state = SyncState::new();
    fresh_state.shared_heads = sync_state.shared_heads;
    self.update_sync_state(doc_key, peer_id, fresh_state);
}
```

This is the proper fix - clearing state at protocol convergence rather than periodic garbage collection.

## Test plan

- [x] All unit tests passing
- [x] Sync E2E tests passing
- [ ] Memory profiling to verify reduced growth

Related: #435, #442, #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)