### PR TITLE
feat(hive-btle): Add NodeId::from_mac_address for consistent ID derivation

### DIFF
--- a/examples/android-hive-demo/app/src/main/java/com/hive/demo/MainActivity.kt
+++ b/examples/android-hive-demo/app/src/main/java/com/hive/demo/MainActivity.kt
@@ -36,13 +36,13 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
 
     companion object {
         private const val TAG = "HiveDemo"
-        private const val NODE_ID = 0x12345678L // Demo node ID
     }
 
     private lateinit var hiveBtle: HiveBtle
     private lateinit var peerAdapter: PeerAdapter
 
     // UI elements
+    private lateinit var localNodeIdText: TextView
     private lateinit var statusText: TextView
     private lateinit var connectedCountText: TextView
     private lateinit var peerList: RecyclerView
@@ -76,6 +76,7 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
         setContentView(R.layout.activity_main)
 
         // Initialize UI
+        localNodeIdText = findViewById(R.id.localNodeIdText)
         statusText = findViewById(R.id.statusText)
         connectedCountText = findViewById(R.id.connectedDeviceText)
         peerList = findViewById(R.id.deviceList)
@@ -149,13 +150,16 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
 
     private fun initializeHiveBtle() {
         try {
-            hiveBtle = HiveBtle(applicationContext, NODE_ID)
+            hiveBtle = HiveBtle(applicationContext) // nodeId auto-generated from adapter
             hiveBtle.init()
-            Log.i(TAG, "HIVE BLE initialized")
+            Log.i(TAG, "HIVE BLE initialized with nodeId: ${String.format("%08X", hiveBtle.nodeId)}")
+
+            // Update UI with our node ID
+            localNodeIdText.text = "Node: HIVE-${String.format("%08X", hiveBtle.nodeId)}"
 
             // Start the mesh - it handles everything automatically
             hiveBtle.startMesh(this)
-            updateStatus("Mesh active - HIVE-${String.format("%08X", NODE_ID)}")
+            updateStatus("Mesh active")
 
         } catch (e: Exception) {
             Log.e(TAG, "Failed to initialize HIVE BLE", e)
@@ -213,7 +217,7 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
         for (p in hiveBtle.getPeers()) {
             pendingAcks[p.nodeId] = false
         }
-        pendingAcks[NODE_ID] = false // We haven't acked yet
+        pendingAcks[hiveBtle.nodeId] = false // We haven't acked yet
         pendingAcks[peer.nodeId] = true // Source has implicitly acked
 
         Toast.makeText(this, "🚨 EMERGENCY from ${peer.displayName()}!", Toast.LENGTH_LONG).show()
@@ -233,14 +237,14 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
     private fun sendEmergency() {
         Log.i(TAG, ">>> SENDING EMERGENCY")
         alertActive = true
-        emergencySourceNodeId = NODE_ID
+        emergencySourceNodeId = hiveBtle.nodeId
 
         // Initialize ACK tracking
         pendingAcks.clear()
         for (peer in hiveBtle.getPeers()) {
             pendingAcks[peer.nodeId] = false
         }
-        pendingAcks[NODE_ID] = true // We sent it, so we're acked
+        pendingAcks[hiveBtle.nodeId] = true // We sent it, so we're acked
 
         hiveBtle.sendEvent(HiveEventType.EMERGENCY)
         Toast.makeText(this, "🚨 EMERGENCY SENT!", Toast.LENGTH_SHORT).show()
@@ -253,7 +257,7 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
         hiveBtle.sendEvent(HiveEventType.ACK)
         Toast.makeText(this, "✓ ACK sent", Toast.LENGTH_SHORT).show()
 
-        pendingAcks[NODE_ID] = true
+        pendingAcks[hiveBtle.nodeId] = true
         checkAllAcked()
     }
 
@@ -263,7 +267,7 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
         pendingAcks.clear()
         emergencySourceNodeId = null
         updateAckStatusDisplay()
-        updateStatus("Mesh active - HIVE-${String.format("%08X", NODE_ID)}")
+        updateStatus("Mesh active")
         Toast.makeText(this, "Alert reset", Toast.LENGTH_SHORT).show()
     }
 

--- a/examples/android-hive-demo/app/src/main/res/layout/activity_main.xml
+++ b/examples/android-hive-demo/app/src/main/res/layout/activity_main.xml
@@ -16,6 +16,17 @@
         android:textSize="24sp"
         android:textColor="#ffffff"
         android:textStyle="bold"
+        android:layout_marginBottom="4dp" />
+
+    <!-- Local Node ID -->
+    <TextView
+        android:id="@+id/localNodeIdText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Node: HIVE-00000000"
+        android:textSize="16sp"
+        android:textColor="#00aaff"
+        android:textStyle="bold"
         android:layout_marginBottom="8dp" />
 
     <!-- Status -->

--- a/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
+++ b/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
@@ -58,12 +58,18 @@ import android.os.Looper
  * ```
  *
  * @param context Android context (Activity, Service, or Application)
- * @param nodeId This node's HIVE ID (32-bit unsigned)
+ * @param nodeId This node's HIVE ID (32-bit unsigned). If null, auto-generated from Bluetooth MAC address.
  */
 class HiveBtle(
     private val context: Context,
-    private val nodeId: Long
+    private var _nodeId: Long? = null
 ) {
+    /**
+     * This node's HIVE ID. Auto-generated from Bluetooth MAC address if not specified.
+     * Available after init() is called.
+     */
+    val nodeId: Long
+        get() = _nodeId ?: 0L
     companion object {
         private const val TAG = "HiveBtle"
 
@@ -103,6 +109,16 @@ class HiveBtle(
 
         /** HIVE device name prefix */
         const val HIVE_NAME_PREFIX = "HIVE-"
+
+        /**
+         * Derive a NodeId from a BLE MAC address using the native Rust implementation.
+         * This ensures consistency across all platforms (Android, iOS, ESP32).
+         *
+         * @param macAddress MAC address in "AA:BB:CC:DD:EE:FF" format
+         * @return NodeId derived from last 4 bytes of MAC, or 0 if parsing fails
+         */
+        @JvmStatic
+        external fun nativeDeriveNodeId(macAddress: String): Long
 
         init {
             try {
@@ -202,6 +218,12 @@ class HiveBtle(
 
         // Get LE advertiser (may be null if not supported)
         leAdvertiser = bluetoothAdapter?.bluetoothLeAdvertiser
+
+        // Auto-generate nodeId from adapter address if not provided
+        if (_nodeId == null) {
+            _nodeId = generateNodeIdFromAdapter()
+            Log.i(TAG, "Auto-generated nodeId from adapter: ${String.format("%08X", nodeId)}")
+        }
 
         // Initialize native adapter
         nativeHandle = nativeInit(context, nodeId)
@@ -604,7 +626,7 @@ class HiveBtle(
         }
 
         // Derive nodeId from name, service data, or address for new peers
-        val peerNodeId = device.nodeId ?: deriveNodeIdFromAddress(device.address)
+        val peerNodeId = device.nodeId ?: nativeDeriveNodeId(device.address)
 
         // Don't track ourselves
         if (peerNodeId == nodeId) return
@@ -825,10 +847,43 @@ class HiveBtle(
     }
 
     /**
-     * Derive a nodeId from a BLE MAC address.
+     * Generate nodeId from the local Bluetooth adapter's address.
+     * Falls back to a random ID if adapter address is unavailable (Android 12+ restrictions).
+     */
+    @Suppress("MissingPermission")
+    private fun generateNodeIdFromAdapter(): Long {
+        return try {
+            // On Android 12+, getAddress() requires BLUETOOTH_CONNECT and may return "02:00:00:00:00:00"
+            val address = bluetoothAdapter?.address
+            if (address != null && address != "02:00:00:00:00:00") {
+                // Use native Rust implementation for consistency across platforms
+                val nodeId = nativeDeriveNodeId(address)
+                if (nodeId != 0L) {
+                    nodeId
+                } else {
+                    // Fallback if native call fails
+                    deriveNodeIdFromAddressFallback(address)
+                }
+            } else {
+                // Fallback: generate from device identifiers or random
+                val fallback = (System.currentTimeMillis() and 0xFFFFFFFFL) xor
+                    (android.os.Process.myPid().toLong() shl 16)
+                Log.w(TAG, "Adapter address unavailable, using fallback nodeId: ${String.format("%08X", fallback)}")
+                fallback
+            }
+        } catch (e: SecurityException) {
+            // No permission to get adapter address
+            val fallback = (System.currentTimeMillis() and 0xFFFFFFFFL)
+            Log.w(TAG, "No permission for adapter address, using fallback nodeId: ${String.format("%08X", fallback)}")
+            fallback
+        }
+    }
+
+    /**
+     * Derive a nodeId from a BLE MAC address (fallback if native call fails).
      * Uses the last 4 bytes of the MAC as a 32-bit node ID.
      */
-    private fun deriveNodeIdFromAddress(address: String): Long {
+    private fun deriveNodeIdFromAddressFallback(address: String): Long {
         // MAC format: "AA:BB:CC:DD:EE:FF"
         val parts = address.split(":")
         if (parts.size != 6) return 0L

--- a/hive-btle/src/lib.rs
+++ b/hive-btle/src/lib.rs
@@ -172,6 +172,64 @@ impl NodeId {
         let s = s.trim_start_matches("0x").trim_start_matches("0X");
         u32::from_str_radix(s, 16).ok().map(Self::new)
     }
+
+    /// Derive a NodeId from a BLE MAC address.
+    ///
+    /// Uses the last 4 bytes of the 6-byte MAC address as the 32-bit node ID.
+    /// This provides a consistent node ID derived from the device's Bluetooth
+    /// hardware address.
+    ///
+    /// # Arguments
+    /// * `mac` - 6-byte MAC address array (e.g., [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF])
+    ///
+    /// # Example
+    /// ```
+    /// use hive_btle::NodeId;
+    ///
+    /// let mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+    /// let node_id = NodeId::from_mac_address(&mac);
+    /// assert_eq!(node_id.as_u32(), 0x22334455);
+    /// ```
+    pub fn from_mac_address(mac: &[u8; 6]) -> Self {
+        // Use last 4 bytes: mac[2], mac[3], mac[4], mac[5]
+        let id = ((mac[2] as u32) << 24)
+            | ((mac[3] as u32) << 16)
+            | ((mac[4] as u32) << 8)
+            | (mac[5] as u32);
+        Self::new(id)
+    }
+
+    /// Derive a NodeId from a MAC address string.
+    ///
+    /// Parses a MAC address in "AA:BB:CC:DD:EE:FF" format and derives
+    /// the node ID from the last 4 bytes.
+    ///
+    /// # Arguments
+    /// * `mac_str` - MAC address string in colon-separated hex format
+    ///
+    /// # Returns
+    /// `Some(NodeId)` if parsing succeeds, `None` otherwise
+    ///
+    /// # Example
+    /// ```
+    /// use hive_btle::NodeId;
+    ///
+    /// let node_id = NodeId::from_mac_string("00:11:22:33:44:55").unwrap();
+    /// assert_eq!(node_id.as_u32(), 0x22334455);
+    /// ```
+    pub fn from_mac_string(mac_str: &str) -> Option<Self> {
+        let parts: Vec<&str> = mac_str.split(':').collect();
+        if parts.len() != 6 {
+            return None;
+        }
+
+        let mut mac = [0u8; 6];
+        for (i, part) in parts.iter().enumerate() {
+            mac[i] = u8::from_str_radix(part, 16).ok()?;
+        }
+
+        Some(Self::from_mac_address(&mac))
+    }
 }
 
 impl core::fmt::Display for NodeId {
@@ -267,6 +325,30 @@ mod tests {
         assert_eq!(NodeId::parse("12345678").unwrap().as_u32(), 0x12345678);
         assert_eq!(NodeId::parse("0x12345678").unwrap().as_u32(), 0x12345678);
         assert!(NodeId::parse("not_hex").is_none());
+    }
+
+    #[test]
+    fn test_node_id_from_mac_address() {
+        // MAC: AA:BB:CC:DD:EE:FF -> NodeId from last 4 bytes: 0xCCDDEEFF
+        let mac = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+        let node_id = NodeId::from_mac_address(&mac);
+        assert_eq!(node_id.as_u32(), 0xCCDDEEFF);
+    }
+
+    #[test]
+    fn test_node_id_from_mac_string() {
+        let node_id = NodeId::from_mac_string("AA:BB:CC:DD:EE:FF").unwrap();
+        assert_eq!(node_id.as_u32(), 0xCCDDEEFF);
+
+        // Lowercase should work too
+        let node_id = NodeId::from_mac_string("aa:bb:cc:dd:ee:ff").unwrap();
+        assert_eq!(node_id.as_u32(), 0xCCDDEEFF);
+
+        // Invalid formats
+        assert!(NodeId::from_mac_string("invalid").is_none());
+        assert!(NodeId::from_mac_string("AA:BB:CC:DD:EE").is_none()); // Too short
+        assert!(NodeId::from_mac_string("AA:BB:CC:DD:EE:FF:GG").is_none()); // Too long
+        assert!(NodeId::from_mac_string("ZZ:BB:CC:DD:EE:FF").is_none()); // Invalid hex
     }
 
     #[test]

--- a/hive-btle/src/platform/android/jni_bridge.rs
+++ b/hive-btle/src/platform/android/jni_bridge.rs
@@ -444,6 +444,41 @@ pub extern "system" fn Java_com_hive_btle_HiveBtle_nativeShutdown<'local>(
     // Clean up native resources if needed
 }
 
