### PR TITLE
feat(hive-btle): Add mesh management API for automatic peer connectivity (Issue #410)

### DIFF
--- a/examples/android-hive-demo/app/src/main/java/com/hive/demo/MainActivity.kt
+++ b/examples/android-hive-demo/app/src/main/java/com/hive/demo/MainActivity.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
@@ -16,20 +17,22 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.hive.btle.DiscoveredDevice
 import com.hive.btle.HiveBtle
+import com.hive.btle.HiveEventType
+import com.hive.btle.HiveMeshListener
+import com.hive.btle.HivePeer
 import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Demo activity for HIVE BLE mesh connectivity.
  *
  * This app demonstrates:
- * 1. Scanning for HIVE BLE nodes (e.g., M5Stack Core2 devices)
- * 2. Connecting to discovered nodes
- * 3. Advertising as a HIVE node
- * 4. CRDT sync data exchange
+ * 1. Starting a HIVE mesh network
+ * 2. Automatic peer discovery and connection
+ * 3. Sending/receiving events (Emergency, ACK)
+ * 4. CRDT sync across the mesh
  */
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(), HiveMeshListener {
 
     companion object {
         private const val TAG = "HiveDemo"
@@ -37,14 +40,22 @@ class MainActivity : AppCompatActivity() {
     }
 
     private lateinit var hiveBtle: HiveBtle
-    private lateinit var deviceAdapter: DeviceAdapter
-    private val discoveredDevices = ConcurrentHashMap<String, DiscoveredDevice>()
+    private lateinit var peerAdapter: PeerAdapter
 
     // UI elements
     private lateinit var statusText: TextView
-    private lateinit var scanButton: Button
-    private lateinit var advertiseButton: Button
-    private lateinit var deviceList: RecyclerView
+    private lateinit var connectedCountText: TextView
+    private lateinit var peerList: RecyclerView
+    private lateinit var emergencyButton: Button
+    private lateinit var ackButton: Button
+    private lateinit var resetButton: Button
+    private lateinit var ackStatusPanel: LinearLayout
+    private lateinit var ackStatusText: TextView
+
+    // Alert state
+    private var alertActive = false
+    private val pendingAcks = ConcurrentHashMap<Long, Boolean>() // nodeId -> has acked
+    private var emergencySourceNodeId: Long? = null
 
     // Permission launcher
     private val permissionLauncher = registerForActivityResult(
@@ -66,20 +77,23 @@ class MainActivity : AppCompatActivity() {
 
         // Initialize UI
         statusText = findViewById(R.id.statusText)
-        scanButton = findViewById(R.id.scanButton)
-        advertiseButton = findViewById(R.id.advertiseButton)
-        deviceList = findViewById(R.id.deviceList)
+        connectedCountText = findViewById(R.id.connectedDeviceText)
+        peerList = findViewById(R.id.deviceList)
+        emergencyButton = findViewById(R.id.emergencyButton)
+        ackButton = findViewById(R.id.ackButton)
+        resetButton = findViewById(R.id.resetButton)
+        ackStatusPanel = findViewById(R.id.ackStatusPanel)
+        ackStatusText = findViewById(R.id.ackStatusText)
 
         // Setup RecyclerView
-        deviceAdapter = DeviceAdapter(
-            onDeviceClick = { device -> connectToDevice(device) }
-        )
-        deviceList.layoutManager = LinearLayoutManager(this)
-        deviceList.adapter = deviceAdapter
+        peerAdapter = PeerAdapter()
+        peerList.layoutManager = LinearLayoutManager(this)
+        peerList.adapter = peerAdapter
 
         // Setup button listeners
-        scanButton.setOnClickListener { toggleScan() }
-        advertiseButton.setOnClickListener { toggleAdvertise() }
+        emergencyButton.setOnClickListener { sendEmergency() }
+        ackButton.setOnClickListener { sendAck() }
+        resetButton.setOnClickListener { resetAlert() }
 
         // Check permissions
         if (hasAllPermissions()) {
@@ -89,37 +103,10 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        // Stop scanning when app goes to background to save battery
-        if (::hiveBtle.isInitialized && hiveBtle.isScanning()) {
-            hiveBtle.stopScan()
-            Log.i(TAG, "Stopped scanning (app paused)")
-        }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        // Resume scanning when app comes back
-        if (::hiveBtle.isInitialized && !hiveBtle.isScanning()) {
-            try {
-                hiveBtle.startScan { device ->
-                    runOnUiThread {
-                        onDeviceDiscovered(device)
-                    }
-                }
-                scanButton.text = "Stop Scan"
-                Log.i(TAG, "Resumed scanning")
-            } catch (e: Exception) {
-                Log.e(TAG, "Failed to resume scanning", e)
-            }
-        }
-    }
-
     override fun onDestroy() {
         super.onDestroy()
         if (::hiveBtle.isInitialized) {
-            Log.i(TAG, "Shutting down HIVE BLE")
+            Log.i(TAG, "Shutting down HIVE mesh")
             hiveBtle.shutdown()
         }
     }
@@ -166,8 +153,10 @@ class MainActivity : AppCompatActivity() {
             hiveBtle.init()
             Log.i(TAG, "HIVE BLE initialized")
 
-            // Auto-start scanning and advertising
-            startAutoMode()
+            // Start the mesh - it handles everything automatically
+            hiveBtle.startMesh(this)
+            updateStatus("Mesh active - HIVE-${String.format("%08X", NODE_ID)}")
+
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize HIVE BLE", e)
             updateStatus("Error: ${e.message}")
@@ -175,115 +164,171 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun startAutoMode() {
-        // Start advertising
-        try {
-            hiveBtle.startAdvertising()
-            advertiseButton.text = "Stop Advertise"
-            Log.i(TAG, "Auto-started advertising")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to auto-start advertising", e)
+    // ==================== HiveMeshListener Implementation ====================
+
+    override fun onMeshUpdated(peers: List<HivePeer>) {
+        Log.d(TAG, "Mesh updated: ${peers.size} peers")
+        for (peer in peers) {
+            Log.d(TAG, "  Peer: ${peer.displayName()} connected=${peer.isConnected} rssi=${peer.rssi}")
         }
+        runOnUiThread {
+            peerAdapter.updatePeers(peers)
 
-        // Start scanning with callback
-        try {
-            hiveBtle.startScan { device ->
-                runOnUiThread {
-                    onDeviceDiscovered(device)
-                }
-            }
-            scanButton.text = "Stop Scan"
-            Log.i(TAG, "Auto-started scanning")
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to auto-start scanning", e)
-        }
-
-        updateStatus("Scanning & Advertising - HIVE-${String.format("%08X", NODE_ID)}")
-    }
-
-    private fun toggleScan() {
-        if (!::hiveBtle.isInitialized) {
-            Toast.makeText(this, "Not initialized", Toast.LENGTH_SHORT).show()
-            return
-        }
-
-        if (hiveBtle.isScanning()) {
-            hiveBtle.stopScan()
-            scanButton.text = "Start Scan"
-            updateStatus("Scan stopped")
-        } else {
-            discoveredDevices.clear()
-            deviceAdapter.updateDevices(emptyList())
-
-            hiveBtle.startScan { device ->
-                runOnUiThread {
-                    onDeviceDiscovered(device)
-                }
-            }
-            scanButton.text = "Stop Scan"
-            updateStatus("Scanning for HIVE devices...")
-        }
-    }
-
-    private fun toggleAdvertise() {
-        if (!::hiveBtle.isInitialized) {
-            Toast.makeText(this, "Not initialized", Toast.LENGTH_SHORT).show()
-            return
-        }
-
-        if (hiveBtle.isAdvertising()) {
-            hiveBtle.stopAdvertising()
-            advertiseButton.text = "Start Advertise"
-            updateStatus("Advertising stopped")
-        } else {
-            hiveBtle.startAdvertising()
-            advertiseButton.text = "Stop Advertise"
-            updateStatus("Advertising as HIVE-${String.format("%08X", NODE_ID)}")
-        }
-    }
-
-    private fun onDeviceDiscovered(device: DiscoveredDevice) {
-        Log.d(TAG, "Discovered: ${device.address} (${device.name}) RSSI=${device.rssi}")
-        discoveredDevices[device.address] = device
-        deviceAdapter.updateDevices(discoveredDevices.values.toList().sortedByDescending { it.rssi })
-    }
-
-    private fun connectToDevice(device: DiscoveredDevice) {
-        Log.i(TAG, "Connecting to ${device.address}")
-        updateStatus("Connecting to ${device.name.ifEmpty { device.address }}...")
-
-        try {
-            val connection = hiveBtle.connect(device.address)
-            if (connection != null) {
-                updateStatus("Connected to ${device.address}")
-                Toast.makeText(this, "Connected!", Toast.LENGTH_SHORT).show()
+            val connectedCount = peers.count { it.isConnected }
+            if (peers.isEmpty()) {
+                connectedCountText.visibility = View.GONE
             } else {
-                updateStatus("Connection failed")
-                Toast.makeText(this, "Connection failed", Toast.LENGTH_SHORT).show()
+                connectedCountText.text = "$connectedCount/${peers.size} peers connected"
+                connectedCountText.visibility = View.VISIBLE
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Connection error", e)
-            updateStatus("Error: ${e.message}")
+        }
+    }
+
+    override fun onPeerEvent(peer: HivePeer, eventType: HiveEventType) {
+        Log.i(TAG, "Peer event: ${peer.displayName()} sent $eventType")
+
+        runOnUiThread {
+            when (eventType) {
+                HiveEventType.EMERGENCY -> handleEmergencyReceived(peer)
+                HiveEventType.ACK -> handleAckReceived(peer)
+                HiveEventType.NEED_ASSIST -> {
+                    Toast.makeText(this, "🆘 ${peer.displayName()} needs assistance", Toast.LENGTH_LONG).show()
+                }
+                HiveEventType.PING -> {
+                    Toast.makeText(this, "📍 Ping from ${peer.displayName()}", Toast.LENGTH_SHORT).show()
+                }
+                else -> {}
+            }
+        }
+    }
+
+    // ==================== Event Handling ====================
+
+    private fun handleEmergencyReceived(peer: HivePeer) {
+        alertActive = true
+        emergencySourceNodeId = peer.nodeId
+
+        // Initialize ACK tracking
+        pendingAcks.clear()
+        for (p in hiveBtle.getPeers()) {
+            pendingAcks[p.nodeId] = false
+        }
+        pendingAcks[NODE_ID] = false // We haven't acked yet
+        pendingAcks[peer.nodeId] = true // Source has implicitly acked
+
+        Toast.makeText(this, "🚨 EMERGENCY from ${peer.displayName()}!", Toast.LENGTH_LONG).show()
+        updateStatus("⚠️ EMERGENCY - TAP ACK")
+        updateAckStatusDisplay()
+
+        // Vibrate
+        vibrate()
+    }
+
+    private fun handleAckReceived(peer: HivePeer) {
+        pendingAcks[peer.nodeId] = true
+        Toast.makeText(this, "✓ ACK from ${peer.displayName()}", Toast.LENGTH_SHORT).show()
+        checkAllAcked()
+    }
+
+    private fun sendEmergency() {
+        Log.i(TAG, ">>> SENDING EMERGENCY")
+        alertActive = true
+        emergencySourceNodeId = NODE_ID
+
+        // Initialize ACK tracking
+        pendingAcks.clear()
+        for (peer in hiveBtle.getPeers()) {
+            pendingAcks[peer.nodeId] = false
+        }
+        pendingAcks[NODE_ID] = true // We sent it, so we're acked
+
+        hiveBtle.sendEvent(HiveEventType.EMERGENCY)
+        Toast.makeText(this, "🚨 EMERGENCY SENT!", Toast.LENGTH_SHORT).show()
+        updateAckStatusDisplay()
+    }
+
+    private fun sendAck() {
+        Log.i(TAG, ">>> SENDING ACK")
+
+        hiveBtle.sendEvent(HiveEventType.ACK)
+        Toast.makeText(this, "✓ ACK sent", Toast.LENGTH_SHORT).show()
+
+        pendingAcks[NODE_ID] = true
+        checkAllAcked()
+    }
+
+    private fun resetAlert() {
+        Log.i(TAG, ">>> RESETTING ALERT")
+        alertActive = false
+        pendingAcks.clear()
+        emergencySourceNodeId = null
+        updateAckStatusDisplay()
+        updateStatus("Mesh active - HIVE-${String.format("%08X", NODE_ID)}")
+        Toast.makeText(this, "Alert reset", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun checkAllAcked() {
+        if (pendingAcks.isNotEmpty() && pendingAcks.values.all { it }) {
+            alertActive = false
+            pendingAcks.clear()
+            emergencySourceNodeId = null
+            updateAckStatusDisplay()
+            updateStatus("All peers acknowledged")
+        } else {
+            updateAckStatusDisplay()
+        }
+    }
+
+    private fun updateAckStatusDisplay() {
+        if (alertActive && pendingAcks.isNotEmpty()) {
+            ackStatusPanel.visibility = View.VISIBLE
+
+            val ackedNodes = pendingAcks.filter { it.value }.keys
+            val notAckedNodes = pendingAcks.filter { !it.value }.keys
+
+            val statusBuilder = StringBuilder()
+            if (ackedNodes.isNotEmpty()) {
+                statusBuilder.append("✓ ACK'd: ")
+                statusBuilder.append(ackedNodes.joinToString(", ") { "HIVE-${String.format("%08X", it)}" })
+            }
+            if (notAckedNodes.isNotEmpty()) {
+                if (statusBuilder.isNotEmpty()) statusBuilder.append("\n")
+                statusBuilder.append("⏳ Waiting: ")
+                statusBuilder.append(notAckedNodes.joinToString(", ") { "HIVE-${String.format("%08X", it)}" })
+            }
+
+            ackStatusText.text = statusBuilder.toString()
+        } else {
+            ackStatusPanel.visibility = View.GONE
         }
     }
 
     private fun updateStatus(text: String) {
-        runOnUiThread {
-            statusText.text = text
+        statusText.text = text
+    }
+
+    private fun vibrate() {
+        try {
+            val vibrator = getSystemService(android.content.Context.VIBRATOR_SERVICE) as? android.os.Vibrator
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                vibrator?.vibrate(android.os.VibrationEffect.createOneShot(500, android.os.VibrationEffect.DEFAULT_AMPLITUDE))
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator?.vibrate(500)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Vibration failed", e)
         }
     }
 
-    /**
-     * RecyclerView adapter for discovered devices
-     */
-    inner class DeviceAdapter(
-        private val onDeviceClick: (DiscoveredDevice) -> Unit
-    ) : RecyclerView.Adapter<DeviceAdapter.ViewHolder>() {
+    // ==================== RecyclerView Adapter ====================
 
-        private var devices: List<DiscoveredDevice> = emptyList()
+    inner class PeerAdapter : RecyclerView.Adapter<PeerAdapter.ViewHolder>() {
 
-        fun updateDevices(newDevices: List<DiscoveredDevice>) {
-            devices = newDevices
+        private var peers: List<HivePeer> = emptyList()
+
+        fun updatePeers(newPeers: List<HivePeer>) {
+            peers = newPeers.sortedByDescending { it.rssi }
             notifyDataSetChanged()
         }
 
@@ -294,30 +339,28 @@ class MainActivity : AppCompatActivity() {
         }
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val device = devices[position]
-            holder.bind(device)
+            holder.bind(peers[position])
         }
 
-        override fun getItemCount() = devices.size
+        override fun getItemCount() = peers.size
 
         inner class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
             private val nameText: TextView = view.findViewById(R.id.deviceName)
             private val addressText: TextView = view.findViewById(R.id.deviceAddress)
             private val rssiText: TextView = view.findViewById(R.id.deviceRssi)
 
-            fun bind(device: DiscoveredDevice) {
-                nameText.text = device.name.ifEmpty { "Unknown" }
-                addressText.text = device.address
-                rssiText.text = "${device.rssi} dBm"
+            fun bind(peer: HivePeer) {
+                nameText.text = peer.displayName()
+                addressText.text = if (peer.isConnected) "● Connected" else "○ Discovered"
+                rssiText.text = "${peer.rssi} dBm"
 
-                // Highlight HIVE devices
-                if (device.name.startsWith("HIVE-") || device.nodeId != null) {
-                    nameText.setTextColor(ContextCompat.getColor(itemView.context, android.R.color.holo_green_dark))
+                // Color based on connection status
+                val color = if (peer.isConnected) {
+                    ContextCompat.getColor(itemView.context, android.R.color.holo_green_light)
                 } else {
-                    nameText.setTextColor(ContextCompat.getColor(itemView.context, android.R.color.white))
+                    ContextCompat.getColor(itemView.context, android.R.color.darker_gray)
                 }
-
-                itemView.setOnClickListener { onDeviceClick(device) }
+                nameText.setTextColor(color)
             }
         }
     }

--- a/examples/android-hive-demo/app/src/main/res/layout/activity_main.xml
+++ b/examples/android-hive-demo/app/src/main/res/layout/activity_main.xml
@@ -26,9 +26,20 @@
         android:text="Initializing..."
         android:textSize="14sp"
         android:textColor="#888888"
+        android:layout_marginBottom="8dp" />
+
+    <!-- Connected device info -->
+    <TextView
+        android:id="@+id/connectedDeviceText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Not connected"
+        android:textSize="16sp"
+        android:textColor="#00aa00"
+        android:visibility="gone"
         android:layout_marginBottom="16dp" />
 
-    <!-- Control buttons -->
+    <!-- Action buttons (Emergency/Ack/Reset) -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -36,28 +47,72 @@
         android:layout_marginBottom="16dp">
 
         <Button
-            android:id="@+id/scanButton"
+            android:id="@+id/emergencyButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Start Scan"
-            android:layout_marginEnd="8dp" />
+            android:text="EMERGENCY"
+            android:backgroundTint="#cc0000"
+            android:textColor="#ffffff"
+            android:layout_marginEnd="4dp" />
 
         <Button
-            android:id="@+id/advertiseButton"
+            android:id="@+id/ackButton"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Start Advertise"
-            android:layout_marginStart="8dp" />
+            android:text="ACK"
+            android:backgroundTint="#00aa00"
+            android:textColor="#ffffff"
+            android:layout_marginHorizontal="4dp" />
+
+        <Button
+            android:id="@+id/resetButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="RESET"
+            android:backgroundTint="#666666"
+            android:textColor="#ffffff"
+            android:layout_marginStart="4dp" />
 
     </LinearLayout>
 
-    <!-- Device list header -->
+    <!-- ACK Status Panel (shown during emergency) -->
+    <LinearLayout
+        android:id="@+id/ackStatusPanel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="#331a00"
+        android:padding="8dp"
+        android:layout_marginBottom="8dp"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="⚠️ EMERGENCY ACTIVE"
+            android:textSize="14sp"
+            android:textColor="#ffaa00"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/ackStatusText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Waiting for acknowledgments..."
+            android:textSize="12sp"
+            android:textColor="#cccccc"
+            android:layout_marginTop="4dp" />
+
+    </LinearLayout>
+
+    <!-- Peer list header -->
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Discovered Devices"
+        android:text="Mesh Peers"
         android:textSize="16sp"
         android:textColor="#ffffff"
         android:layout_marginBottom="8dp" />

--- a/hive-btle/android/src/main/java/com/hive/btle/GattCallbackProxy.kt
+++ b/hive-btle/android/src/main/java/com/hive/btle/GattCallbackProxy.kt
@@ -8,6 +8,26 @@ import android.bluetooth.BluetoothProfile
 import android.util.Log
 
 /**
+ * Listener interface for HIVE document events.
+ */
+interface HiveDocumentListener {
+    /**
+     * Called when document data is received (via read or notification).
+     */
+    fun onDocumentReceived(data: ByteArray)
+
+    /**
+     * Called when services are discovered.
+     */
+    fun onServicesDiscovered() {}
+
+    /**
+     * Called when connection state changes.
+     */
+    fun onConnectionStateChanged(connected: Boolean) {}
+}
+
+/**
  * Proxy class that forwards GATT events to native Rust code via JNI.
  *
  * This class extends Android's BluetoothGattCallback and bridges all GATT
@@ -23,6 +43,11 @@ import android.util.Log
  * @param connectionId Unique identifier for this connection (used by native code)
  */
 class GattCallbackProxy(private val connectionId: Long) : BluetoothGattCallback() {
+
+    /**
+     * Optional listener for document events.
+     */
+    var documentListener: HiveDocumentListener? = null
 
     companion object {
         private const val TAG = "HiveBtle.GattCallback"
@@ -65,6 +90,9 @@ class GattCallbackProxy(private val connectionId: Long) : BluetoothGattCallback(
         val address = gatt.device?.address ?: ""
         nativeOnConnectionStateChange(connectionId, address, status, newState)
 
+        // Notify listener
+        documentListener?.onConnectionStateChanged(newState == STATE_CONNECTED)
+
         // Auto-discover services on connect
         if (newState == STATE_CONNECTED && status == GATT_SUCCESS) {
             Log.d(TAG, "Starting service discovery")
@@ -99,6 +127,11 @@ class GattCallbackProxy(private val connectionId: Long) : BluetoothGattCallback(
         }
 
         nativeOnServicesDiscovered(connectionId, address, status, serviceUuids)
+
+        // Notify listener
+        if (status == GATT_SUCCESS) {
+            documentListener?.onServicesDiscovered()
+        }
     }
 
     /**
@@ -124,6 +157,15 @@ class GattCallbackProxy(private val connectionId: Long) : BluetoothGattCallback(
             status,
             value
         )
+
+        // Notify listener if this is the HIVE document characteristic
+        if (status == GATT_SUCCESS && isHiveDocumentCharacteristic(characteristic)) {
+            documentListener?.onDocumentReceived(value)
+        }
+    }
+
+    private fun isHiveDocumentCharacteristic(characteristic: BluetoothGattCharacteristic): Boolean {
+        return characteristic.uuid.toString().contains("F47B", ignoreCase = true)
     }
 
     /**
@@ -144,6 +186,11 @@ class GattCallbackProxy(private val connectionId: Long) : BluetoothGattCallback(
             status,
             value
         )
+
+        // Notify listener if this is the HIVE document characteristic
+        if (status == GATT_SUCCESS && isHiveDocumentCharacteristic(characteristic)) {
+            documentListener?.onDocumentReceived(value)
+        }
     }
 
     /**
@@ -188,6 +235,11 @@ class GattCallbackProxy(private val connectionId: Long) : BluetoothGattCallback(
             characteristic.uuid.toString(),
             value
         )
+
+        // Notify listener if this is the HIVE document characteristic
+        if (isHiveDocumentCharacteristic(characteristic)) {
+            documentListener?.onDocumentReceived(value)
+        }
     }
 
     /**
@@ -206,6 +258,11 @@ class GattCallbackProxy(private val connectionId: Long) : BluetoothGattCallback(
             characteristic.uuid.toString(),
             value
         )
+
+        // Notify listener if this is the HIVE document characteristic
+        if (isHiveDocumentCharacteristic(characteristic)) {
+            documentListener?.onDocumentReceived(value)
+        }
     }
 
     /**

--- a/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
+++ b/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
@@ -4,6 +4,8 @@ import android.Manifest
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGattCharacteristic
+import android.bluetooth.BluetoothGattDescriptor
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.AdvertiseData
 import android.bluetooth.le.AdvertiseSettings
@@ -20,6 +22,8 @@ import androidx.core.content.ContextCompat
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
+import android.os.Handler
+import android.os.Looper
 
 /**
  * Main entry point for HIVE BLE operations on Android.
@@ -129,9 +133,41 @@ class HiveBtle(
     private var isInitialized = false
     private var isScanning = false
     private var isAdvertising = false
+    private var isMeshRunning = false
 
     // Native handle
     private var nativeHandle: Long = 0
+
+    // Mesh management
+    private val peers = ConcurrentHashMap<Long, HivePeer>() // nodeId -> peer
+    private val addressToNodeId = ConcurrentHashMap<String, Long>() // address -> nodeId
+    private var meshListener: HiveMeshListener? = null
+    private val handler = Handler(Looper.getMainLooper())
+    private var localDocument: HiveDocument? = null
+    private var localCounter = mutableListOf<GCounterEntry>()
+
+    // Mesh configuration
+    private val PEER_TIMEOUT_MS = 30000L // Remove peers after 30s without advertisement
+    private val CLEANUP_INTERVAL_MS = 10000L // Cleanup check interval
+    private val SYNC_INTERVAL_MS = 3000L // Sync documents every 3s
+
+    private val cleanupRunnable = object : Runnable {
+        override fun run() {
+            cleanupStalePeers()
+            if (isMeshRunning) {
+                handler.postDelayed(this, CLEANUP_INTERVAL_MS)
+            }
+        }
+    }
+
+    private val syncRunnable = object : Runnable {
+        override fun run() {
+            syncWithPeers()
+            if (isMeshRunning) {
+                handler.postDelayed(this, SYNC_INTERVAL_MS)
+            }
+        }
+    }
 
     /**
      * Initialize the HIVE BLE adapter.
@@ -432,10 +468,439 @@ class HiveBtle(
         }
     }
 
+    // ==================== Mesh Management API ====================
+
+    /**
+     * Start the HIVE mesh network.
+     *
+     * This starts scanning, advertising, and automatically manages
+     * connections to discovered HIVE peers. The mesh handles document
+     * synchronization automatically.
+     *
+     * @param listener Callback for mesh events (peer updates, events)
+     */
+    fun startMesh(listener: HiveMeshListener) {
+        checkInitialized()
+
+        if (isMeshRunning) {
+            Log.w(TAG, "Mesh already running")
+            return
+        }
+
+        meshListener = listener
+        isMeshRunning = true
+
+        // Start advertising
+        try {
+            startAdvertising()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start advertising", e)
+        }
+
+        // Start scanning with internal handler
+        try {
+            startScan { device -> onDeviceDiscovered(device) }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start scanning", e)
+        }
+
+        // Start periodic tasks
+        handler.post(cleanupRunnable)
+        handler.postDelayed(syncRunnable, SYNC_INTERVAL_MS)
+
+        Log.i(TAG, "Mesh started for HIVE-${String.format("%08X", nodeId)}")
+    }
+
+    /**
+     * Stop the HIVE mesh network.
+     */
+    fun stopMesh() {
+        if (!isMeshRunning) return
+
+        isMeshRunning = false
+        handler.removeCallbacks(cleanupRunnable)
+        handler.removeCallbacks(syncRunnable)
+
+        stopScan()
+        stopAdvertising()
+
+        // Disconnect all peers
+        for (address in connections.keys.toList()) {
+            disconnect(address)
+        }
+
+        peers.clear()
+        addressToNodeId.clear()
+        meshListener = null
+
+        Log.i(TAG, "Mesh stopped")
+    }
+
+    /**
+     * Send an event to all peers in the mesh.
+     *
+     * @param eventType The event to broadcast
+     */
+    fun sendEvent(eventType: HiveEventType) {
+        if (!isMeshRunning) {
+            Log.w(TAG, "Mesh not running, cannot send event")
+            return
+        }
+
+        Log.i(TAG, "Broadcasting event: $eventType")
+
+        // Increment our counter
+        incrementLocalCounter()
+
+        // Create document with event
+        val peripheral = HivePeripheral(
+            id = nodeId,
+            parentNode = 0,
+            peripheralType = HivePeripheralType.SOLDIER_SENSOR,
+            callsign = "ANDROID",
+            health = HiveHealthStatus(100, null, 0, 0),
+            lastEvent = HivePeripheralEvent(eventType, System.currentTimeMillis()),
+            timestamp = System.currentTimeMillis()
+        )
+
+        val documentBytes = HiveDocument.encode(nodeId, localCounter, peripheral)
+
+        // Send to all connected peers
+        for ((address, gatt) in connections) {
+            writeDocumentToGatt(gatt, documentBytes)
+        }
+    }
+
+    /**
+     * Get the current list of peers in the mesh.
+     */
+    fun getPeers(): List<HivePeer> = peers.values.toList()
+
+    /**
+     * Get a specific peer by node ID.
+     */
+    fun getPeer(nodeId: Long): HivePeer? = peers[nodeId]
+
+    /**
+     * Check if the mesh is running.
+     */
+    fun isMeshRunning(): Boolean = isMeshRunning
+
+    // ==================== Internal Mesh Methods ====================
+
+    private fun onDeviceDiscovered(device: DiscoveredDevice) {
+        if (!device.isHiveDevice) return
+
+        // Check if we already know this address (peer might have been renamed by document)
+        val knownNodeId = addressToNodeId[device.address]
+        if (knownNodeId != null) {
+            // Update existing peer by address
+            peers[knownNodeId]?.let { peer ->
+                peer.rssi = device.rssi
+                peer.lastSeen = System.currentTimeMillis()
+                notifyMeshUpdated()
+            }
+            return
+        }
+
+        // Derive nodeId from name, service data, or address for new peers
+        val peerNodeId = device.nodeId ?: deriveNodeIdFromAddress(device.address)
+
+        // Don't track ourselves
+        if (peerNodeId == nodeId) return
+
+        val now = System.currentTimeMillis()
+        addressToNodeId[device.address] = peerNodeId
+
+        val existingPeer = peers[peerNodeId]
+        if (existingPeer != null) {
+            // Update existing peer
+            existingPeer.rssi = device.rssi
+            existingPeer.lastSeen = now
+        } else {
+            // New peer discovered
+            val peer = HivePeer(
+                nodeId = peerNodeId,
+                address = device.address,
+                name = device.name.ifEmpty { "HIVE-${String.format("%08X", peerNodeId)}" },
+                rssi = device.rssi,
+                isConnected = false,
+                lastDocument = null,
+                lastSeen = now
+            )
+            peers[peerNodeId] = peer
+            Log.i(TAG, "New peer discovered: ${peer.displayName()}")
+
+            // Auto-connect to new peer
+            connectToPeer(peer)
+        }
+
+        notifyMeshUpdated()
+    }
+
+    private fun connectToPeer(peer: HivePeer) {
+        if (connections.containsKey(peer.address)) {
+            Log.d(TAG, "Already connected to ${peer.displayName()}")
+            return
+        }
+
+        Log.i(TAG, "Connecting to peer: ${peer.displayName()}")
+
+        val adapter = bluetoothAdapter ?: return
+
+        try {
+            val device = adapter.getRemoteDevice(peer.address)
+            val connectionId = connectionIdCounter.incrementAndGet()
+            val callback = GattCallbackProxy(connectionId)
+
+            // Set up document listener
+            callback.documentListener = object : HiveDocumentListener {
+                override fun onDocumentReceived(data: ByteArray) {
+                    handlePeerDocument(peer, data)
+                }
+
+                override fun onServicesDiscovered() {
+                    Log.i(TAG, "Services discovered for ${peer.displayName()}")
+                    peer.isConnected = true
+                    notifyMeshUpdated()
+
+                    // Enable notifications first, then read after a delay
+                    connections[peer.address]?.let { gatt ->
+                        enableNotificationsForGatt(gatt)
+                        // Delay read to allow descriptor write to complete
+                        handler.postDelayed({
+                            readDocumentFromGatt(gatt)
+                        }, 500)
+                    }
+                }
+
+                override fun onConnectionStateChanged(connected: Boolean) {
+                    Log.i(TAG, "Peer ${peer.displayName()} connected: $connected")
+                    // Find the current peer entry (may have been updated with new nodeId)
+                    val currentPeer = peers.values.find { it.address == peer.address }
+                    if (currentPeer != null) {
+                        currentPeer.isConnected = connected
+                        currentPeer.lastSeen = System.currentTimeMillis()
+                    }
+                    if (!connected) {
+                        connections.remove(peer.address)
+                        gattCallbacks.remove(peer.address)
+                        // Retry connection after a delay if mesh is still running
+                        if (isMeshRunning && currentPeer != null) {
+                            handler.postDelayed({
+                                if (isMeshRunning && !connections.containsKey(peer.address)) {
+                                    Log.i(TAG, "Retrying connection to ${currentPeer.displayName()}")
+                                    connectToPeer(currentPeer)
+                                }
+                            }, 2000)
+                        }
+                    }
+                    notifyMeshUpdated()
+                }
+            }
+
+            val gatt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                device.connectGatt(context, false, callback, BluetoothDevice.TRANSPORT_LE)
+            } else {
+                device.connectGatt(context, false, callback)
+            }
+
+            if (gatt != null) {
+                connections[peer.address] = gatt
+                gattCallbacks[peer.address] = callback
+            }
+        } catch (e: SecurityException) {
+            Log.e(TAG, "Missing BLUETOOTH_CONNECT permission", e)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to connect to peer", e)
+        }
+    }
+
+    private fun handlePeerDocument(peer: HivePeer, data: ByteArray) {
+        val document = HiveDocument.decode(data) ?: return
+
+        Log.d(TAG, "Received document from ${peer.displayName()} (docNodeId=${String.format("%08X", document.nodeId)}): event=${document.currentEventType()}")
+
+        // Update peer's nodeId from document if different (document nodeId is authoritative)
+        if (document.nodeId != peer.nodeId && document.nodeId != 0L) {
+            val oldNodeId = peer.nodeId
+            Log.i(TAG, "Updating peer nodeId from ${String.format("%08X", oldNodeId)} to ${String.format("%08X", document.nodeId)}")
+
+            // Re-register peer with correct nodeId
+            peers.remove(oldNodeId)
+            val updatedPeer = peer.copy(nodeId = document.nodeId)
+            peers[document.nodeId] = updatedPeer
+            addressToNodeId[peer.address] = document.nodeId
+
+            // Continue with updated peer reference
+            handlePeerDocumentInternal(updatedPeer, document)
+            return
+        }
+
+        handlePeerDocumentInternal(peer, document)
+    }
+
+    private fun handlePeerDocumentInternal(peer: HivePeer, document: HiveDocument) {
+        // Store last document
+        val previousEventType = peer.lastDocument?.currentEventType() ?: HiveEventType.NONE
+        peer.lastDocument = document
+        peer.lastSeen = System.currentTimeMillis()
+
+        // Merge counters (CRDT merge)
+        mergeCounter(document.counter)
+
+        // Check for new events
+        val eventType = document.currentEventType()
+        if (eventType != HiveEventType.NONE && eventType != previousEventType) {
+            handler.post {
+                meshListener?.onPeerEvent(peer, eventType)
+            }
+        }
+
+        handler.post {
+            meshListener?.onDocumentSynced(document)
+        }
+
+        notifyMeshUpdated()
+    }
+
+    private fun mergeCounter(remoteCounter: List<GCounterEntry>) {
+        for (entry in remoteCounter) {
+            val existing = localCounter.find { it.nodeId == entry.nodeId }
+            if (existing != null) {
+                if (entry.count > existing.count) {
+                    val index = localCounter.indexOf(existing)
+                    localCounter[index] = entry
+                }
+            } else {
+                localCounter.add(entry)
+            }
+        }
+    }
+
+    private fun incrementLocalCounter() {
+        val existing = localCounter.find { it.nodeId == nodeId }
+        if (existing != null) {
+            val index = localCounter.indexOf(existing)
+            localCounter[index] = GCounterEntry(nodeId, existing.count + 1)
+        } else {
+            localCounter.add(GCounterEntry(nodeId, 1))
+        }
+    }
+
+    private fun syncWithPeers() {
+        if (connections.isEmpty()) return
+
+        // Create sync document (no event, just counter state - don't increment on sync)
+        val documentBytes = HiveDocument.encode(nodeId, localCounter, null)
+
+        for ((address, gatt) in connections) {
+            writeDocumentToGatt(gatt, documentBytes)
+        }
+    }
+
+    private fun cleanupStalePeers() {
+        val now = System.currentTimeMillis()
+        val staleNodeIds = peers.filter { (_, peer) ->
+            now - peer.lastSeen > PEER_TIMEOUT_MS && !peer.isConnected
+        }.keys
+
+        if (staleNodeIds.isNotEmpty()) {
+            Log.d(TAG, "Removing ${staleNodeIds.size} stale peers")
+            for (nodeId in staleNodeIds) {
+                val peer = peers.remove(nodeId)
+                peer?.let {
+                    addressToNodeId.remove(it.address)
+                    disconnect(it.address)
+                }
+            }
+            notifyMeshUpdated()
+        }
+    }
+
+    private fun notifyMeshUpdated() {
+        handler.post {
+            meshListener?.onMeshUpdated(peers.values.toList())
+        }
+    }
+
+    /**
+     * Derive a nodeId from a BLE MAC address.
+     * Uses the last 4 bytes of the MAC as a 32-bit node ID.
+     */
+    private fun deriveNodeIdFromAddress(address: String): Long {
+        // MAC format: "AA:BB:CC:DD:EE:FF"
+        val parts = address.split(":")
+        if (parts.size != 6) return 0L
+
+        return try {
+            // Use last 4 bytes of MAC as node ID
+            val b2 = parts[2].toLong(16)
+            val b3 = parts[3].toLong(16)
+            val b4 = parts[4].toLong(16)
+            val b5 = parts[5].toLong(16)
+            (b2 shl 24) or (b3 shl 16) or (b4 shl 8) or b5
+        } catch (e: NumberFormatException) {
+            0L
+        }
+    }
+
+    private fun writeDocumentToGatt(gatt: BluetoothGatt, data: ByteArray) {
+        try {
+            val service = gatt.getService(HIVE_SERVICE_UUID) ?: return
+            val char = service.getCharacteristic(HIVE_CHAR_DOCUMENT) ?: return
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                gatt.writeCharacteristic(char, data, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
+            } else {
+                @Suppress("DEPRECATION")
+                char.value = data
+                @Suppress("DEPRECATION")
+                gatt.writeCharacteristic(char)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to write document", e)
+        }
+    }
+
+    private fun readDocumentFromGatt(gatt: BluetoothGatt) {
+        try {
+            val service = gatt.getService(HIVE_SERVICE_UUID) ?: return
+            val char = service.getCharacteristic(HIVE_CHAR_DOCUMENT) ?: return
+            gatt.readCharacteristic(char)
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to read document", e)
+        }
+    }
+
+    private fun enableNotificationsForGatt(gatt: BluetoothGatt) {
+        try {
+            val service = gatt.getService(HIVE_SERVICE_UUID) ?: return
+            val char = service.getCharacteristic(HIVE_CHAR_DOCUMENT) ?: return
+
+            gatt.setCharacteristicNotification(char, true)
+
+            val descriptor = char.getDescriptor(CCCD_UUID)
+            if (descriptor != null) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    gatt.writeDescriptor(descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
+                } else {
+                    @Suppress("DEPRECATION")
+                    descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                    @Suppress("DEPRECATION")
+                    gatt.writeDescriptor(descriptor)
+                }
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to enable notifications", e)
+        }
+    }
+
     /**
      * Disconnect all devices and clean up resources.
      */
     fun shutdown() {
+        stopMesh()
         stopScan()
         stopAdvertising()
 
@@ -494,8 +959,56 @@ data class DiscoveredDevice(
     val name: String,
     val rssi: Int,
     val nodeId: Long?,
-    val timestampNanos: Long
+    val timestampNanos: Long,
+    val isHiveDevice: Boolean = false
 )
+
+/**
+ * Represents a peer in the HIVE mesh network.
+ */
+data class HivePeer(
+    val nodeId: Long,
+    val address: String,
+    val name: String,
+    var rssi: Int,
+    var isConnected: Boolean,
+    var lastDocument: HiveDocument?,
+    var lastSeen: Long
+) {
+    /**
+     * Get the display name for this peer (HIVE-XXXXXXXX format).
+     */
+    fun displayName(): String = "HIVE-${String.format("%08X", nodeId)}"
+
+    /**
+     * Get the current event type from this peer's last document.
+     */
+    fun currentEventType(): HiveEventType = lastDocument?.currentEventType() ?: HiveEventType.NONE
+}
+
+/**
+ * Listener interface for HIVE mesh events.
+ */
+interface HiveMeshListener {
+    /**
+     * Called when the mesh state changes (peers added/removed/updated).
+     * @param peers Current list of all known peers
+     */
+    fun onMeshUpdated(peers: List<HivePeer>)
+
+    /**
+     * Called when a peer sends an event (Emergency, ACK, etc.).
+     * @param peer The peer that sent the event
+     * @param eventType The event type
+     */
+    fun onPeerEvent(peer: HivePeer, eventType: HiveEventType)
+
+    /**
+     * Called when mesh document is synced.
+     * @param document The merged document state
+     */
+    fun onDocumentSynced(document: HiveDocument) {}
+}
 
 /**
  * Represents an active GATT connection to a HIVE device.
@@ -505,6 +1018,13 @@ class HiveConnection internal constructor(
     private val gatt: BluetoothGatt,
     private val callback: GattCallbackProxy
 ) {
+    /**
+     * Set a listener for document events.
+     */
+    fun setDocumentListener(listener: HiveDocumentListener?) {
+        callback.documentListener = listener
+    }
+
     /**
      * Request MTU change.
      *
@@ -547,4 +1067,633 @@ class HiveConnection internal constructor(
             false
         }
     }
+
+    /**
+     * Read the HIVE document characteristic.
+     *
+     * @return true if read was initiated
+     */
+    fun readDocument(): Boolean {
+        return try {
+            val service = gatt.getService(HiveBtle.HIVE_SERVICE_UUID)
+            if (service == null) {
+                Log.e("HiveConnection", "HIVE service not found")
+                return false
+            }
+            val char = service.getCharacteristic(HiveBtle.HIVE_CHAR_DOCUMENT)
+            if (char == null) {
+                Log.e("HiveConnection", "HIVE document characteristic not found")
+                return false
+            }
+            gatt.readCharacteristic(char)
+        } catch (e: SecurityException) {
+            Log.e("HiveConnection", "Missing BLUETOOTH_CONNECT permission", e)
+            false
+        }
+    }
+
+    /**
+     * Write data to the HIVE document characteristic.
+     *
+     * @param data The document data to write
+     * @return true if write was initiated
+     */
+    fun writeDocument(data: ByteArray): Boolean {
+        return try {
+            val service = gatt.getService(HiveBtle.HIVE_SERVICE_UUID)
+            if (service == null) {
+                Log.e("HiveConnection", "HIVE service not found")
+                return false
+            }
+            val char = service.getCharacteristic(HiveBtle.HIVE_CHAR_DOCUMENT)
+            if (char == null) {
+                Log.e("HiveConnection", "HIVE document characteristic not found")
+                return false
+            }
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                gatt.writeCharacteristic(char, data, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT)
+            } else {
+                @Suppress("DEPRECATION")
+                char.value = data
+                @Suppress("DEPRECATION")
+                gatt.writeCharacteristic(char)
+            }
+            true
+        } catch (e: SecurityException) {
+            Log.e("HiveConnection", "Missing BLUETOOTH_CONNECT permission", e)
+            false
+        }
+    }
+
+    /**
+     * Enable notifications for the HIVE document characteristic.
+     *
+     * @return true if notification was enabled
+     */
+    fun enableDocumentNotifications(): Boolean {
+        return try {
+            val service = gatt.getService(HiveBtle.HIVE_SERVICE_UUID)
+            if (service == null) {
+                Log.e("HiveConnection", "HIVE service not found")
+                return false
+            }
+            val char = service.getCharacteristic(HiveBtle.HIVE_CHAR_DOCUMENT)
+            if (char == null) {
+                Log.e("HiveConnection", "HIVE document characteristic not found")
+                return false
+            }
+
+            // Enable local notifications
+            if (!gatt.setCharacteristicNotification(char, true)) {
+                Log.e("HiveConnection", "Failed to enable local notifications")
+                return false
+            }
+
+            // Write to CCCD to enable remote notifications
+            val descriptor = char.getDescriptor(HiveBtle.CCCD_UUID)
+            if (descriptor == null) {
+                Log.w("HiveConnection", "CCCD descriptor not found, notifications may not work")
+                return true  // Local notifications are enabled at least
+            }
+
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                gatt.writeDescriptor(descriptor, BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE)
+            } else {
+                @Suppress("DEPRECATION")
+                descriptor.value = BluetoothGattDescriptor.ENABLE_NOTIFICATION_VALUE
+                @Suppress("DEPRECATION")
+                gatt.writeDescriptor(descriptor)
+            }
+            true
+        } catch (e: SecurityException) {
+            Log.e("HiveConnection", "Missing BLUETOOTH_CONNECT permission", e)
+            false
+        }
+    }
+}
+
+/**
+ * HIVE document event types.
+ * Values must match the Rust EventType enum in hive-btle/src/sync/crdt.rs
+ */
+enum class HiveEventType(val value: Int) {
+    NONE(0),
+    PING(1),
+    NEED_ASSIST(2),
+    EMERGENCY(3),
+    MOVING(4),
+    IN_POSITION(5),
+    ACK(6);
+
+    companion object {
+        fun fromValue(v: Int): HiveEventType = entries.find { it.value == v } ?: NONE
+    }
+}
+
+/**
+ * HIVE Peripheral type.
+ */
+enum class HivePeripheralType(val value: Int) {
+    UNKNOWN(0),
+    SOLDIER_SENSOR(1),
+    VEHICLE(2),
+    ASSET_TAG(3);
+
+    companion object {
+        fun fromValue(v: Int): HivePeripheralType = entries.find { it.value == v } ?: UNKNOWN
+    }
+}
+
+/**
+ * HIVE health status data.
+ */
+data class HiveHealthStatus(
+    val batteryPercent: Int,
+    val heartRate: Int?,
+    val activityLevel: Int,
+    val alerts: Int
+) {
+    companion object {
+        const val ALERT_MAN_DOWN = 0x01
+        const val ALERT_LOW_BATTERY = 0x02
+        const val ALERT_GEOFENCE = 0x04
+        const val ALERT_PANIC = 0x08
+
+        fun decode(data: ByteArray, offset: Int): HiveHealthStatus? {
+            if (data.size < offset + 4) return null
+            val battery = data[offset].toInt() and 0xFF
+            val hr = data[offset + 1].toInt() and 0xFF
+            val activity = data[offset + 2].toInt() and 0xFF
+            val alerts = data[offset + 3].toInt() and 0xFF
+            return HiveHealthStatus(
+                batteryPercent = battery,
+                heartRate = if (hr > 0) hr else null,
+                activityLevel = activity,
+                alerts = alerts
+            )
+        }
+
+        fun encode(status: HiveHealthStatus): ByteArray {
+            return byteArrayOf(
+                status.batteryPercent.toByte(),
+                (status.heartRate ?: 0).toByte(),
+                status.activityLevel.toByte(),
+                status.alerts.toByte()
+            )
+        }
+    }
+
+    fun hasAlert(flag: Int): Boolean = (alerts and flag) != 0
+}
+
+/**
+ * HIVE peripheral event.
+ */
+data class HivePeripheralEvent(
+    val eventType: HiveEventType,
+    val timestamp: Long
+) {
+    companion object {
+        private const val SIZE = 9
+
+        fun decode(data: ByteArray, offset: Int): HivePeripheralEvent? {
+            if (data.size < offset + SIZE) return null
+            val eventType = HiveEventType.fromValue(data[offset].toInt() and 0xFF)
+            val timestamp = readU64LE(data, offset + 1)
+            return HivePeripheralEvent(eventType, timestamp)
+        }
+
+        fun encode(event: HivePeripheralEvent): ByteArray {
+            val buf = ByteArray(SIZE)
+            buf[0] = event.eventType.value.toByte()
+            writeU64LE(buf, 1, event.timestamp)
+            return buf
+        }
+
+        private fun readU64LE(data: ByteArray, offset: Int): Long {
+            return ((data[offset].toLong() and 0xFF) or
+                    ((data[offset + 1].toLong() and 0xFF) shl 8) or
+                    ((data[offset + 2].toLong() and 0xFF) shl 16) or
+                    ((data[offset + 3].toLong() and 0xFF) shl 24) or
+                    ((data[offset + 4].toLong() and 0xFF) shl 32) or
+                    ((data[offset + 5].toLong() and 0xFF) shl 40) or
+                    ((data[offset + 6].toLong() and 0xFF) shl 48) or
+                    ((data[offset + 7].toLong() and 0xFF) shl 56))
+        }
+
+        private fun writeU64LE(data: ByteArray, offset: Int, value: Long) {
+            data[offset] = (value and 0xFF).toByte()
+            data[offset + 1] = ((value shr 8) and 0xFF).toByte()
+            data[offset + 2] = ((value shr 16) and 0xFF).toByte()
+            data[offset + 3] = ((value shr 24) and 0xFF).toByte()
+            data[offset + 4] = ((value shr 32) and 0xFF).toByte()
+            data[offset + 5] = ((value shr 40) and 0xFF).toByte()
+            data[offset + 6] = ((value shr 48) and 0xFF).toByte()
+            data[offset + 7] = ((value shr 56) and 0xFF).toByte()
+        }
+    }
+}
+
+/**
+ * HIVE Peripheral data structure.
+ * Format: [id:4][parent:4][type:1][callsign:12][health:4][has_event:1][event:9?][timestamp:8]
+ */
+data class HivePeripheral(
+    val id: Long,
+    val parentNode: Long,
+    val peripheralType: HivePeripheralType,
+    val callsign: String,
+    val health: HiveHealthStatus,
+    val lastEvent: HivePeripheralEvent?,
+    val timestamp: Long
+) {
+    companion object {
+        private const val TAG = "HivePeripheral"
+        private const val MIN_SIZE = 34  // Without event
+        private const val SIZE_WITH_EVENT = 43
+
+        fun decode(data: ByteArray, offset: Int = 0): HivePeripheral? {
+            if (data.size < offset + MIN_SIZE) {
+                Log.e(TAG, "Peripheral data too short: ${data.size - offset} bytes (need $MIN_SIZE)")
+                return null
+            }
+
+            var pos = offset
+            val id = readU32LE(data, pos)
+            pos += 4
+            val parentNode = readU32LE(data, pos)
+            pos += 4
+            val peripheralType = HivePeripheralType.fromValue(data[pos].toInt() and 0xFF)
+            pos += 1
+
+            // Read callsign (12 bytes, null-terminated string)
+            val callsignBytes = data.sliceArray(pos until pos + 12)
+            val nullIndex = callsignBytes.indexOf(0)
+            val callsign = if (nullIndex >= 0) {
+                String(callsignBytes, 0, nullIndex, Charsets.UTF_8)
+            } else {
+                String(callsignBytes, Charsets.UTF_8)
+            }
+            pos += 12
+
+            val health = HiveHealthStatus.decode(data, pos)
+            if (health == null) {
+                Log.e(TAG, "Failed to decode health status")
+                return null
+            }
+            pos += 4
+
+            val hasEvent = data[pos] != 0.toByte()
+            pos += 1
+
+            val lastEvent = if (hasEvent) {
+                if (data.size < offset + SIZE_WITH_EVENT) {
+                    Log.e(TAG, "Peripheral with event too short: ${data.size - offset} bytes (need $SIZE_WITH_EVENT)")
+                    return null
+                }
+                val event = HivePeripheralEvent.decode(data, pos)
+                pos += 9
+                event
+            } else {
+                null
+            }
+
+            if (data.size < pos + 8) {
+                Log.e(TAG, "No room for timestamp at offset $pos")
+                return null
+            }
+            val timestamp = readU64LE(data, pos)
+
+            Log.d(TAG, "Decoded: id=${String.format("%08X", id)}, type=$peripheralType, " +
+                    "event=${lastEvent?.eventType}, health=${health.batteryPercent}%")
+
+            return HivePeripheral(
+                id = id,
+                parentNode = parentNode,
+                peripheralType = peripheralType,
+                callsign = callsign,
+                health = health,
+                lastEvent = lastEvent,
+                timestamp = timestamp
+            )
+        }
+
+        fun encode(peripheral: HivePeripheral): ByteArray {
+            val hasEvent = peripheral.lastEvent != null
+            val size = if (hasEvent) SIZE_WITH_EVENT else MIN_SIZE
+            val buf = ByteArray(size)
+            var pos = 0
+
+            writeU32LE(buf, pos, peripheral.id)
+            pos += 4
+            writeU32LE(buf, pos, peripheral.parentNode)
+            pos += 4
+            buf[pos] = peripheral.peripheralType.value.toByte()
+            pos += 1
+
+            // Write callsign (12 bytes)
+            val callsignBytes = peripheral.callsign.toByteArray(Charsets.UTF_8)
+            for (i in 0 until 12) {
+                buf[pos + i] = if (i < callsignBytes.size) callsignBytes[i] else 0
+            }
+            pos += 12
+
+            val healthBytes = HiveHealthStatus.encode(peripheral.health)
+            healthBytes.copyInto(buf, pos)
+            pos += 4
+
+            buf[pos] = if (hasEvent) 1 else 0
+            pos += 1
+
+            if (hasEvent && peripheral.lastEvent != null) {
+                val eventBytes = HivePeripheralEvent.encode(peripheral.lastEvent)
+                eventBytes.copyInto(buf, pos)
+                pos += 9
+            }
+
+            writeU64LE(buf, pos, peripheral.timestamp)
+            return buf
+        }
+
+        private fun readU32LE(data: ByteArray, offset: Int): Long {
+            return ((data[offset].toLong() and 0xFF) or
+                    ((data[offset + 1].toLong() and 0xFF) shl 8) or
+                    ((data[offset + 2].toLong() and 0xFF) shl 16) or
+                    ((data[offset + 3].toLong() and 0xFF) shl 24))
+        }
+
+        private fun readU64LE(data: ByteArray, offset: Int): Long {
+            return ((data[offset].toLong() and 0xFF) or
+                    ((data[offset + 1].toLong() and 0xFF) shl 8) or
+                    ((data[offset + 2].toLong() and 0xFF) shl 16) or
+                    ((data[offset + 3].toLong() and 0xFF) shl 24) or
+                    ((data[offset + 4].toLong() and 0xFF) shl 32) or
+                    ((data[offset + 5].toLong() and 0xFF) shl 40) or
+                    ((data[offset + 6].toLong() and 0xFF) shl 48) or
+                    ((data[offset + 7].toLong() and 0xFF) shl 56))
+        }
+
+        private fun writeU32LE(data: ByteArray, offset: Int, value: Long) {
+            data[offset] = (value and 0xFF).toByte()
+            data[offset + 1] = ((value shr 8) and 0xFF).toByte()
+            data[offset + 2] = ((value shr 16) and 0xFF).toByte()
+            data[offset + 3] = ((value shr 24) and 0xFF).toByte()
+        }
+
+        private fun writeU64LE(data: ByteArray, offset: Int, value: Long) {
+            data[offset] = (value and 0xFF).toByte()
+            data[offset + 1] = ((value shr 8) and 0xFF).toByte()
+            data[offset + 2] = ((value shr 16) and 0xFF).toByte()
+            data[offset + 3] = ((value shr 24) and 0xFF).toByte()
+            data[offset + 4] = ((value shr 32) and 0xFF).toByte()
+            data[offset + 5] = ((value shr 40) and 0xFF).toByte()
+            data[offset + 6] = ((value shr 48) and 0xFF).toByte()
+            data[offset + 7] = ((value shr 56) and 0xFF).toByte()
+        }
+    }
+
+    /**
+     * Get the current event type, or NONE if no event.
+     */
+    fun currentEventType(): HiveEventType = lastEvent?.eventType ?: HiveEventType.NONE
+}
+
+/**
+ * HIVE CRDT GCounter entry.
+ */
+data class GCounterEntry(
+    val nodeId: Long,
+    val count: Long
+)
+
+/**
+ * HIVE document format (compatible with M5Stack HIVE-lite).
+ *
+ * Wire format:
+ * - Header: version (u32 LE) + node_id (u32 LE)
+ * - GCounter: num_entries (u32 LE) + [node_id (u32 LE) + count (u64 LE)] * N
+ * - Extended: 0xAB marker + reserved (u8) + peripheral_len (u16 LE) + peripheral data
+ */
+data class HiveDocument(
+    val version: Long,
+    val nodeId: Long,
+    val counter: List<GCounterEntry>,
+    val peripheral: HivePeripheral?
+) {
+    companion object {
+        private const val TAG = "HiveDocument"
+        private const val EXTENDED_MARKER: Byte = 0xAB.toByte()
+
+        /**
+         * Decode a HIVE document from raw bytes.
+         *
+         * @param data Raw document bytes
+         * @return Decoded document, or null if parsing failed
+         */
+        fun decode(data: ByteArray): HiveDocument? {
+            if (data.size < 8) {
+                Log.e(TAG, "Document too short: ${data.size} bytes (minimum 8)")
+                return null
+            }
+
+            try {
+                var offset = 0
+
+                // Read header
+                val version = readU32LE(data, offset)
+                offset += 4
+                val nodeId = readU32LE(data, offset)
+                offset += 4
+
+                Log.d(TAG, "Header: version=$version, nodeId=${String.format("%08X", nodeId)}")
+
+                // Read GCounter
+                if (data.size < offset + 4) {
+                    Log.e(TAG, "Document too short for GCounter count")
+                    return null
+                }
+                val numEntries = readU32LE(data, offset).toInt()
+                offset += 4
+
+                if (data.size < offset + numEntries * 12) {
+                    Log.e(TAG, "Document too short for GCounter entries: need ${offset + numEntries * 12}, have ${data.size}")
+                    return null
+                }
+
+                val counter = mutableListOf<GCounterEntry>()
+                for (i in 0 until numEntries) {
+                    val entryNodeId = readU32LE(data, offset)
+                    offset += 4
+                    val count = readU64LE(data, offset)
+                    offset += 8
+                    counter.add(GCounterEntry(entryNodeId, count))
+                    Log.d(TAG, "GCounter[$i]: nodeId=${String.format("%08X", entryNodeId)}, count=$count")
+                }
+
+                // Check for extended data (peripheral)
+                var peripheral: HivePeripheral? = null
+                if (data.size > offset && data[offset] == EXTENDED_MARKER) {
+                    offset += 1  // Skip marker
+                    if (data.size >= offset + 3) {
+                        val reserved = data[offset].toInt() and 0xFF
+                        offset += 1
+                        val peripheralLen = readU16LE(data, offset).toInt()
+                        offset += 2
+
+                        Log.d(TAG, "Extended: reserved=$reserved, peripheralLen=$peripheralLen")
+
+                        if (data.size >= offset + peripheralLen && peripheralLen > 0) {
+                            // Decode full Peripheral structure
+                            peripheral = HivePeripheral.decode(data, offset)
+                            if (peripheral != null) {
+                                Log.d(TAG, "Peripheral: eventType=${peripheral.currentEventType()}, " +
+                                        "battery=${peripheral.health.batteryPercent}%")
+                            } else {
+                                Log.w(TAG, "Failed to decode peripheral data ($peripheralLen bytes)")
+                            }
+                        }
+                    }
+                }
+
+                return HiveDocument(version, nodeId, counter, peripheral)
+
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to decode document", e)
+                return null
+            }
+        }
+
+        /**
+         * Create an encoded HIVE document with full Peripheral structure.
+         *
+         * @param nodeId This node's ID
+         * @param counter GCounter entries
+         * @param peripheral Optional Peripheral data (contains event, health, etc.)
+         * @return Encoded document bytes
+         */
+        fun encode(nodeId: Long, counter: List<GCounterEntry>, peripheral: HivePeripheral? = null): ByteArray {
+            val headerSize = 8  // version + nodeId
+            val counterSize = 4 + counter.size * 12  // count + entries
+            val peripheralBytes = peripheral?.let { HivePeripheral.encode(it) }
+            val extendedSize = if (peripheralBytes != null) 4 + peripheralBytes.size else 0  // marker + reserved + len(2) + data
+            val totalSize = headerSize + counterSize + extendedSize
+
+            val data = ByteArray(totalSize)
+            var offset = 0
+
+            // Write header
+            writeU32LE(data, offset, 1)  // version = 1
+            offset += 4
+            writeU32LE(data, offset, nodeId)
+            offset += 4
+
+            // Write GCounter
+            writeU32LE(data, offset, counter.size.toLong())
+            offset += 4
+            for (entry in counter) {
+                writeU32LE(data, offset, entry.nodeId)
+                offset += 4
+                writeU64LE(data, offset, entry.count)
+                offset += 8
+            }
+
+            // Write extended data (Peripheral)
+            if (peripheralBytes != null) {
+                data[offset] = EXTENDED_MARKER
+                offset += 1
+                data[offset] = 0  // reserved
+                offset += 1
+                writeU16LE(data, offset, peripheralBytes.size.toLong())
+                offset += 2
+                peripheralBytes.copyInto(data, offset)
+            }
+
+            return data
+        }
+
+        /**
+         * Create an encoded HIVE document with just an event type (simple form).
+         *
+         * @param nodeId This node's ID
+         * @param counter GCounter entries
+         * @param eventType Optional event type
+         * @return Encoded document bytes
+         */
+        fun encodeWithEvent(nodeId: Long, counter: List<GCounterEntry>, eventType: HiveEventType = HiveEventType.NONE): ByteArray {
+            val peripheral = if (eventType != HiveEventType.NONE) {
+                val timestamp = System.currentTimeMillis()
+                HivePeripheral(
+                    id = nodeId,
+                    parentNode = 0,
+                    peripheralType = HivePeripheralType.SOLDIER_SENSOR,
+                    callsign = "",
+                    health = HiveHealthStatus(100, null, 0, 0),
+                    lastEvent = HivePeripheralEvent(eventType, timestamp),
+                    timestamp = timestamp
+                )
+            } else null
+            return encode(nodeId, counter, peripheral)
+        }
+
+        private fun readU16LE(data: ByteArray, offset: Int): Long {
+            return ((data[offset].toLong() and 0xFF) or
+                    ((data[offset + 1].toLong() and 0xFF) shl 8))
+        }
+
+        private fun readU32LE(data: ByteArray, offset: Int): Long {
+            return ((data[offset].toLong() and 0xFF) or
+                    ((data[offset + 1].toLong() and 0xFF) shl 8) or
+                    ((data[offset + 2].toLong() and 0xFF) shl 16) or
+                    ((data[offset + 3].toLong() and 0xFF) shl 24))
+        }
+
+        private fun readU64LE(data: ByteArray, offset: Int): Long {
+            return ((data[offset].toLong() and 0xFF) or
+                    ((data[offset + 1].toLong() and 0xFF) shl 8) or
+                    ((data[offset + 2].toLong() and 0xFF) shl 16) or
+                    ((data[offset + 3].toLong() and 0xFF) shl 24) or
+                    ((data[offset + 4].toLong() and 0xFF) shl 32) or
+                    ((data[offset + 5].toLong() and 0xFF) shl 40) or
+                    ((data[offset + 6].toLong() and 0xFF) shl 48) or
+                    ((data[offset + 7].toLong() and 0xFF) shl 56))
+        }
+
+        private fun writeU16LE(data: ByteArray, offset: Int, value: Long) {
+            data[offset] = (value and 0xFF).toByte()
+            data[offset + 1] = ((value shr 8) and 0xFF).toByte()
+        }
+
+        private fun writeU32LE(data: ByteArray, offset: Int, value: Long) {
+            data[offset] = (value and 0xFF).toByte()
+            data[offset + 1] = ((value shr 8) and 0xFF).toByte()
+            data[offset + 2] = ((value shr 16) and 0xFF).toByte()
+            data[offset + 3] = ((value shr 24) and 0xFF).toByte()
+        }
+
+        private fun writeU64LE(data: ByteArray, offset: Int, value: Long) {
+            data[offset] = (value and 0xFF).toByte()
+            data[offset + 1] = ((value shr 8) and 0xFF).toByte()
+            data[offset + 2] = ((value shr 16) and 0xFF).toByte()
+            data[offset + 3] = ((value shr 24) and 0xFF).toByte()
+            data[offset + 4] = ((value shr 32) and 0xFF).toByte()
+            data[offset + 5] = ((value shr 40) and 0xFF).toByte()
+            data[offset + 6] = ((value shr 48) and 0xFF).toByte()
+            data[offset + 7] = ((value shr 56) and 0xFF).toByte()
+        }
+    }
+
+    /**
+     * Get the total count from all GCounter entries.
+     */
+    fun totalCount(): Long = counter.sumOf { it.count }
+
+    /**
+     * Get the current event type from peripheral data.
+     */
+    fun currentEventType(): HiveEventType = peripheral?.currentEventType() ?: HiveEventType.NONE
+
+    /**
+     * Get the battery percentage from peripheral health data.
+     */
+    fun batteryPercent(): Int? = peripheral?.health?.batteryPercent
 }

--- a/hive-btle/android/src/main/java/com/hive/btle/ScanCallbackProxy.kt
+++ b/hive-btle/android/src/main/java/com/hive/btle/ScanCallbackProxy.kt
@@ -66,16 +66,33 @@ class ScanCallbackProxy(
 
             // Check if this is a HIVE device (by name prefix or service UUID)
             val isHiveDevice = name.startsWith(HiveBtle.HIVE_NAME_PREFIX) ||
-                serviceUuids.any { it.contains("F47A", ignoreCase = true) }
+                serviceUuids.any { it.contains("F47A", ignoreCase = true) } ||
+                hiveServiceData != null
 
-            // Parse node ID from name if present (HIVE-XXXXXXXX format)
-            val nodeId: Long? = if (name.startsWith(HiveBtle.HIVE_NAME_PREFIX)) {
-                try {
-                    name.removePrefix(HiveBtle.HIVE_NAME_PREFIX).toLong(16)
-                } catch (e: NumberFormatException) {
-                    null
+            // Parse node ID from name (HIVE-XXXXXXXX format) or service data
+            val nodeId: Long? = when {
+                // Try parsing from name first
+                name.startsWith(HiveBtle.HIVE_NAME_PREFIX) -> {
+                    try {
+                        name.removePrefix(HiveBtle.HIVE_NAME_PREFIX).toLong(16)
+                    } catch (e: NumberFormatException) {
+                        null
+                    }
                 }
-            } else null
+                // Try parsing from service data (4 bytes, big-endian node ID)
+                hiveServiceData != null && hiveServiceData.size >= 4 -> {
+                    ((hiveServiceData[0].toLong() and 0xFF) shl 24) or
+                    ((hiveServiceData[1].toLong() and 0xFF) shl 16) or
+                    ((hiveServiceData[2].toLong() and 0xFF) shl 8) or
+                    (hiveServiceData[3].toLong() and 0xFF)
+                }
+                else -> null
+            }
+
+            // Debug: log service data if present
+            if (hiveServiceData != null) {
+                Log.d(TAG, "HIVE service data (${hiveServiceData.size} bytes): ${hiveServiceData.joinToString(" ") { String.format("%02X", it) }}")
+            }
 
             Log.d(TAG, "Scan result: $address ($name) RSSI=$rssi, isHive=$isHiveDevice, nodeId=${nodeId?.let { String.format("%08X", it) }}")
 
@@ -85,7 +102,8 @@ class ScanCallbackProxy(
                 name = name,
                 rssi = rssi,
                 nodeId = nodeId,
-                timestampNanos = result.timestampNanos
+                timestampNanos = result.timestampNanos,
+                isHiveDevice = isHiveDevice
             )
 
             // Invoke Kotlin callback for UI updates


### PR DESCRIPTION
## Summary

- Adds `HiveMesh` API to `HiveBtle` class for automatic BLE mesh topology management
- Implements `HivePeer` and `HiveMeshListener` for peer tracking and event callbacks  
- Auto-discovers, connects, and syncs with HIVE devices without manual intervention
- Handles connection failures with retry logic, stale peer cleanup, and nodeId resolution
- Simplifies demo app to just implement `HiveMeshListener` callbacks

## Changes

**hive-btle library:**
- `startMesh(listener)` / `stopMesh()` for mesh lifecycle
- `sendEvent(eventType)` for broadcasting Emergency/ACK/Ping events
- `getPeers()` for current peer list
- Auto-connect to discovered HIVE devices
- Auto-update peer nodeId from document (handles MAC-derived vs actual nodeId mismatch)
- CRDT counter merge for document sync
- Connection retry on failure (2s delay)
- Stale peer cleanup (30s timeout)

**Demo app:**
- Removed manual scan/advertise/connect buttons
- Shows "Mesh Peers" list with connection status
- ACK tracking panel for emergency acknowledgments
- Implements `HiveMeshListener` for peer/event updates

## Test plan

- [x] Build and deploy to Android device
- [x] Verify auto-discovery of M5Stack Core2 HIVE devices
- [x] Verify auto-connection to multiple peers (tested with 2 Core2s)
- [x] Verify Emergency/ACK event propagation between devices
- [x] Verify peer list updates correctly when devices come/go
- [x] Verify connection retry after temporary disconnection

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)