### PR TITLE
feat(hive-btle): Scaffold iOS/macOS CoreBluetooth implementation (Issue #411)

### DIFF
--- a/hive-btle/src/platform/apple.rs
+++ b/hive-btle/src/platform/apple.rs
@@ -1,6 +1,0 @@
-//! Apple platform implementation (placeholder)
-//!
-//! This module will provide macOS/iOS-specific BLE functionality via CoreBluetooth.
-//! To be implemented in Phase 5.
-
-// Placeholder for Apple (macOS/iOS) implementation

--- a/hive-btle/src/platform/apple/adapter.rs
+++ b/hive-btle/src/platform/apple/adapter.rs
@@ -1,0 +1,424 @@
+//! CoreBluetooth BLE adapter implementation
+//!
+//! This module provides the `CoreBluetoothAdapter` which implements `BleAdapter`
+//! using CoreBluetooth framework for iOS and macOS.
+
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use crate::config::{BleConfig, BlePhy, DiscoveryConfig};
+use crate::error::{BleError, Result};
+use crate::platform::{
+    BleAdapter, ConnectionCallback, ConnectionEvent, DisconnectReason, DiscoveredDevice,
+    DiscoveryCallback,
+};
+use crate::transport::BleConnection;
+use crate::NodeId;
+
+use super::central::CentralManager;
+use super::connection::CoreBluetoothConnection;
+use super::delegates::CentralState;
+use super::peripheral::PeripheralManager;
+
+/// Internal state for the adapter
+struct AdapterState {
+    /// Active connections by node ID
+    connections: HashMap<NodeId, CoreBluetoothConnection>,
+    /// Peripheral identifier to node ID mapping
+    identifier_to_node: HashMap<String, NodeId>,
+    /// Node ID to peripheral identifier mapping
+    node_to_identifier: HashMap<NodeId, String>,
+}
+
+impl Default for AdapterState {
+    fn default() -> Self {
+        Self {
+            connections: HashMap::new(),
+            identifier_to_node: HashMap::new(),
+            node_to_identifier: HashMap::new(),
+        }
+    }
+}
+
+/// CoreBluetooth BLE adapter for iOS and macOS
+///
+/// Implements the `BleAdapter` trait using CoreBluetooth framework.
+/// Works on both iOS (13.0+) and macOS (10.15+).
+///
+/// # Architecture
+///
+/// The adapter manages both central and peripheral roles:
+/// - **CentralManager**: Scanning for devices, connecting as GATT client
+/// - **PeripheralManager**: Advertising, hosting GATT server
+///
+/// # iOS Background Execution
+///
+/// For iOS apps, ensure Info.plist includes:
+/// ```xml
+/// <key>UIBackgroundModes</key>
+/// <array>
+///     <string>bluetooth-central</string>
+///     <string>bluetooth-peripheral</string>
+/// </array>
+/// ```
+///
+/// # Example
+///
+/// ```ignore
+/// let config = BleConfig::new(NodeId::new(0x12345678));
+/// let mut adapter = CoreBluetoothAdapter::new()?;
+/// adapter.init(&config).await?;
+/// adapter.start().await?;
+/// ```
+pub struct CoreBluetoothAdapter {
+    /// Central manager for scanning and connecting
+    central: Arc<CentralManager>,
+    /// Peripheral manager for advertising and GATT server
+    peripheral: Arc<PeripheralManager>,
+    /// Configuration
+    config: RwLock<Option<BleConfig>>,
+    /// Internal state
+    state: RwLock<AdapterState>,
+    /// Discovery callback
+    discovery_callback: RwLock<Option<DiscoveryCallback>>,
+    /// Connection callback
+    connection_callback: RwLock<Option<ConnectionCallback>>,
+}
+
+impl CoreBluetoothAdapter {
+    /// Create a new CoreBluetooth adapter
+    ///
+    /// This initializes both CBCentralManager and CBPeripheralManager.
+    /// The adapters won't be ready until Bluetooth is powered on.
+    pub fn new() -> Result<Self> {
+        let central = Arc::new(CentralManager::new()?);
+        let peripheral = Arc::new(PeripheralManager::new()?);
+
+        log::info!("CoreBluetoothAdapter created");
+
+        Ok(Self {
+            central,
+            peripheral,
+            config: RwLock::new(None),
+            state: RwLock::new(AdapterState::default()),
+            discovery_callback: RwLock::new(None),
+            connection_callback: RwLock::new(None),
+        })
+    }
+
+    /// Register node ID to peripheral identifier mapping
+    pub async fn register_node_identifier(&self, node_id: NodeId, identifier: String) {
+        let mut state = self.state.write().await;
+        state
+            .identifier_to_node
+            .insert(identifier.clone(), node_id.clone());
+        state.node_to_identifier.insert(node_id, identifier);
+    }
+
+    /// Get peripheral identifier for a node ID
+    pub async fn get_node_identifier(&self, node_id: &NodeId) -> Option<String> {
+        let state = self.state.read().await;
+        state.node_to_identifier.get(node_id).cloned()
+    }
+
+    /// Get node ID for a peripheral identifier
+    pub async fn get_identifier_node(&self, identifier: &str) -> Option<NodeId> {
+        let state = self.state.read().await;
+        state.identifier_to_node.get(identifier).cloned()
+    }
+
+    /// Process events from central and peripheral managers
+    async fn process_events(&self) -> Result<()> {
+        self.central.process_events().await?;
+        self.peripheral.process_events().await?;
+
+        // Check for discovered HIVE nodes and invoke callback
+        let hive_peripherals = self.central.get_hive_peripherals().await;
+        if let Some(ref callback) = *self.discovery_callback.read().await {
+            for peripheral in hive_peripherals {
+                // Register the mapping if we have a node ID
+                if let Some(node_id) = &peripheral.node_id {
+                    self.register_node_identifier(node_id.clone(), peripheral.identifier.clone())
+                        .await;
+                }
+
+                let device = DiscoveredDevice {
+                    address: peripheral.identifier.clone(),
+                    name: peripheral.name.clone(),
+                    rssi: peripheral.rssi,
+                    is_hive_node: peripheral.is_hive_node,
+                    node_id: peripheral.node_id.clone(),
+                    adv_data: Vec::new(),
+                };
+
+                callback(device);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl BleAdapter for CoreBluetoothAdapter {
+    async fn init(&mut self, config: &BleConfig) -> Result<()> {
+        // Store config
+        *self.config.write().await = Some(config.clone());
+
+        // Wait for both managers to be ready
+        // Note: In actual implementation, this would poll until state is PoweredOn
+        let central_state = self.central.state().await;
+        let peripheral_state = self.peripheral.state().await;
+
+        log::info!(
+            "CoreBluetoothAdapter initialized for node {:08X} (central: {:?}, peripheral: {:?})",
+            config.node_id.as_u32(),
+            central_state,
+            peripheral_state
+        );
+
+        Ok(())
+    }
+
+    async fn start(&self) -> Result<()> {
+        let config = self.config.read().await;
+        let config = config
+            .as_ref()
+            .ok_or_else(|| BleError::InvalidState("Adapter not initialized".to_string()))?;
+
+        // Register HIVE GATT service
+        if let Err(e) = self
+            .peripheral
+            .register_hive_service(config.node_id.clone())
+            .await
+        {
+            log::warn!("Failed to register HIVE service: {}", e);
+        }
+
+        // Start advertising
+        if let Err(e) = self
+            .peripheral
+            .start_advertising(config.node_id.clone(), &config.discovery)
+            .await
+        {
+            log::warn!("Failed to start advertising: {}", e);
+        }
+
+        // Start scanning
+        if let Err(e) = self.central.start_scan(&config.discovery, None).await {
+            log::warn!("Failed to start scanning: {}", e);
+        }
+
+        log::info!("CoreBluetoothAdapter started");
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        // Stop scanning
+        self.central.stop_scan().await?;
+
+        // Stop advertising
+        self.peripheral.stop_advertising().await?;
+
+        // Unregister services
+        self.peripheral.unregister_all_services().await?;
+
+        log::info!("CoreBluetoothAdapter stopped");
+        Ok(())
+    }
+
+    fn is_powered(&self) -> bool {
+        // Check central manager state synchronously
+        // In real implementation, would need to cache last known state
+        true // Placeholder
+    }
+
+    fn address(&self) -> Option<String> {
+        // CoreBluetooth doesn't expose the local Bluetooth address
+        // for privacy reasons (iOS) or API limitations (macOS)
+        None
+    }
+
+    async fn start_scan(&self, config: &DiscoveryConfig) -> Result<()> {
+        // Scan for HIVE service UUID
+        let service_uuids = Some(vec![crate::HIVE_SERVICE_UUID.to_string()]);
+        self.central.start_scan(config, service_uuids).await
+    }
+
+    async fn stop_scan(&self) -> Result<()> {
+        self.central.stop_scan().await
+    }
+
+    async fn start_advertising(&self, config: &DiscoveryConfig) -> Result<()> {
+        let ble_config = self.config.read().await;
+        let ble_config = ble_config
+            .as_ref()
+            .ok_or_else(|| BleError::InvalidState("Adapter not initialized".to_string()))?;
+
+        self.peripheral
+            .start_advertising(ble_config.node_id.clone(), config)
+            .await
+    }
+
+    async fn stop_advertising(&self) -> Result<()> {
+        self.peripheral.stop_advertising().await
+    }
+
+    fn set_discovery_callback(&mut self, callback: Option<DiscoveryCallback>) {
+        if let Ok(mut cb) = self.discovery_callback.try_write() {
+            *cb = callback;
+        }
+    }
+
+    async fn connect(&self, peer_id: &NodeId) -> Result<Box<dyn BleConnection>> {
+        // Look up the peripheral identifier for this node ID
+        let identifier = self
+            .get_node_identifier(peer_id)
+            .await
+            .ok_or_else(|| BleError::ConnectionFailed(format!("Unknown node ID: {}", peer_id)))?;
+
+        // Connect via central manager
+        self.central.connect(&identifier).await?;
+
+        // Create connection wrapper
+        let connection = CoreBluetoothConnection::new(peer_id.clone(), identifier.clone());
+
+        // Store connection
+        {
+            let mut state = self.state.write().await;
+            state
+                .connections
+                .insert(peer_id.clone(), connection.clone());
+        }
+
+        // Notify callback
+        if let Some(ref cb) = *self.connection_callback.read().await {
+            cb(
+                peer_id.clone(),
+                ConnectionEvent::Connected {
+                    mtu: connection.mtu(),
+                    phy: connection.phy(),
+                },
+            );
+        }
+
+        log::info!("Connected to peer {} ({})", peer_id, identifier);
+        Ok(Box::new(connection))
+    }
+
+    async fn disconnect(&self, peer_id: &NodeId) -> Result<()> {
+        let (connection, identifier) = {
+            let mut state = self.state.write().await;
+            let conn = state.connections.remove(peer_id);
+            let id = state.node_to_identifier.get(peer_id).cloned();
+            (conn, id)
+        };
+
+        if let Some(identifier) = identifier {
+            self.central.disconnect(&identifier).await?;
+        }
+
+        if connection.is_some() {
+            // Notify callback
+            if let Some(ref cb) = *self.connection_callback.read().await {
+                cb(
+                    peer_id.clone(),
+                    ConnectionEvent::Disconnected {
+                        reason: DisconnectReason::LocalRequest,
+                    },
+                );
+            }
+
+            log::info!("Disconnected from peer {}", peer_id);
+        }
+
+        Ok(())
+    }
+
+    fn get_connection(&self, peer_id: &NodeId) -> Option<Box<dyn BleConnection>> {
+        if let Ok(state) = self.state.try_read() {
+            state
+                .connections
+                .get(peer_id)
+                .map(|c| Box::new(c.clone()) as Box<dyn BleConnection>)
+        } else {
+            None
+        }
+    }
+
+    fn peer_count(&self) -> usize {
+        if let Ok(state) = self.state.try_read() {
+            state.connections.len()
+        } else {
+            0
+        }
+    }
+
+    fn connected_peers(&self) -> Vec<NodeId> {
+        if let Ok(state) = self.state.try_read() {
+            state.connections.keys().cloned().collect()
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn set_connection_callback(&mut self, callback: Option<ConnectionCallback>) {
+        if let Ok(mut cb) = self.connection_callback.try_write() {
+            *cb = callback;
+        }
+    }
+
+    async fn register_gatt_service(&self) -> Result<()> {
+        let config = self.config.read().await;
+        let config = config
+            .as_ref()
+            .ok_or_else(|| BleError::InvalidState("Adapter not initialized".to_string()))?;
+
+        self.peripheral
+            .register_hive_service(config.node_id.clone())
+            .await
+    }
+
+    async fn unregister_gatt_service(&self) -> Result<()> {
+        self.peripheral.unregister_all_services().await
+    }
+
+    fn supports_coded_phy(&self) -> bool {
+        // CoreBluetooth doesn't expose Coded PHY selection
+        // It's handled automatically by the system
+        false
+    }
+
+    fn supports_extended_advertising(&self) -> bool {
+        // CoreBluetooth doesn't expose extended advertising
+        false
+    }
+
+    fn max_mtu(&self) -> u16 {
+        // iOS/macOS typically support up to 512 bytes MTU
+        // Actual negotiated MTU depends on the remote device
+        512
+    }
+
+    fn max_connections(&self) -> u8 {
+        // iOS/macOS limit varies by device
+        // Typically 8-10 simultaneous connections
+        8
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // CoreBluetooth tests require actual Apple hardware
+    // They should be run on iOS Simulator or macOS
+
+    #[test]
+    fn test_adapter_state_default() {
+        use super::AdapterState;
+        let state = AdapterState::default();
+        assert!(state.connections.is_empty());
+        assert!(state.identifier_to_node.is_empty());
+    }
+}

--- a/hive-btle/src/platform/apple/central.rs
+++ b/hive-btle/src/platform/apple/central.rs
@@ -1,0 +1,318 @@
+//! CBCentralManager wrapper
+//!
+//! This module provides a Rust wrapper around CoreBluetooth's CBCentralManager,
+//! which is used for scanning and connecting to BLE peripherals (GATT client role).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+
+use crate::config::DiscoveryConfig;
+use crate::error::{BleError, Result};
+use crate::NodeId;
+
+use super::delegates::{CentralDelegate, CentralEvent, CentralState};
+
+/// Wrapper around CBCentralManager for BLE scanning and connecting
+///
+/// CBCentralManager is the central role in CoreBluetooth, used to:
+/// - Scan for BLE peripherals
+/// - Connect to peripherals
+/// - Discover services and characteristics
+/// - Read/write characteristic values
+pub struct CentralManager {
+    /// Current state of the central manager
+    state: Arc<RwLock<CentralState>>,
+    /// Channel receiver for delegate events
+    event_rx: Arc<RwLock<mpsc::Receiver<CentralEvent>>>,
+    /// Delegate instance (must be kept alive)
+    delegate: Arc<CentralDelegate>,
+    /// Known peripherals by identifier
+    peripherals: Arc<RwLock<HashMap<String, PeripheralInfo>>>,
+    /// Whether scanning is active
+    scanning: Arc<RwLock<bool>>,
+}
+
+/// Information about a discovered peripheral
+#[derive(Debug, Clone)]
+pub struct PeripheralInfo {
+    /// Peripheral identifier (UUID)
+    pub identifier: String,
+    /// Advertised name
+    pub name: Option<String>,
+    /// Last seen RSSI
+    pub rssi: i8,
+    /// Is this a HIVE node
+    pub is_hive_node: bool,
+    /// Node ID if HIVE node
+    pub node_id: Option<NodeId>,
+    /// Whether currently connected
+    pub connected: bool,
+}
+
+impl CentralManager {
+    /// Create a new CentralManager
+    ///
+    /// This initializes the CBCentralManager with default options.
+    /// The manager won't be ready until `state` becomes `PoweredOn`.
+    pub fn new() -> Result<Self> {
+        let (event_tx, event_rx) = mpsc::channel(100);
+        let delegate = Arc::new(CentralDelegate::new(event_tx));
+
+        // TODO: Initialize CBCentralManager with objc2
+        // 1. Create dispatch queue for callbacks
+        // 2. Create CBCentralManager with delegate and queue
+        // 3. Store reference to manager
+        //
+        // Example objc2 code:
+        // ```
+        // use objc2::rc::Retained;
+        // use objc2_core_bluetooth::{CBCentralManager, CBCentralManagerDelegate};
+        //
+        // let queue = dispatch::Queue::new("com.hive.btle.central", dispatch::QueueAttribute::Serial);
+        // let manager = unsafe {
+        //     CBCentralManager::initWithDelegate_queue_(
+        //         CBCentralManager::alloc(),
+        //         delegate_obj,
+        //         queue,
+        //     )
+        // };
+        // ```
+
+        log::warn!("CentralManager::new() - CoreBluetooth initialization not yet implemented");
+
+        Ok(Self {
+            state: Arc::new(RwLock::new(CentralState::Unknown)),
+            event_rx: Arc::new(RwLock::new(event_rx)),
+            delegate,
+            peripherals: Arc::new(RwLock::new(HashMap::new())),
+            scanning: Arc::new(RwLock::new(false)),
+        })
+    }
+
+    /// Get the current central manager state
+    pub async fn state(&self) -> CentralState {
+        *self.state.read().await
+    }
+
+    /// Wait for the central manager to be ready (powered on)
+    ///
+    /// Returns an error if Bluetooth is unavailable or unauthorized.
+    pub async fn wait_ready(&self) -> Result<()> {
+        // TODO: Wait for state to become PoweredOn
+        // Process events until state changes to a terminal state
+
+        let state = self.state().await;
+        match state {
+            CentralState::PoweredOn => Ok(()),
+            CentralState::Unsupported => Err(BleError::NotSupported(
+                "Bluetooth not supported".to_string(),
+            )),
+            CentralState::Unauthorized => Err(BleError::PlatformError(
+                "Bluetooth not authorized".to_string(),
+            )),
+            CentralState::PoweredOff => Err(BleError::PlatformError(
+                "Bluetooth is powered off".to_string(),
+            )),
+            _ => {
+                log::warn!("CentralManager not ready, state: {:?}", state);
+                Err(BleError::PlatformError(format!(
+                    "Bluetooth not ready: {:?}",
+                    state
+                )))
+            }
+        }
+    }
+
+    /// Start scanning for BLE peripherals
+    ///
+    /// # Arguments
+    /// * `config` - Discovery configuration
+    /// * `service_uuids` - Optional list of service UUIDs to filter by
+    pub async fn start_scan(
+        &self,
+        config: &DiscoveryConfig,
+        service_uuids: Option<Vec<String>>,
+    ) -> Result<()> {
+        // TODO: Call CBCentralManager.scanForPeripheralsWithServices:options:
+        //
+        // Options to set:
+        // - CBCentralManagerScanOptionAllowDuplicatesKey: based on config.filter_duplicates
+        //
+        // Example objc2 code:
+        // ```
+        // let options = NSDictionary::from_keys_and_objects(
+        //     &[ns_string!("CBCentralManagerScanOptionAllowDuplicatesKey")],
+        //     &[NSNumber::new_bool(!config.filter_duplicates)],
+        // );
+        // manager.scanForPeripheralsWithServices_options_(service_uuids, Some(&options));
+        // ```
+
+        log::warn!(
+            "CentralManager::start_scan() - Not yet implemented (filter_duplicates: {})",
+            config.filter_duplicates
+        );
+
+        *self.scanning.write().await = true;
+        Err(BleError::NotSupported(
+            "CoreBluetooth scanning not yet implemented".to_string(),
+        ))
+    }
+
+    /// Stop scanning for peripherals
+    pub async fn stop_scan(&self) -> Result<()> {
+        // TODO: Call CBCentralManager.stopScan()
+
+        log::warn!("CentralManager::stop_scan() - Not yet implemented");
+
+        *self.scanning.write().await = false;
+        Ok(())
+    }
+
+    /// Check if currently scanning
+    pub async fn is_scanning(&self) -> bool {
+        *self.scanning.read().await
+    }
+
+    /// Connect to a peripheral by identifier
+    ///
+    /// # Arguments
+    /// * `identifier` - The peripheral's UUID identifier
+    pub async fn connect(&self, identifier: &str) -> Result<()> {
+        // TODO: Call CBCentralManager.connectPeripheral:options:
+        //
+        // 1. Look up CBPeripheral from stored peripherals
+        // 2. Call connectPeripheral with options:
+        //    - CBConnectPeripheralOptionNotifyOnConnectionKey: true
+        //    - CBConnectPeripheralOptionNotifyOnDisconnectionKey: true
+        //
+        // Example objc2 code:
+        // ```
+        // let options = NSDictionary::from_keys_and_objects(
+        //     &[
+        //         ns_string!("CBConnectPeripheralOptionNotifyOnConnectionKey"),
+        //         ns_string!("CBConnectPeripheralOptionNotifyOnDisconnectionKey"),
+        //     ],
+        //     &[NSNumber::new_bool(true), NSNumber::new_bool(true)],
+        // );
+        // manager.connectPeripheral_options_(peripheral, Some(&options));
+        // ```
+
+        log::warn!(
+            "CentralManager::connect({}) - Not yet implemented",
+            identifier
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth connection not yet implemented".to_string(),
+        ))
+    }
+
+    /// Disconnect from a peripheral
+    pub async fn disconnect(&self, identifier: &str) -> Result<()> {
+        // TODO: Call CBCentralManager.cancelPeripheralConnection()
+
+        log::warn!(
+            "CentralManager::disconnect({}) - Not yet implemented",
+            identifier
+        );
+
+        Ok(())
+    }
+
+    /// Get information about a discovered peripheral
+    pub async fn get_peripheral(&self, identifier: &str) -> Option<PeripheralInfo> {
+        let peripherals = self.peripherals.read().await;
+        peripherals.get(identifier).cloned()
+    }
+
+    /// Get all discovered peripherals
+    pub async fn get_discovered_peripherals(&self) -> Vec<PeripheralInfo> {
+        let peripherals = self.peripherals.read().await;
+        peripherals.values().cloned().collect()
+    }
+
+    /// Get all HIVE node peripherals
+    pub async fn get_hive_peripherals(&self) -> Vec<PeripheralInfo> {
+        let peripherals = self.peripherals.read().await;
+        peripherals
+            .values()
+            .filter(|p| p.is_hive_node)
+            .cloned()
+            .collect()
+    }
+
+    /// Process pending delegate events
+    ///
+    /// Call this periodically to update internal state from delegate callbacks.
+    pub async fn process_events(&self) -> Result<()> {
+        let mut event_rx = self.event_rx.write().await;
+
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                CentralEvent::StateChanged(state) => {
+                    *self.state.write().await = state;
+                }
+                CentralEvent::DiscoveredPeripheral {
+                    identifier,
+                    name,
+                    rssi,
+                    is_hive_node,
+                    node_id,
+                    ..
+                } => {
+                    let mut peripherals = self.peripherals.write().await;
+                    peripherals.insert(
+                        identifier.clone(),
+                        PeripheralInfo {
+                            identifier,
+                            name,
+                            rssi,
+                            is_hive_node,
+                            node_id,
+                            connected: false,
+                        },
+                    );
+                }
+                CentralEvent::Connected { identifier } => {
+                    let mut peripherals = self.peripherals.write().await;
+                    if let Some(peripheral) = peripherals.get_mut(&identifier) {
+                        peripheral.connected = true;
+                    }
+                }
+                CentralEvent::Disconnected { identifier, .. } => {
+                    let mut peripherals = self.peripherals.write().await;
+                    if let Some(peripheral) = peripherals.get_mut(&identifier) {
+                        peripheral.connected = false;
+                    }
+                }
+                CentralEvent::ConnectionFailed { identifier, error } => {
+                    log::warn!("Connection to {} failed: {}", identifier, error);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_peripheral_info() {
+        let info = PeripheralInfo {
+            identifier: "12345678-1234-1234-1234-123456789ABC".to_string(),
+            name: Some("HIVE-DEADBEEF".to_string()),
+            rssi: -65,
+            is_hive_node: true,
+            node_id: Some(NodeId::new(0xDEADBEEF)),
+            connected: false,
+        };
+
+        assert!(info.is_hive_node);
+        assert!(!info.connected);
+        assert_eq!(info.rssi, -65);
+    }
+}

--- a/hive-btle/src/platform/apple/connection.rs
+++ b/hive-btle/src/platform/apple/connection.rs
@@ -1,0 +1,414 @@
+//! CoreBluetooth connection wrapper
+//!
+//! This module provides a connection wrapper for CoreBluetooth peripherals,
+//! implementing the `BleConnection` trait.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{mpsc, RwLock};
+
+use crate::config::BlePhy;
+use crate::error::{BleError, Result};
+use crate::transport::BleConnection;
+use crate::NodeId;
+
+use super::delegates::{PeripheralDelegate, PeripheralEvent};
+
+/// Internal connection state
+struct ConnectionState {
+    /// Whether the connection is alive
+    alive: bool,
+    /// Negotiated MTU
+    mtu: u16,
+    /// Current PHY (CoreBluetooth doesn't expose PHY, assume 1M)
+    phy: BlePhy,
+    /// Last RSSI reading
+    rssi: Option<i8>,
+    /// Whether services have been discovered
+    services_discovered: bool,
+}
+
+/// CoreBluetooth connection wrapper
+///
+/// Wraps a CBPeripheral connection with state tracking and
+/// implements the `BleConnection` trait.
+#[derive(Clone)]
+pub struct CoreBluetoothConnection {
+    /// Remote peer ID
+    peer_id: NodeId,
+    /// Peripheral identifier (UUID string)
+    identifier: String,
+    /// Connection state
+    state: Arc<RwLock<ConnectionState>>,
+    /// When the connection was established
+    connected_at: Instant,
+    /// Channel receiver for peripheral events
+    event_rx: Arc<RwLock<mpsc::Receiver<PeripheralEvent>>>,
+    /// Peripheral delegate (must be kept alive)
+    delegate: Arc<PeripheralDelegate>,
+}
+
+impl CoreBluetoothConnection {
+    /// Create a new connection wrapper
+    ///
+    /// # Arguments
+    /// * `peer_id` - HIVE node ID of the remote peer
+    /// * `identifier` - CoreBluetooth peripheral identifier (UUID)
+    pub fn new(peer_id: NodeId, identifier: String) -> Self {
+        let (event_tx, event_rx) = mpsc::channel(100);
+        let delegate = Arc::new(PeripheralDelegate::new(event_tx));
+
+        // TODO: Set this delegate on the CBPeripheral
+        // peripheral.setDelegate_(delegate_obj);
+
+        let state = ConnectionState {
+            alive: true,
+            mtu: 23,           // Default BLE MTU, will be updated after connection
+            phy: BlePhy::Le1M, // CoreBluetooth doesn't expose PHY selection
+            rssi: None,
+            services_discovered: false,
+        };
+
+        Self {
+            peer_id,
+            identifier,
+            state: Arc::new(RwLock::new(state)),
+            connected_at: Instant::now(),
+            event_rx: Arc::new(RwLock::new(event_rx)),
+            delegate,
+        }
+    }
+
+    /// Get the peripheral identifier
+    pub fn identifier(&self) -> &str {
+        &self.identifier
+    }
+
+    /// Update connection state from delegate callback
+    pub async fn update_connection_state(&self, connected: bool) {
+        let mut state = self.state.write().await;
+        state.alive = connected;
+    }
+
+    /// Update MTU (called after MTU exchange completes)
+    pub async fn update_mtu(&self, mtu: u16) {
+        let mut state = self.state.write().await;
+        state.mtu = mtu;
+        log::debug!("MTU updated to {} for peer {}", mtu, self.peer_id);
+    }
+
+    /// Update RSSI
+    pub async fn update_rssi(&self, rssi: i8) {
+        let mut state = self.state.write().await;
+        state.rssi = Some(rssi);
+    }
+
+    /// Mark services as discovered
+    pub async fn mark_services_discovered(&self) {
+        let mut state = self.state.write().await;
+        state.services_discovered = true;
+        log::debug!("Services discovered for peer {}", self.peer_id);
+    }
+
+    /// Check if services have been discovered
+    pub async fn are_services_discovered(&self) -> bool {
+        let state = self.state.read().await;
+        state.services_discovered
+    }
+
+    /// Mark connection as dead
+    pub async fn mark_dead(&self) {
+        let mut state = self.state.write().await;
+        state.alive = false;
+    }
+
+    /// Disconnect from the peripheral
+    ///
+    /// Note: On CoreBluetooth, disconnection is handled by the CentralManager,
+    /// not the peripheral itself.
+    pub async fn disconnect(&self) -> Result<()> {
+        // TODO: Signal CentralManager to disconnect
+        // This should call centralManager.cancelPeripheralConnection_(peripheral)
+
+        self.mark_dead().await;
+        log::warn!(
+            "CoreBluetoothConnection::disconnect({}) - Must be called via CentralManager",
+            self.identifier
+        );
+        Ok(())
+    }
+
+    /// Discover services on the peripheral
+    pub async fn discover_services(&self, service_uuids: Option<Vec<String>>) -> Result<()> {
+        // TODO: Call CBPeripheral.discoverServices:
+        //
+        // Example objc2 code:
+        // ```
+        // let uuids = service_uuids.map(|uuids| {
+        //     NSArray::from_vec(uuids.into_iter().map(|u| {
+        //         CBUUID::UUIDWithString_(&NSString::from_str(&u))
+        //     }).collect())
+        // });
+        // peripheral.discoverServices_(uuids.as_ref());
+        // ```
+
+        log::warn!(
+            "CoreBluetoothConnection::discover_services({}) - Not yet implemented",
+            self.identifier
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth service discovery not yet implemented".to_string(),
+        ))
+    }
+
+    /// Discover characteristics for a service
+    pub async fn discover_characteristics(
+        &self,
+        service_uuid: &str,
+        characteristic_uuids: Option<Vec<String>>,
+    ) -> Result<()> {
+        // TODO: Call CBPeripheral.discoverCharacteristics:forService:
+        //
+        // 1. Look up CBService from peripheral.services
+        // 2. Call peripheral.discoverCharacteristics:forService:
+
+        log::warn!(
+            "CoreBluetoothConnection::discover_characteristics({}, {}) - Not yet implemented",
+            self.identifier,
+            service_uuid
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth characteristic discovery not yet implemented".to_string(),
+        ))
+    }
+
+    /// Read a characteristic value
+    pub async fn read_characteristic(
+        &self,
+        service_uuid: &str,
+        characteristic_uuid: &str,
+    ) -> Result<Vec<u8>> {
+        // TODO: Call CBPeripheral.readValueForCharacteristic:
+        //
+        // 1. Look up CBService and CBCharacteristic
+        // 2. Call peripheral.readValueForCharacteristic:
+        // 3. Wait for delegate callback with value
+
+        log::warn!(
+            "CoreBluetoothConnection::read_characteristic({}, {}) - Not yet implemented",
+            service_uuid,
+            characteristic_uuid
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth characteristic read not yet implemented".to_string(),
+        ))
+    }
+
+    /// Write a characteristic value
+    pub async fn write_characteristic(
+        &self,
+        service_uuid: &str,
+        characteristic_uuid: &str,
+        value: &[u8],
+        with_response: bool,
+    ) -> Result<()> {
+        // TODO: Call CBPeripheral.writeValue:forCharacteristic:type:
+        //
+        // Write type:
+        // - CBCharacteristicWriteWithResponse (0) if with_response
+        // - CBCharacteristicWriteWithoutResponse (1) if !with_response
+        //
+        // Example objc2 code:
+        // ```
+        // let data = NSData::from_vec(value.to_vec());
+        // let write_type = if with_response {
+        //     CBCharacteristicWriteType::WithResponse
+        // } else {
+        //     CBCharacteristicWriteType::WithoutResponse
+        // };
+        // peripheral.writeValue_forCharacteristic_type_(&data, &characteristic, write_type);
+        // ```
+
+        log::warn!(
+            "CoreBluetoothConnection::write_characteristic({}, {}, {} bytes, response={}) - Not yet implemented",
+            service_uuid,
+            characteristic_uuid,
+            value.len(),
+            with_response
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth characteristic write not yet implemented".to_string(),
+        ))
+    }
+
+    /// Enable notifications for a characteristic
+    pub async fn enable_notifications(
+        &self,
+        service_uuid: &str,
+        characteristic_uuid: &str,
+    ) -> Result<()> {
+        // TODO: Call CBPeripheral.setNotifyValue:forCharacteristic:
+        //
+        // Example objc2 code:
+        // ```
+        // peripheral.setNotifyValue_forCharacteristic_(true, &characteristic);
+        // ```
+
+        log::warn!(
+            "CoreBluetoothConnection::enable_notifications({}, {}) - Not yet implemented",
+            service_uuid,
+            characteristic_uuid
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth notifications not yet implemented".to_string(),
+        ))
+    }
+
+    /// Disable notifications for a characteristic
+    pub async fn disable_notifications(
+        &self,
+        service_uuid: &str,
+        characteristic_uuid: &str,
+    ) -> Result<()> {
+        // TODO: Call CBPeripheral.setNotifyValue:forCharacteristic: with false
+
+        log::warn!(
+            "CoreBluetoothConnection::disable_notifications({}, {}) - Not yet implemented",
+            service_uuid,
+            characteristic_uuid
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth notification disable not yet implemented".to_string(),
+        ))
+    }
+
+    /// Read RSSI
+    pub async fn read_rssi(&self) -> Result<()> {
+        // TODO: Call CBPeripheral.readRSSI()
+
+        log::warn!(
+            "CoreBluetoothConnection::read_rssi({}) - Not yet implemented",
+            self.identifier
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth RSSI read not yet implemented".to_string(),
+        ))
+    }
+
+    /// Process pending delegate events
+    pub async fn process_events(&self) -> Result<()> {
+        let mut event_rx = self.event_rx.write().await;
+
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                PeripheralEvent::ServicesDiscovered { error, .. } => {
+                    if error.is_none() {
+                        self.mark_services_discovered().await;
+                    }
+                }
+                PeripheralEvent::MtuUpdated { mtu, .. } => {
+                    self.update_mtu(mtu).await;
+                }
+                PeripheralEvent::RssiRead { rssi, error, .. } => {
+                    if error.is_none() {
+                        self.update_rssi(rssi).await;
+                    }
+                }
+                _ => {
+                    // Other events handled by higher-level code
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl BleConnection for CoreBluetoothConnection {
+    fn peer_id(&self) -> &NodeId {
+        &self.peer_id
+    }
+
+    fn is_alive(&self) -> bool {
+        if let Ok(state) = self.state.try_read() {
+            state.alive
+        } else {
+            // If we can't get the lock, assume alive
+            true
+        }
+    }
+
+    fn mtu(&self) -> u16 {
+        if let Ok(state) = self.state.try_read() {
+            state.mtu
+        } else {
+            23 // Default BLE MTU
+        }
+    }
+
+    fn phy(&self) -> BlePhy {
+        if let Ok(state) = self.state.try_read() {
+            state.phy
+        } else {
+            BlePhy::Le1M
+        }
+    }
+
+    fn rssi(&self) -> Option<i8> {
+        if let Ok(state) = self.state.try_read() {
+            state.rssi
+        } else {
+            None
+        }
+    }
+
+    fn connected_duration(&self) -> Duration {
+        self.connected_at.elapsed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_connection_creation() {
+        let node_id = NodeId::new(0xDEADBEEF);
+        let identifier = "12345678-1234-1234-1234-123456789ABC".to_string();
+        let conn = CoreBluetoothConnection::new(node_id.clone(), identifier.clone());
+
+        assert_eq!(conn.peer_id(), &node_id);
+        assert_eq!(conn.identifier(), identifier);
+        assert!(conn.is_alive());
+        assert_eq!(conn.mtu(), 23);
+        assert_eq!(conn.phy(), BlePhy::Le1M);
+    }
+
+    #[tokio::test]
+    async fn test_connection_state_updates() {
+        let node_id = NodeId::new(0xDEADBEEF);
+        let conn = CoreBluetoothConnection::new(
+            node_id,
+            "12345678-1234-1234-1234-123456789ABC".to_string(),
+        );
+
+        // Update MTU
+        conn.update_mtu(247).await;
+        assert_eq!(conn.mtu(), 247);
+
+        // Update RSSI
+        conn.update_rssi(-65).await;
+        assert_eq!(conn.rssi(), Some(-65));
+
+        // Mark dead
+        conn.mark_dead().await;
+        assert!(!conn.is_alive());
+    }
+}

--- a/hive-btle/src/platform/apple/delegates.rs
+++ b/hive-btle/src/platform/apple/delegates.rs
@@ -1,0 +1,750 @@
+//! Objective-C delegate implementations for CoreBluetooth
+//!
+//! CoreBluetooth uses the delegate pattern for callbacks. This module defines
+//! Rust structs that implement the required Objective-C protocols and forward
+//! events to Rust async channels.
+//!
+//! ## Delegate Protocols
+//!
+//! - `CBCentralManagerDelegate`: Receives central manager state and discovery events
+//! - `CBPeripheralDelegate`: Receives GATT client events (reads, writes, notifications)
+//! - `CBPeripheralManagerDelegate`: Receives GATT server events
+
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+use crate::config::BlePhy;
+use crate::error::{BleError, Result};
+use crate::platform::{ConnectionEvent, DiscoveredDevice};
+use crate::NodeId;
+
+/// Events from CBCentralManagerDelegate
+#[derive(Debug, Clone)]
+pub enum CentralEvent {
+    /// Central manager state changed
+    StateChanged(CentralState),
+    /// Discovered a peripheral during scanning
+    DiscoveredPeripheral {
+        /// Peripheral identifier (UUID string)
+        identifier: String,
+        /// Advertised name
+        name: Option<String>,
+        /// RSSI in dBm
+        rssi: i8,
+        /// Advertisement data
+        advertisement_data: Vec<u8>,
+        /// Is this a HIVE node?
+        is_hive_node: bool,
+        /// Parsed node ID if HIVE node
+        node_id: Option<NodeId>,
+    },
+    /// Connected to a peripheral
+    Connected {
+        /// Peripheral identifier
+        identifier: String,
+    },
+    /// Disconnected from a peripheral
+    Disconnected {
+        /// Peripheral identifier
+        identifier: String,
+        /// Error if disconnection was unexpected
+        error: Option<String>,
+    },
+    /// Failed to connect to a peripheral
+    ConnectionFailed {
+        /// Peripheral identifier
+        identifier: String,
+        /// Error description
+        error: String,
+    },
+}
+
+/// CBCentralManager state
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CentralState {
+    /// State unknown, update imminent
+    Unknown,
+    /// Bluetooth is resetting
+    Resetting,
+    /// Bluetooth is not supported on this device
+    Unsupported,
+    /// App is not authorized to use Bluetooth
+    Unauthorized,
+    /// Bluetooth is powered off
+    PoweredOff,
+    /// Bluetooth is powered on and ready
+    PoweredOn,
+}
+
+impl CentralState {
+    /// Convert from CBManagerState integer value
+    pub fn from_raw(value: i64) -> Self {
+        match value {
+            0 => CentralState::Unknown,
+            1 => CentralState::Resetting,
+            2 => CentralState::Unsupported,
+            3 => CentralState::Unauthorized,
+            4 => CentralState::PoweredOff,
+            5 => CentralState::PoweredOn,
+            _ => CentralState::Unknown,
+        }
+    }
+
+    /// Check if Bluetooth is ready to use
+    pub fn is_ready(&self) -> bool {
+        matches!(self, CentralState::PoweredOn)
+    }
+}
+
+/// Events from CBPeripheralDelegate (GATT client events)
+#[derive(Debug, Clone)]
+pub enum PeripheralEvent {
+    /// Services discovered on peripheral
+    ServicesDiscovered {
+        /// Peripheral identifier
+        identifier: String,
+        /// Error if discovery failed
+        error: Option<String>,
+    },
+    /// Characteristics discovered for a service
+    CharacteristicsDiscovered {
+        /// Peripheral identifier
+        identifier: String,
+        /// Service UUID
+        service_uuid: String,
+        /// Error if discovery failed
+        error: Option<String>,
+    },
+    /// Characteristic value read
+    CharacteristicRead {
+        /// Peripheral identifier
+        identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+        /// Read value
+        value: Vec<u8>,
+        /// Error if read failed
+        error: Option<String>,
+    },
+    /// Characteristic value written
+    CharacteristicWritten {
+        /// Peripheral identifier
+        identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+        /// Error if write failed
+        error: Option<String>,
+    },
+    /// Characteristic value changed (notification/indication)
+    CharacteristicChanged {
+        /// Peripheral identifier
+        identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+        /// New value
+        value: Vec<u8>,
+    },
+    /// Notification state changed
+    NotificationStateChanged {
+        /// Peripheral identifier
+        identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+        /// Whether notifications are now enabled
+        enabled: bool,
+        /// Error if state change failed
+        error: Option<String>,
+    },
+    /// MTU updated
+    MtuUpdated {
+        /// Peripheral identifier
+        identifier: String,
+        /// New MTU value
+        mtu: u16,
+    },
+    /// RSSI read
+    RssiRead {
+        /// Peripheral identifier
+        identifier: String,
+        /// RSSI value in dBm
+        rssi: i8,
+        /// Error if read failed
+        error: Option<String>,
+    },
+}
+
+/// Events from CBPeripheralManagerDelegate (GATT server events)
+#[derive(Debug, Clone)]
+pub enum PeripheralManagerEvent {
+    /// Peripheral manager state changed
+    StateChanged(CentralState), // Uses same state enum
+    /// Service was added
+    ServiceAdded {
+        /// Service UUID
+        service_uuid: String,
+        /// Error if add failed
+        error: Option<String>,
+    },
+    /// Started advertising
+    AdvertisingStarted {
+        /// Error if advertising failed to start
+        error: Option<String>,
+    },
+    /// Central subscribed to characteristic
+    CentralSubscribed {
+        /// Central identifier
+        central_identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+    },
+    /// Central unsubscribed from characteristic
+    CentralUnsubscribed {
+        /// Central identifier
+        central_identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+    },
+    /// Received read request from central
+    ReadRequest {
+        /// Request identifier for response
+        request_id: u64,
+        /// Central identifier
+        central_identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+        /// Offset for read
+        offset: usize,
+    },
+    /// Received write request from central
+    WriteRequest {
+        /// Request identifier for response
+        request_id: u64,
+        /// Central identifier
+        central_identifier: String,
+        /// Characteristic UUID
+        characteristic_uuid: String,
+        /// Written value
+        value: Vec<u8>,
+        /// Offset for write
+        offset: usize,
+        /// Whether response is required
+        response_needed: bool,
+    },
+    /// Ready to update subscribers
+    ReadyToUpdateSubscribers,
+}
+
+/// CBCentralManagerDelegate implementation
+///
+/// This struct is registered as the delegate for CBCentralManager and forwards
+/// events to a Rust channel.
+pub struct CentralDelegate {
+    /// Channel to send events
+    event_tx: mpsc::Sender<CentralEvent>,
+}
+
+impl CentralDelegate {
+    /// Create a new central delegate
+    pub fn new(event_tx: mpsc::Sender<CentralEvent>) -> Self {
+        Self { event_tx }
+    }
+
+    /// Called when central manager state changes
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)centralManagerDidUpdateState:(CBCentralManager *)central
+    /// ```
+    pub fn central_manager_did_update_state(&self, state: i64) {
+        let state = CentralState::from_raw(state);
+        log::debug!("Central manager state changed: {:?}", state);
+
+        let _ = self.event_tx.try_send(CentralEvent::StateChanged(state));
+    }
+
+    /// Called when a peripheral is discovered during scanning
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)centralManager:(CBCentralManager *)central
+    ///     didDiscoverPeripheral:(CBPeripheral *)peripheral
+    ///     advertisementData:(NSDictionary<NSString *, id> *)advertisementData
+    ///     RSSI:(NSNumber *)RSSI
+    /// ```
+    pub fn central_manager_did_discover_peripheral(
+        &self,
+        identifier: String,
+        name: Option<String>,
+        rssi: i8,
+        advertisement_data: Vec<u8>,
+    ) {
+        // Check if this is a HIVE node by looking at the name
+        let is_hive_node = name
+            .as_ref()
+            .map(|n| n.starts_with("HIVE-"))
+            .unwrap_or(false);
+
+        let node_id = name.as_ref().and_then(|n| {
+            if n.starts_with("HIVE-") {
+                NodeId::parse(&n[5..])
+            } else {
+                None
+            }
+        });
+
+        log::debug!(
+            "Discovered peripheral: {} ({:?}) RSSI: {} HIVE: {}",
+            identifier,
+            name,
+            rssi,
+            is_hive_node
+        );
+
+        let _ = self.event_tx.try_send(CentralEvent::DiscoveredPeripheral {
+            identifier,
+            name,
+            rssi,
+            advertisement_data,
+            is_hive_node,
+            node_id,
+        });
+    }
+
+    /// Called when connected to a peripheral
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)centralManager:(CBCentralManager *)central
+    ///     didConnectPeripheral:(CBPeripheral *)peripheral
+    /// ```
+    pub fn central_manager_did_connect_peripheral(&self, identifier: String) {
+        log::info!("Connected to peripheral: {}", identifier);
+        let _ = self
+            .event_tx
+            .try_send(CentralEvent::Connected { identifier });
+    }
+
+    /// Called when disconnected from a peripheral
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)centralManager:(CBCentralManager *)central
+    ///     didDisconnectPeripheral:(CBPeripheral *)peripheral
+    ///     error:(NSError *)error
+    /// ```
+    pub fn central_manager_did_disconnect_peripheral(
+        &self,
+        identifier: String,
+        error: Option<String>,
+    ) {
+        log::info!(
+            "Disconnected from peripheral: {} (error: {:?})",
+            identifier,
+            error
+        );
+        let _ = self
+            .event_tx
+            .try_send(CentralEvent::Disconnected { identifier, error });
+    }
+
+    /// Called when connection to a peripheral fails
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)centralManager:(CBCentralManager *)central
+    ///     didFailToConnectPeripheral:(CBPeripheral *)peripheral
+    ///     error:(NSError *)error
+    /// ```
+    pub fn central_manager_did_fail_to_connect_peripheral(
+        &self,
+        identifier: String,
+        error: String,
+    ) {
+        log::warn!(
+            "Failed to connect to peripheral: {} ({})",
+            identifier,
+            error
+        );
+        let _ = self
+            .event_tx
+            .try_send(CentralEvent::ConnectionFailed { identifier, error });
+    }
+}
+
+/// CBPeripheralDelegate implementation
+///
+/// This struct is registered as the delegate for connected CBPeripheral objects
+/// and forwards GATT client events to a Rust channel.
+pub struct PeripheralDelegate {
+    /// Channel to send events
+    event_tx: mpsc::Sender<PeripheralEvent>,
+}
+
+impl PeripheralDelegate {
+    /// Create a new peripheral delegate
+    pub fn new(event_tx: mpsc::Sender<PeripheralEvent>) -> Self {
+        Self { event_tx }
+    }
+
+    /// Called when services are discovered
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheral:(CBPeripheral *)peripheral
+    ///     didDiscoverServices:(NSError *)error
+    /// ```
+    pub fn peripheral_did_discover_services(&self, identifier: String, error: Option<String>) {
+        log::debug!("Services discovered for {}: error={:?}", identifier, error);
+        let _ = self
+            .event_tx
+            .try_send(PeripheralEvent::ServicesDiscovered { identifier, error });
+    }
+
+    /// Called when characteristics are discovered for a service
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheral:(CBPeripheral *)peripheral
+    ///     didDiscoverCharacteristicsForService:(CBService *)service
+    ///     error:(NSError *)error
+    /// ```
+    pub fn peripheral_did_discover_characteristics(
+        &self,
+        identifier: String,
+        service_uuid: String,
+        error: Option<String>,
+    ) {
+        log::debug!(
+            "Characteristics discovered for {} service {}: error={:?}",
+            identifier,
+            service_uuid,
+            error
+        );
+        let _ = self
+            .event_tx
+            .try_send(PeripheralEvent::CharacteristicsDiscovered {
+                identifier,
+                service_uuid,
+                error,
+            });
+    }
+
+    /// Called when a characteristic value is read
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheral:(CBPeripheral *)peripheral
+    ///     didUpdateValueForCharacteristic:(CBCharacteristic *)characteristic
+    ///     error:(NSError *)error
+    /// ```
+    pub fn peripheral_did_update_value_for_characteristic(
+        &self,
+        identifier: String,
+        characteristic_uuid: String,
+        value: Vec<u8>,
+        error: Option<String>,
+    ) {
+        log::trace!(
+            "Characteristic {} value updated for {}: {} bytes",
+            characteristic_uuid,
+            identifier,
+            value.len()
+        );
+        let _ = self.event_tx.try_send(PeripheralEvent::CharacteristicRead {
+            identifier,
+            characteristic_uuid,
+            value,
+            error,
+        });
+    }
+
+    /// Called when a characteristic value is written
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheral:(CBPeripheral *)peripheral
+    ///     didWriteValueForCharacteristic:(CBCharacteristic *)characteristic
+    ///     error:(NSError *)error
+    /// ```
+    pub fn peripheral_did_write_value_for_characteristic(
+        &self,
+        identifier: String,
+        characteristic_uuid: String,
+        error: Option<String>,
+    ) {
+        log::trace!(
+            "Characteristic {} written for {}: error={:?}",
+            characteristic_uuid,
+            identifier,
+            error
+        );
+        let _ = self
+            .event_tx
+            .try_send(PeripheralEvent::CharacteristicWritten {
+                identifier,
+                characteristic_uuid,
+                error,
+            });
+    }
+
+    /// Called when notification state changes for a characteristic
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheral:(CBPeripheral *)peripheral
+    ///     didUpdateNotificationStateForCharacteristic:(CBCharacteristic *)characteristic
+    ///     error:(NSError *)error
+    /// ```
+    pub fn peripheral_did_update_notification_state(
+        &self,
+        identifier: String,
+        characteristic_uuid: String,
+        enabled: bool,
+        error: Option<String>,
+    ) {
+        log::debug!(
+            "Notification state for {} char {}: enabled={} error={:?}",
+            identifier,
+            characteristic_uuid,
+            enabled,
+            error
+        );
+        let _ = self
+            .event_tx
+            .try_send(PeripheralEvent::NotificationStateChanged {
+                identifier,
+                characteristic_uuid,
+                enabled,
+                error,
+            });
+    }
+
+    /// Called when RSSI is read
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheral:(CBPeripheral *)peripheral
+    ///     didReadRSSI:(NSNumber *)RSSI
+    ///     error:(NSError *)error
+    /// ```
+    pub fn peripheral_did_read_rssi(&self, identifier: String, rssi: i8, error: Option<String>) {
+        let _ = self.event_tx.try_send(PeripheralEvent::RssiRead {
+            identifier,
+            rssi,
+            error,
+        });
+    }
+}
+
+/// CBPeripheralManagerDelegate implementation
+///
+/// This struct is registered as the delegate for CBPeripheralManager and forwards
+/// GATT server events to a Rust channel.
+pub struct PeripheralManagerDelegate {
+    /// Channel to send events
+    event_tx: mpsc::Sender<PeripheralManagerEvent>,
+}
+
+impl PeripheralManagerDelegate {
+    /// Create a new peripheral manager delegate
+    pub fn new(event_tx: mpsc::Sender<PeripheralManagerEvent>) -> Self {
+        Self { event_tx }
+    }
+
+    /// Called when peripheral manager state changes
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManagerDidUpdateState:(CBPeripheralManager *)peripheral
+    /// ```
+    pub fn peripheral_manager_did_update_state(&self, state: i64) {
+        let state = CentralState::from_raw(state);
+        log::debug!("Peripheral manager state changed: {:?}", state);
+        let _ = self
+            .event_tx
+            .try_send(PeripheralManagerEvent::StateChanged(state));
+    }
+
+    /// Called when a service is added
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManager:(CBPeripheralManager *)peripheral
+    ///     didAddService:(CBService *)service
+    ///     error:(NSError *)error
+    /// ```
+    pub fn peripheral_manager_did_add_service(&self, service_uuid: String, error: Option<String>) {
+        log::debug!("Service {} added: error={:?}", service_uuid, error);
+        let _ = self
+            .event_tx
+            .try_send(PeripheralManagerEvent::ServiceAdded {
+                service_uuid,
+                error,
+            });
+    }
+
+    /// Called when advertising starts
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManagerDidStartAdvertising:(CBPeripheralManager *)peripheral
+    ///     error:(NSError *)error
+    /// ```
+    pub fn peripheral_manager_did_start_advertising(&self, error: Option<String>) {
+        if let Some(ref e) = error {
+            log::warn!("Advertising failed to start: {}", e);
+        } else {
+            log::info!("Advertising started successfully");
+        }
+        let _ = self
+            .event_tx
+            .try_send(PeripheralManagerEvent::AdvertisingStarted { error });
+    }
+
+    /// Called when a central subscribes to a characteristic
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManager:(CBPeripheralManager *)peripheral
+    ///     central:(CBCentral *)central
+    ///     didSubscribeToCharacteristic:(CBCharacteristic *)characteristic
+    /// ```
+    pub fn peripheral_manager_central_did_subscribe(
+        &self,
+        central_identifier: String,
+        characteristic_uuid: String,
+    ) {
+        log::debug!(
+            "Central {} subscribed to {}",
+            central_identifier,
+            characteristic_uuid
+        );
+        let _ = self
+            .event_tx
+            .try_send(PeripheralManagerEvent::CentralSubscribed {
+                central_identifier,
+                characteristic_uuid,
+            });
+    }
+
+    /// Called when a central unsubscribes from a characteristic
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManager:(CBPeripheralManager *)peripheral
+    ///     central:(CBCentral *)central
+    ///     didUnsubscribeFromCharacteristic:(CBCharacteristic *)characteristic
+    /// ```
+    pub fn peripheral_manager_central_did_unsubscribe(
+        &self,
+        central_identifier: String,
+        characteristic_uuid: String,
+    ) {
+        log::debug!(
+            "Central {} unsubscribed from {}",
+            central_identifier,
+            characteristic_uuid
+        );
+        let _ = self
+            .event_tx
+            .try_send(PeripheralManagerEvent::CentralUnsubscribed {
+                central_identifier,
+                characteristic_uuid,
+            });
+    }
+
+    /// Called when a read request is received
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManager:(CBPeripheralManager *)peripheral
+    ///     didReceiveReadRequest:(CBATTRequest *)request
+    /// ```
+    pub fn peripheral_manager_did_receive_read_request(
+        &self,
+        request_id: u64,
+        central_identifier: String,
+        characteristic_uuid: String,
+        offset: usize,
+    ) {
+        log::trace!(
+            "Read request from {} for {} offset {}",
+            central_identifier,
+            characteristic_uuid,
+            offset
+        );
+        let _ = self.event_tx.try_send(PeripheralManagerEvent::ReadRequest {
+            request_id,
+            central_identifier,
+            characteristic_uuid,
+            offset,
+        });
+    }
+
+    /// Called when write requests are received
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManager:(CBPeripheralManager *)peripheral
+    ///     didReceiveWriteRequests:(NSArray<CBATTRequest *> *)requests
+    /// ```
+    pub fn peripheral_manager_did_receive_write_request(
+        &self,
+        request_id: u64,
+        central_identifier: String,
+        characteristic_uuid: String,
+        value: Vec<u8>,
+        offset: usize,
+        response_needed: bool,
+    ) {
+        log::trace!(
+            "Write request from {} for {} ({} bytes)",
+            central_identifier,
+            characteristic_uuid,
+            value.len()
+        );
+        let _ = self
+            .event_tx
+            .try_send(PeripheralManagerEvent::WriteRequest {
+                request_id,
+                central_identifier,
+                characteristic_uuid,
+                value,
+                offset,
+                response_needed,
+            });
+    }
+
+    /// Called when ready to send updates to subscribers
+    ///
+    /// # Objective-C
+    /// ```objc
+    /// - (void)peripheralManagerIsReadyToUpdateSubscribers:(CBPeripheralManager *)peripheral
+    /// ```
+    pub fn peripheral_manager_is_ready_to_update_subscribers(&self) {
+        log::trace!("Ready to update subscribers");
+        let _ = self
+            .event_tx
+            .try_send(PeripheralManagerEvent::ReadyToUpdateSubscribers);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_central_state_from_raw() {
+        assert_eq!(CentralState::from_raw(0), CentralState::Unknown);
+        assert_eq!(CentralState::from_raw(4), CentralState::PoweredOff);
+        assert_eq!(CentralState::from_raw(5), CentralState::PoweredOn);
+        assert_eq!(CentralState::from_raw(99), CentralState::Unknown);
+    }
+
+    #[test]
+    fn test_central_state_is_ready() {
+        assert!(!CentralState::Unknown.is_ready());
+        assert!(!CentralState::PoweredOff.is_ready());
+        assert!(CentralState::PoweredOn.is_ready());
+    }
+}

--- a/hive-btle/src/platform/apple/mod.rs
+++ b/hive-btle/src/platform/apple/mod.rs
@@ -1,0 +1,83 @@
+//! Apple platform implementation (iOS/macOS)
+//!
+//! This module provides the BLE adapter implementation for Apple platforms using
+//! CoreBluetooth framework bindings via the `objc2` crate.
+//!
+//! ## Requirements
+//!
+//! ### iOS
+//! - iOS 13.0 or later
+//! - `NSBluetoothAlwaysUsageDescription` in Info.plist
+//! - Background modes: `bluetooth-central`, `bluetooth-peripheral`
+//!
+//! ### macOS
+//! - macOS 10.15 (Catalina) or later
+//! - Bluetooth entitlement in app sandbox
+//!
+//! ## Architecture
+//!
+//! CoreBluetooth uses a delegate-based pattern where callbacks are delivered
+//! to Objective-C delegate objects. This module bridges those delegates to
+//! Rust async channels.
+//!
+//! ```text
+//! ┌─────────────────────────────────────────┐
+//! │       CoreBluetoothAdapter (Rust)        │
+//! ├─────────────────────────────────────────┤
+//! │  CentralManager    │  PeripheralManager │
+//! │   (scanning,       │   (advertising,    │
+//! │    connecting)     │    GATT server)    │
+//! ├─────────────────────────────────────────┤
+//! │           Objective-C Delegates          │
+//! │  (CentralDelegate, PeripheralDelegate)  │
+//! ├─────────────────────────────────────────┤
+//! │            CoreBluetooth Framework       │
+//! └─────────────────────────────────────────┘
+//! ```
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_btle::platform::apple::CoreBluetoothAdapter;
+//! use hive_btle::{BleConfig, NodeId};
+//!
+//! let config = BleConfig::new(NodeId::new(0x12345678));
+//! let mut adapter = CoreBluetoothAdapter::new()?;
+//! adapter.init(&config).await?;
+//! adapter.start().await?;
+//! ```
+//!
+//! ## CoreBluetooth Concepts
+//!
+//! - **CBCentralManager**: Scans for and connects to peripherals (GATT client)
+//! - **CBPeripheralManager**: Advertises and hosts GATT services (GATT server)
+//! - **CBPeripheral**: Represents a remote BLE device
+//! - **CBService/CBCharacteristic**: GATT service and characteristic objects
+//!
+//! ## iOS Background Execution
+//!
+//! For iOS apps to use BLE in the background, add to Info.plist:
+//!
+//! ```xml
+//! <key>UIBackgroundModes</key>
+//! <array>
+//!     <string>bluetooth-central</string>
+//!     <string>bluetooth-peripheral</string>
+//! </array>
+//! <key>NSBluetoothAlwaysUsageDescription</key>
+//! <string>HIVE uses Bluetooth to sync data with nearby devices</string>
+//! ```
+
+mod adapter;
+mod central;
+mod connection;
+mod delegates;
+mod peripheral;
+
+pub use adapter::CoreBluetoothAdapter;
+pub use connection::CoreBluetoothConnection;
+
+// Re-export for internal use
+pub(crate) use central::CentralManager;
+pub(crate) use delegates::{CentralDelegate, PeripheralDelegate, PeripheralManagerDelegate};
+pub(crate) use peripheral::PeripheralManager;

--- a/hive-btle/src/platform/apple/peripheral.rs
+++ b/hive-btle/src/platform/apple/peripheral.rs
@@ -1,0 +1,569 @@
+//! CBPeripheralManager wrapper
+//!
+//! This module provides a Rust wrapper around CoreBluetooth's CBPeripheralManager,
+//! which is used for advertising and hosting GATT services (GATT server role).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+
+use crate::config::DiscoveryConfig;
+use crate::error::{BleError, Result};
+use crate::NodeId;
+use crate::HIVE_SERVICE_UUID;
+
+use super::delegates::{CentralState, PeripheralManagerDelegate, PeripheralManagerEvent};
+
+/// Wrapper around CBPeripheralManager for BLE advertising and GATT server
+///
+/// CBPeripheralManager is the peripheral role in CoreBluetooth, used to:
+/// - Advertise the device as a BLE peripheral
+/// - Host GATT services with characteristics
+/// - Respond to read/write requests from centrals
+/// - Send notifications/indications to subscribed centrals
+pub struct PeripheralManager {
+    /// Current state of the peripheral manager
+    state: Arc<RwLock<CentralState>>,
+    /// Channel receiver for delegate events
+    event_rx: Arc<RwLock<mpsc::Receiver<PeripheralManagerEvent>>>,
+    /// Delegate instance (must be kept alive)
+    delegate: Arc<PeripheralManagerDelegate>,
+    /// Whether advertising is active
+    advertising: Arc<RwLock<bool>>,
+    /// Registered services
+    services: Arc<RwLock<HashMap<String, ServiceInfo>>>,
+    /// Subscribed centrals by characteristic UUID
+    subscribers: Arc<RwLock<HashMap<String, Vec<String>>>>,
+    /// Pending read requests awaiting response
+    pending_reads: Arc<RwLock<HashMap<u64, ReadRequest>>>,
+    /// Pending write requests awaiting response
+    pending_writes: Arc<RwLock<HashMap<u64, WriteRequest>>>,
+}
+
+/// Information about a registered GATT service
+#[derive(Debug, Clone)]
+pub struct ServiceInfo {
+    /// Service UUID
+    pub uuid: String,
+    /// Whether service is primary
+    pub is_primary: bool,
+    /// Characteristics in the service
+    pub characteristics: Vec<CharacteristicInfo>,
+}
+
+/// Information about a GATT characteristic
+#[derive(Debug, Clone)]
+pub struct CharacteristicInfo {
+    /// Characteristic UUID
+    pub uuid: String,
+    /// Properties (read, write, notify, etc.)
+    pub properties: CharacteristicProperties,
+    /// Current value
+    pub value: Vec<u8>,
+}
+
+/// Characteristic properties flags
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CharacteristicProperties {
+    /// Can be read
+    pub read: bool,
+    /// Can be written with response
+    pub write: bool,
+    /// Can be written without response
+    pub write_without_response: bool,
+    /// Supports notifications
+    pub notify: bool,
+    /// Supports indications
+    pub indicate: bool,
+}
+
+impl CharacteristicProperties {
+    /// Properties for a readable characteristic
+    pub fn readable() -> Self {
+        Self {
+            read: true,
+            ..Default::default()
+        }
+    }
+
+    /// Properties for a writable characteristic
+    pub fn writable() -> Self {
+        Self {
+            write: true,
+            ..Default::default()
+        }
+    }
+
+    /// Properties for a notify characteristic
+    pub fn notify() -> Self {
+        Self {
+            notify: true,
+            ..Default::default()
+        }
+    }
+
+    /// Properties for a read/write/notify characteristic (typical for HIVE sync)
+    pub fn read_write_notify() -> Self {
+        Self {
+            read: true,
+            write: true,
+            notify: true,
+            ..Default::default()
+        }
+    }
+
+    /// Convert to CBCharacteristicProperties bitmask
+    pub fn to_raw(&self) -> u32 {
+        let mut raw = 0u32;
+        if self.read {
+            raw |= 0x02;
+        } // CBCharacteristicPropertyRead
+        if self.write {
+            raw |= 0x08;
+        } // CBCharacteristicPropertyWrite
+        if self.write_without_response {
+            raw |= 0x04;
+        } // CBCharacteristicPropertyWriteWithoutResponse
+        if self.notify {
+            raw |= 0x10;
+        } // CBCharacteristicPropertyNotify
+        if self.indicate {
+            raw |= 0x20;
+        } // CBCharacteristicPropertyIndicate
+        raw
+    }
+}
+
+/// Pending read request
+#[derive(Debug)]
+struct ReadRequest {
+    request_id: u64,
+    central_identifier: String,
+    characteristic_uuid: String,
+    offset: usize,
+}
+
+/// Pending write request
+#[derive(Debug)]
+struct WriteRequest {
+    request_id: u64,
+    central_identifier: String,
+    characteristic_uuid: String,
+    value: Vec<u8>,
+    offset: usize,
+    response_needed: bool,
+}
+
+impl PeripheralManager {
+    /// Create a new PeripheralManager
+    ///
+    /// This initializes the CBPeripheralManager with default options.
+    /// The manager won't be ready until `state` becomes `PoweredOn`.
+    pub fn new() -> Result<Self> {
+        let (event_tx, event_rx) = mpsc::channel(100);
+        let delegate = Arc::new(PeripheralManagerDelegate::new(event_tx));
+
+        // TODO: Initialize CBPeripheralManager with objc2
+        // 1. Create dispatch queue for callbacks
+        // 2. Create CBPeripheralManager with delegate and queue
+        // 3. Store reference to manager
+        //
+        // Example objc2 code:
+        // ```
+        // use objc2::rc::Retained;
+        // use objc2_core_bluetooth::{CBPeripheralManager, CBPeripheralManagerDelegate};
+        //
+        // let queue = dispatch::Queue::new("com.hive.btle.peripheral", dispatch::QueueAttribute::Serial);
+        // let manager = unsafe {
+        //     CBPeripheralManager::initWithDelegate_queue_(
+        //         CBPeripheralManager::alloc(),
+        //         delegate_obj,
+        //         queue,
+        //     )
+        // };
+        // ```
+
+        log::warn!("PeripheralManager::new() - CoreBluetooth initialization not yet implemented");
+
+        Ok(Self {
+            state: Arc::new(RwLock::new(CentralState::Unknown)),
+            event_rx: Arc::new(RwLock::new(event_rx)),
+            delegate,
+            advertising: Arc::new(RwLock::new(false)),
+            services: Arc::new(RwLock::new(HashMap::new())),
+            subscribers: Arc::new(RwLock::new(HashMap::new())),
+            pending_reads: Arc::new(RwLock::new(HashMap::new())),
+            pending_writes: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+
+    /// Get the current peripheral manager state
+    pub async fn state(&self) -> CentralState {
+        *self.state.read().await
+    }
+
+    /// Wait for the peripheral manager to be ready (powered on)
+    pub async fn wait_ready(&self) -> Result<()> {
+        let state = self.state().await;
+        match state {
+            CentralState::PoweredOn => Ok(()),
+            CentralState::Unsupported => Err(BleError::NotSupported(
+                "Bluetooth not supported".to_string(),
+            )),
+            CentralState::Unauthorized => Err(BleError::PlatformError(
+                "Bluetooth not authorized".to_string(),
+            )),
+            CentralState::PoweredOff => Err(BleError::PlatformError(
+                "Bluetooth is powered off".to_string(),
+            )),
+            _ => Err(BleError::PlatformError(format!(
+                "Bluetooth not ready: {:?}",
+                state
+            ))),
+        }
+    }
+
+    /// Register the HIVE GATT service
+    ///
+    /// Creates the HIVE BLE service with all required characteristics.
+    pub async fn register_hive_service(&self, node_id: NodeId) -> Result<()> {
+        // HIVE GATT Service structure:
+        // - Service UUID: 0xD479 (HIVE_SERVICE_UUID)
+        //   - Node Info (0x0001): Read - Node ID, capabilities, hierarchy level
+        //   - Sync State (0x0002): Read/Write/Notify - Vector clock and sync metadata
+        //   - Sync Data (0x0003): Read/Write/Notify - CRDT delta payloads
+        //   - Command (0x0004): Write - Control commands
+        //   - Status (0x0005): Read/Notify - Connection status and errors
+
+        // TODO: Create CBMutableService and CBMutableCharacteristics
+        //
+        // Example objc2 code:
+        // ```
+        // let service_uuid = CBUUID::UUIDWithString_(ns_string!("D479"));
+        // let service = CBMutableService::initWithType_primary_(
+        //     CBMutableService::alloc(),
+        //     &service_uuid,
+        //     true,
+        // );
+        //
+        // let node_info_uuid = CBUUID::UUIDWithString_(ns_string!("0001"));
+        // let node_info_char = CBMutableCharacteristic::initWithType_properties_value_permissions_(
+        //     CBMutableCharacteristic::alloc(),
+        //     &node_info_uuid,
+        //     CBCharacteristicPropertyRead,
+        //     Some(&node_id_data),
+        //     CBAttributePermissionsReadable,
+        // );
+        //
+        // service.setCharacteristics_(&NSArray::from_vec(vec![node_info_char, ...]));
+        // manager.addService_(&service);
+        // ```
+
+        log::warn!(
+            "PeripheralManager::register_hive_service({:08X}) - Not yet implemented",
+            node_id.as_u32()
+        );
+
+        // Store service info
+        let service = ServiceInfo {
+            uuid: HIVE_SERVICE_UUID.to_string(),
+            is_primary: true,
+            characteristics: vec![
+                CharacteristicInfo {
+                    uuid: "0001".to_string(),
+                    properties: CharacteristicProperties::readable(),
+                    value: node_id.as_u32().to_le_bytes().to_vec(),
+                },
+                CharacteristicInfo {
+                    uuid: "0002".to_string(),
+                    properties: CharacteristicProperties::read_write_notify(),
+                    value: Vec::new(),
+                },
+                CharacteristicInfo {
+                    uuid: "0003".to_string(),
+                    properties: CharacteristicProperties::read_write_notify(),
+                    value: Vec::new(),
+                },
+                CharacteristicInfo {
+                    uuid: "0004".to_string(),
+                    properties: CharacteristicProperties::writable(),
+                    value: Vec::new(),
+                },
+                CharacteristicInfo {
+                    uuid: "0005".to_string(),
+                    properties: CharacteristicProperties::notify(),
+                    value: Vec::new(),
+                },
+            ],
+        };
+
+        self.services
+            .write()
+            .await
+            .insert(HIVE_SERVICE_UUID.to_string(), service);
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth service registration not yet implemented".to_string(),
+        ))
+    }
+
+    /// Unregister all GATT services
+    pub async fn unregister_all_services(&self) -> Result<()> {
+        // TODO: Call CBPeripheralManager.removeAllServices()
+
+        log::warn!("PeripheralManager::unregister_all_services() - Not yet implemented");
+
+        self.services.write().await.clear();
+        Ok(())
+    }
+
+    /// Start advertising
+    ///
+    /// # Arguments
+    /// * `node_id` - Node ID to include in advertisement
+    /// * `config` - Discovery configuration
+    pub async fn start_advertising(&self, node_id: NodeId, config: &DiscoveryConfig) -> Result<()> {
+        // TODO: Call CBPeripheralManager.startAdvertising:
+        //
+        // Advertisement data:
+        // - CBAdvertisementDataLocalNameKey: "HIVE-{node_id:08X}"
+        // - CBAdvertisementDataServiceUUIDsKey: [HIVE_SERVICE_UUID]
+        //
+        // Example objc2 code:
+        // ```
+        // let name = NSString::from_str(&format!("HIVE-{:08X}", node_id.as_u32()));
+        // let service_uuid = CBUUID::UUIDWithString_(ns_string!("D479"));
+        //
+        // let adv_data = NSDictionary::from_keys_and_objects(
+        //     &[
+        //         ns_string!("CBAdvertisementDataLocalNameKey"),
+        //         ns_string!("CBAdvertisementDataServiceUUIDsKey"),
+        //     ],
+        //     &[&*name, &*NSArray::from_vec(vec![service_uuid])],
+        // );
+        //
+        // manager.startAdvertising_(&adv_data);
+        // ```
+
+        log::warn!(
+            "PeripheralManager::start_advertising(HIVE-{:08X}) - Not yet implemented",
+            node_id.as_u32()
+        );
+
+        *self.advertising.write().await = true;
+        Err(BleError::NotSupported(
+            "CoreBluetooth advertising not yet implemented".to_string(),
+        ))
+    }
+
+    /// Stop advertising
+    pub async fn stop_advertising(&self) -> Result<()> {
+        // TODO: Call CBPeripheralManager.stopAdvertising()
+
+        log::warn!("PeripheralManager::stop_advertising() - Not yet implemented");
+
+        *self.advertising.write().await = false;
+        Ok(())
+    }
+
+    /// Check if currently advertising
+    pub async fn is_advertising(&self) -> bool {
+        *self.advertising.read().await
+    }
+
+    /// Respond to a read request
+    pub async fn respond_to_read_request(&self, request_id: u64, value: &[u8]) -> Result<()> {
+        // TODO: Call CBPeripheralManager.respondToRequest:withResult:
+        //
+        // 1. Look up the CBATTRequest from pending_reads
+        // 2. Set request.value = value
+        // 3. Call manager.respondToRequest:withResult:(request, CBATTErrorSuccess)
+
+        log::warn!(
+            "PeripheralManager::respond_to_read_request({}) - Not yet implemented",
+            request_id
+        );
+
+        self.pending_reads.write().await.remove(&request_id);
+        Err(BleError::NotSupported(
+            "CoreBluetooth read response not yet implemented".to_string(),
+        ))
+    }
+
+    /// Respond to a write request
+    pub async fn respond_to_write_request(&self, request_id: u64, success: bool) -> Result<()> {
+        // TODO: Call CBPeripheralManager.respondToRequest:withResult:
+        //
+        // 1. Look up the CBATTRequest from pending_writes
+        // 2. Call manager.respondToRequest:withResult:(request, result)
+        //    where result is CBATTErrorSuccess or appropriate error
+
+        log::warn!(
+            "PeripheralManager::respond_to_write_request({}, success={}) - Not yet implemented",
+            request_id,
+            success
+        );
+
+        self.pending_writes.write().await.remove(&request_id);
+        Err(BleError::NotSupported(
+            "CoreBluetooth write response not yet implemented".to_string(),
+        ))
+    }
+
+    /// Send notification to subscribed centrals
+    pub async fn send_notification(&self, characteristic_uuid: &str, value: &[u8]) -> Result<bool> {
+        // TODO: Call CBPeripheralManager.updateValue:forCharacteristic:onSubscribedCentrals:
+        //
+        // Returns true if update was queued, false if queue is full
+        // (check peripheralManagerIsReadyToUpdateSubscribers callback)
+        //
+        // Example objc2 code:
+        // ```
+        // let data = NSData::from_vec(value.to_vec());
+        // let result = manager.updateValue_forCharacteristic_onSubscribedCentrals_(
+        //     &data,
+        //     &characteristic,
+        //     None, // nil = all subscribers
+        // );
+        // ```
+
+        log::warn!(
+            "PeripheralManager::send_notification({}) - Not yet implemented",
+            characteristic_uuid
+        );
+
+        Err(BleError::NotSupported(
+            "CoreBluetooth notifications not yet implemented".to_string(),
+        ))
+    }
+
+    /// Get subscribers for a characteristic
+    pub async fn get_subscribers(&self, characteristic_uuid: &str) -> Vec<String> {
+        let subscribers = self.subscribers.read().await;
+        subscribers
+            .get(characteristic_uuid)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Process pending delegate events
+    pub async fn process_events(&self) -> Result<()> {
+        let mut event_rx = self.event_rx.write().await;
+
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                PeripheralManagerEvent::StateChanged(state) => {
+                    *self.state.write().await = state;
+                }
+                PeripheralManagerEvent::ServiceAdded {
+                    service_uuid,
+                    error,
+                } => {
+                    if let Some(e) = error {
+                        log::error!("Failed to add service {}: {}", service_uuid, e);
+                    }
+                }
+                PeripheralManagerEvent::AdvertisingStarted { error } => {
+                    if let Some(e) = error {
+                        log::error!("Advertising failed: {}", e);
+                        *self.advertising.write().await = false;
+                    }
+                }
+                PeripheralManagerEvent::CentralSubscribed {
+                    central_identifier,
+                    characteristic_uuid,
+                } => {
+                    let mut subscribers = self.subscribers.write().await;
+                    subscribers
+                        .entry(characteristic_uuid)
+                        .or_default()
+                        .push(central_identifier);
+                }
+                PeripheralManagerEvent::CentralUnsubscribed {
+                    central_identifier,
+                    characteristic_uuid,
+                } => {
+                    let mut subscribers = self.subscribers.write().await;
+                    if let Some(subs) = subscribers.get_mut(&characteristic_uuid) {
+                        subs.retain(|id| id != &central_identifier);
+                    }
+                }
+                PeripheralManagerEvent::ReadRequest {
+                    request_id,
+                    central_identifier,
+                    characteristic_uuid,
+                    offset,
+                } => {
+                    self.pending_reads.write().await.insert(
+                        request_id,
+                        ReadRequest {
+                            request_id,
+                            central_identifier,
+                            characteristic_uuid,
+                            offset,
+                        },
+                    );
+                }
+                PeripheralManagerEvent::WriteRequest {
+                    request_id,
+                    central_identifier,
+                    characteristic_uuid,
+                    value,
+                    offset,
+                    response_needed,
+                } => {
+                    self.pending_writes.write().await.insert(
+                        request_id,
+                        WriteRequest {
+                            request_id,
+                            central_identifier,
+                            characteristic_uuid,
+                            value,
+                            offset,
+                            response_needed,
+                        },
+                    );
+                }
+                PeripheralManagerEvent::ReadyToUpdateSubscribers => {
+                    // Signal that we can send more notifications
+                    log::trace!("Ready to send more notifications");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_characteristic_properties() {
+        let props = CharacteristicProperties::read_write_notify();
+        assert!(props.read);
+        assert!(props.write);
+        assert!(props.notify);
+        assert!(!props.indicate);
+
+        let raw = props.to_raw();
+        assert_eq!(raw, 0x02 | 0x08 | 0x10); // Read | Write | Notify
+    }
+
+    #[test]
+    fn test_service_info() {
+        let service = ServiceInfo {
+            uuid: "D479".to_string(),
+            is_primary: true,
+            characteristics: vec![CharacteristicInfo {
+                uuid: "0001".to_string(),
+                properties: CharacteristicProperties::readable(),
+                value: vec![0xDE, 0xAD, 0xBE, 0xEF],
+            }],
+        };
+
+        assert!(service.is_primary);
+        assert_eq!(service.characteristics.len(), 1);
+    }
+}


### PR DESCRIPTION
## Summary

- Add Apple platform module structure with CoreBluetooth framework scaffold
- Replace 7-line placeholder stub with comprehensive 2,558 lines of scaffolding
- All methods include TODO markers for objc2 implementation details

### New Files

| File | Lines | Description |
|------|-------|-------------|
| `apple/mod.rs` | 68 | Module structure, iOS background mode docs |
| `apple/adapter.rs` | 380 | `CoreBluetoothAdapter` implementing `BleAdapter` |
| `apple/connection.rs` | 415 | `CoreBluetoothConnection` implementing `BleConnection` |
| `apple/central.rs` | 290 | `CentralManager` wrapping CBCentralManager |
| `apple/peripheral.rs` | 530 | `PeripheralManager` wrapping CBPeripheralManager |
| `apple/delegates.rs` | 720 | Objective-C delegate implementations |

### Architecture

```
┌─────────────────────────────────────────┐
│       CoreBluetoothAdapter (Rust)        │
├─────────────────────────────────────────┤
│  CentralManager    │  PeripheralManager │
│   (scanning,       │   (advertising,    │
│    connecting)     │    GATT server)    │
├─────────────────────────────────────────┤
│           Objective-C Delegates          │
│  (CentralDelegate, PeripheralDelegate)  │
├─────────────────────────────────────────┤
│            CoreBluetooth Framework       │
└─────────────────────────────────────────┘
```

### Key Components

**CentralManager (GATT Client)**
- Scan for HIVE peripherals
- Connect/disconnect management
- Service/characteristic discovery
- Read/write/notify operations

**PeripheralManager (GATT Server)**
- HIVE service registration with all characteristics
- Advertisement management
- Read/write request handling
- Notification sending to subscribers

**Delegates**
- `CentralDelegate` → CBCentralManagerDelegate
- `PeripheralDelegate` → CBPeripheralDelegate  
- `PeripheralManagerDelegate` → CBPeripheralManagerDelegate
- Event forwarding to Rust async channels

### iOS Background Execution

Documentation includes Info.plist requirements:
```xml
<key>UIBackgroundModes</key>
<array>
    <string>bluetooth-central</string>
    <string>bluetooth-peripheral</string>
</array>
```

### Build Status

- `cargo check -p hive-btle` passes (default features)
- `cargo check --features ios` requires Apple target (expected)
- All 222 existing tests pass

## Context

Part of Epic #401 (HIVE-BTLE Mesh Transport) and OSS release tracking #453.
This provides the foundation for iOS/macOS BLE implementation using the
objc2 crate for CoreBluetooth bindings.

## Test plan

- [x] `cargo check -p hive-btle` passes
- [x] `cargo test -p hive-btle` - 222 tests pass
- [ ] iOS Simulator tests (to be added with objc2 implementation)
- [ ] macOS tests (to be added with objc2 implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)