+/// Derive NodeId from a BLE MAC address string
+///
+/// Called from Kotlin HiveBtle.nativeDeriveNodeId()
+///
+/// JNI Signature: (Ljava/lang/String;)J
+#[no_mangle]
+pub extern "system" fn Java_com_hive_btle_HiveBtle_nativeDeriveNodeId<'local>(
+    mut env: JNIEnv<'local>,
+    _class: JClass<'local>,
+    mac_address: JString<'local>,
+) -> jlong {
+    let mac_str: String = match env.get_string(&mac_address) {
+        Ok(s) => s.into(),
+        Err(e) => {
+            log::error!("Failed to get MAC address string: {:?}", e);
+            return 0;
+        }
+    };
+
+    match NodeId::from_mac_string(&mac_str) {
+        Some(node_id) => {
+            log::debug!(
+                "Derived NodeId {:08X} from MAC {}",
+                node_id.as_u32(),
+                mac_str
+            );
+            node_id.as_u32() as jlong
+        }
+        None => {
+            log::warn!("Failed to parse MAC address: {}", mac_str);
+            0
+        }
+    }
+}
+
 // ============================================================================
 // JNI Native Method Exports - Scan Callbacks
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add `NodeId::from_mac_address()` and `NodeId::from_mac_string()` to the core Rust hive-btle crate
- Expose via JNI for Android to use the same derivation logic as iOS and ESP32
- Auto-generate node ID from Bluetooth adapter MAC address instead of hardcoding
- Display local node ID in Android demo app UI

## Test plan

- [x] Unit tests pass for `NodeId::from_mac_address` and `NodeId::from_mac_string`
- [x] Android app builds and runs
- [x] Node ID auto-generated on startup (fallback if MAC unavailable on Android 12+)
- [x] Node ID displayed in app header
- [ ] Test with M5Stack Core2 to verify mesh connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)