### PR TITLE
fix(storage): Upgrade redb to 3.1 for improved memory management (Issue #446)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3132,7 +3132,7 @@ dependencies = [
  "quick-xml",
  "rand 0.9.2",
  "rand_core 0.6.4",
- "redb",
+ "redb 3.1.0",
  "serde",
  "serde_json",
  "serial_test",
@@ -3810,7 +3810,7 @@ dependencies = [
  "postcard",
  "rand 0.9.2",
  "range-collections",
- "redb",
+ "redb 2.6.3",
  "ref-cast",
  "reflink-copy",
  "self_cell",
@@ -5762,6 +5762,15 @@ name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "redb"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae323eb086579a3769daa2c753bb96deb95993c534711e0dbe881b5192906a06"
 dependencies = [
  "libc",
 ]

--- a/hive-protocol/Cargo.toml
+++ b/hive-protocol/Cargo.toml
@@ -46,7 +46,7 @@ automerge = { version = "0.7.1", optional = true }  # Automerge CRDT library for
 # AutomergeIrohBackend dependencies (ADR-011)
 iroh = { version = "0.95", optional = true, features = ["discovery-local-network"] }  # QUIC-based P2P networking with local mDNS discovery
 iroh-blobs = { version = "0.97", optional = true }  # Content-addressed blob storage (ADR-025)
-redb = { version = "2.4", optional = true }  # Pure Rust embedded database (replaces RocksDB)
+redb = { version = "3.1", optional = true }  # Pure Rust embedded database - v3 has improved GC (Issue #446)
 lru = { version = "0.12", optional = true }  # LRU cache for hot documents
 toml = { version = "0.8", optional = true }  # Static peer configuration
 hex = "0.4"  # Hex encoding for PublicKeys and encryption keys

--- a/hive-protocol/src/storage/automerge_store.rs
+++ b/hive-protocol/src/storage/automerge_store.rs
@@ -11,7 +11,9 @@ use automerge::{transaction::Transactable, Automerge, ReadDoc};
 #[cfg(feature = "automerge-backend")]
 use lru::LruCache;
 #[cfg(feature = "automerge-backend")]
-use redb::{Builder, Database, ReadableTable, ReadableTableMetadata, TableDefinition};
+use redb::{
+    Builder, Database, ReadableDatabase, ReadableTable, ReadableTableMetadata, TableDefinition,
+};
 #[cfg(feature = "automerge-backend")]
 use std::num::NonZeroUsize;
 #[cfg(feature = "automerge-backend")]

--- a/hive-protocol/src/storage/sync_persistence.rs
+++ b/hive-protocol/src/storage/sync_persistence.rs
@@ -19,7 +19,7 @@ use automerge::sync::State as SyncState;
 #[cfg(feature = "automerge-backend")]
 use iroh::EndpointId;
 #[cfg(feature = "automerge-backend")]
-use redb::{Database, TableDefinition};
+use redb::{Database, ReadableDatabase, TableDefinition};
 #[cfg(feature = "automerge-backend")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "automerge-backend")]


### PR DESCRIPTION
## Summary
- Upgrades redb from 2.4 to 3.1 for improved memory management
- Adds `ReadableDatabase` trait import required by new API

## redb 3.0 Improvements
- **Garbage collection** for non-durable transactions (addresses database file growth)
- **RAM usage** proportional to net database changes, capped at ~0.2% of DB file size
- **15% performance improvement** for bulk loads
- **Reduced minimum file size** from 2.5 MiB to 50 KiB

## API Changes
```rust
// redb 3.x moves begin_read() to a trait
use redb::{Database, ReadableDatabase, ...};
```

## Files Changed
- `hive-protocol/Cargo.toml` - redb version 2.4 → 3.1
- `hive-protocol/src/storage/automerge_store.rs` - import `ReadableDatabase`
- `hive-protocol/src/storage/sync_persistence.rs` - import `ReadableDatabase`

## Test plan
- [x] All 13 automerge_store unit tests passing
- [x] All 1343 lib tests passing
- [x] Pre-commit checks (fmt, clippy) passing
- [ ] Lab testing to verify memory reduction

Combined with PR #448 (16 MiB cache limit), this should further reduce
memory growth from redb page cache allocation.

Fixes: #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)