### PR TITLE
fix(storage): Configure redb cache size to reduce memory growth (Issue #446)

### DIFF
--- a/hive-protocol/src/storage/automerge_store.rs
+++ b/hive-protocol/src/storage/automerge_store.rs
@@ -11,7 +11,7 @@ use automerge::{transaction::Transactable, Automerge, ReadDoc};
 #[cfg(feature = "automerge-backend")]
 use lru::LruCache;
 #[cfg(feature = "automerge-backend")]
-use redb::{Database, ReadableTable, ReadableTableMetadata, TableDefinition};
+use redb::{Builder, Database, ReadableTable, ReadableTableMetadata, TableDefinition};
 #[cfg(feature = "automerge-backend")]
 use std::num::NonZeroUsize;
 #[cfg(feature = "automerge-backend")]
@@ -29,6 +29,16 @@ use anyhow::{Context, Result};
 /// Value: serialized Automerge document bytes
 #[cfg(feature = "automerge-backend")]
 const DOCUMENTS_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("documents");
+
+/// Default redb cache size in bytes (Issue #446)
+///
+/// The redb default is 1 GiB which is excessive for our use case.
+/// We set a much smaller default (16 MiB) that's sufficient for typical
+/// document storage while preventing unbounded memory growth.
+///
+/// Can be overridden via `CAP_REDB_CACHE_SIZE` environment variable (in bytes).
+#[cfg(feature = "automerge-backend")]
+const DEFAULT_REDB_CACHE_SIZE: usize = 16 * 1024 * 1024; // 16 MiB
 
 /// Table definition for tombstone storage (ADR-034 Phase 2)
 /// Key: "collection:document_id" as string bytes
@@ -90,7 +100,20 @@ impl AutomergeStore {
             }
         }
 
-        let db = Database::create(&db_path).context("Failed to open redb database")?;
+        // Configure redb cache size (Issue #446)
+        // Default redb cache is 1 GiB which causes excessive memory growth.
+        // Use a smaller cache (default 16 MiB) or allow override via environment variable.
+        let cache_size = std::env::var("CAP_REDB_CACHE_SIZE")
+            .ok()
+            .and_then(|s| s.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_REDB_CACHE_SIZE);
+
+        tracing::debug!("Opening redb database with cache_size={} bytes", cache_size);
+
+        let db = Builder::new()
+            .set_cache_size(cache_size)
+            .create(&db_path)
+            .context("Failed to open redb database")?;
 
         // Initialize the tables (redb requires this on first use)
         {


### PR DESCRIPTION
## Summary
- Configures redb database cache size to 16 MiB (down from default 1 GiB)
- Adds `CAP_REDB_CACHE_SIZE` environment variable for runtime configuration
- Addresses memory growth from redb page cache allocation

## Root Cause
The redb embedded database defaults to a **1 GiB cache**, which is excessive for our use case where total document storage is typically ~60 KB. Heaptrack profiling showed 5.11M peak memory from `redb::BuddyAllocator::new`.

## Changes
- Import `Builder` from redb
- Use `Builder::new().set_cache_size(cache_size).create()` instead of `Database::create()`
- Add `DEFAULT_REDB_CACHE_SIZE` constant (16 MiB)
- Add `CAP_REDB_CACHE_SIZE` environment variable support

## Configuration
```bash
# Default: 16 MiB
export CAP_REDB_CACHE_SIZE=8388608   # 8 MiB for constrained environments
export CAP_REDB_CACHE_SIZE=33554432  # 32 MiB for larger workloads
```

## Test plan
- [x] All 13 automerge_store unit tests passing
- [x] Pre-commit checks (fmt, clippy) passing
- [ ] Lab testing to verify memory reduction

Fixes: #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)