### PR TITLE
feat(hive-btle): Add mesh ID support for Android BLE (Issue #461)

### DIFF
--- a/examples/android-hive-demo/app/src/main/java/com/hive/demo/MainActivity.kt
+++ b/examples/android-hive-demo/app/src/main/java/com/hive/demo/MainActivity.kt
@@ -150,12 +150,14 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
 
     private fun initializeHiveBtle() {
         try {
-            hiveBtle = HiveBtle(applicationContext) // nodeId auto-generated from adapter
+            // Get mesh ID from environment (HIVE_APP_ID, HIVE_MESH_ID, or default "DEMO")
+            val meshId = HiveBtle.getMeshIdFromEnvironment()
+            hiveBtle = HiveBtle(applicationContext, meshId = meshId) // nodeId auto-generated from adapter
             hiveBtle.init()
             Log.i(TAG, "HIVE BLE initialized with nodeId: ${String.format("%08X", hiveBtle.nodeId)}")
 
-            // Update UI with our node ID
-            localNodeIdText.text = "Node: HIVE-${String.format("%08X", hiveBtle.nodeId)}"
+            // Update UI with our node ID and mesh ID
+            localNodeIdText.text = "Node: ${HiveBtle.generateDeviceName(hiveBtle.getMeshId(), hiveBtle.nodeId)}"
 
             // Start the mesh - it handles everything automatically
             hiveBtle.startMesh(this)
@@ -291,14 +293,15 @@ class MainActivity : AppCompatActivity(), HiveMeshListener {
             val notAckedNodes = pendingAcks.filter { !it.value }.keys
 
             val statusBuilder = StringBuilder()
+            val meshId = if (::hiveBtle.isInitialized) hiveBtle.getMeshId() else HiveBtle.DEFAULT_MESH_ID
             if (ackedNodes.isNotEmpty()) {
                 statusBuilder.append("✓ ACK'd: ")
-                statusBuilder.append(ackedNodes.joinToString(", ") { "HIVE-${String.format("%08X", it)}" })
+                statusBuilder.append(ackedNodes.joinToString(", ") { HiveBtle.generateDeviceName(meshId, it) })
             }
             if (notAckedNodes.isNotEmpty()) {
                 if (statusBuilder.isNotEmpty()) statusBuilder.append("\n")
                 statusBuilder.append("⏳ Waiting: ")
-                statusBuilder.append(notAckedNodes.joinToString(", ") { "HIVE-${String.format("%08X", it)}" })
+                statusBuilder.append(notAckedNodes.joinToString(", ") { HiveBtle.generateDeviceName(meshId, it) })
             }
 
             ackStatusText.text = statusBuilder.toString()

--- a/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
+++ b/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
@@ -59,10 +59,12 @@ import android.os.Looper
  *
  * @param context Android context (Activity, Service, or Application)
  * @param nodeId This node's HIVE ID (32-bit unsigned). If null, auto-generated from Bluetooth MAC address.
+ * @param meshId Mesh identifier for mesh isolation (e.g., "DEMO", "ALFA"). Defaults to "DEMO".
  */
 class HiveBtle(
     private val context: Context,
-    private var _nodeId: Long? = null
+    private var _nodeId: Long? = null,
+    private val meshId: String = DEFAULT_MESH_ID
 ) {
     /**
      * This node's HIVE ID. Auto-generated from Bluetooth MAC address if not specified.
@@ -70,6 +72,11 @@ class HiveBtle(
      */
     val nodeId: Long
         get() = _nodeId ?: 0L
+
+    /**
+     * Get the mesh ID this node belongs to.
+     */
+    fun getMeshId(): String = meshId
     companion object {
         private const val TAG = "HiveBtle"
 
@@ -107,8 +114,133 @@ class HiveBtle(
         /** Client Characteristic Configuration Descriptor UUID */
         val CCCD_UUID: UUID = UUID.fromString("00002902-0000-1000-8000-00805F9B34FB")
 
-        /** HIVE device name prefix */
+        /** HIVE device name prefix (legacy format) */
         const val HIVE_NAME_PREFIX = "HIVE-"
+
+        /** HIVE device name prefix with mesh ID (new format) */
+        const val HIVE_MESH_PREFIX = "HIVE_"
+
+        /** Default mesh ID for demos and testing */
+        const val DEFAULT_MESH_ID = "DEMO"
+
+        /**
+         * Derive a short mesh ID from an app ID string.
+         *
+         * The mesh ID is used in BLE device names and should be short (4-8 chars).
+         * This function takes a potentially long app_id (e.g., "default-atak-formation")
+         * and derives a short mesh ID from it.
+         *
+         * Strategy:
+         * - If app_id is 8 chars or less, use it directly (uppercased)
+         * - Otherwise, use first 4 chars of a hash (uppercased hex)
+         *
+         * @param appId The application/formation ID (e.g., from HIVE_APP_ID env var)
+         * @return A short mesh ID suitable for BLE device names
+         */
+        @JvmStatic
+        fun deriveMeshId(appId: String): String {
+            val normalized = appId.trim().uppercase()
+            return if (normalized.length <= 8) {
+                normalized.ifEmpty { DEFAULT_MESH_ID }
+            } else {
+                // Use first 4 hex chars of hash for longer app IDs
+                String.format("%04X", appId.hashCode() and 0xFFFF)
+            }
+        }
+
+        /**
+         * Get the mesh ID from environment or system properties.
+         *
+         * Checks in order:
+         * 1. System property "hive.mesh_id"
+         * 2. System property "hive.app_id" (derives mesh ID from it)
+         * 3. Environment variable "HIVE_MESH_ID"
+         * 4. Environment variable "HIVE_APP_ID" (derives mesh ID from it)
+         * 5. Falls back to DEFAULT_MESH_ID ("DEMO")
+         *
+         * @return The mesh ID to use for this node
+         */
+        @JvmStatic
+        fun getMeshIdFromEnvironment(): String {
+            // Direct mesh ID takes priority
+            System.getProperty("hive.mesh_id")?.let { return it }
+            System.getenv("HIVE_MESH_ID")?.let { return it }
+
+            // Derive from app ID if available
+            System.getProperty("hive.app_id")?.let { return deriveMeshId(it) }
+            System.getenv("HIVE_APP_ID")?.let { return deriveMeshId(it) }
+
+            return DEFAULT_MESH_ID
+        }
+
+        /**
+         * Generate a device name in the new mesh format: HIVE_<MESH_ID>-<NODE_ID>
+         *
+         * @param meshId Mesh identifier (e.g., "DEMO", "ALFA")
+         * @param nodeId Node ID as 32-bit unsigned long
+         * @return Device name string (e.g., "HIVE_DEMO-12345678")
+         */
+        @JvmStatic
+        fun generateDeviceName(meshId: String, nodeId: Long): String {
+            return "HIVE_${meshId}-${String.format("%08X", nodeId)}"
+        }
+
+        /**
+         * Parse mesh ID and node ID from a device name.
+         *
+         * Supports both formats:
+         * - New: HIVE_<MESH_ID>-<NODE_ID> (e.g., "HIVE_DEMO-12345678")
+         * - Legacy: HIVE-<NODE_ID> (e.g., "HIVE-12345678") - returns null meshId
+         *
+         * @param name Device name to parse
+         * @return Pair of (meshId, nodeId) or null if parsing fails
+         */
+        @JvmStatic
+        fun parseDeviceName(name: String): Pair<String?, Long>? {
+            return when {
+                name.startsWith(HIVE_MESH_PREFIX) -> {
+                    // New format: HIVE_MESHID-NODEID
+                    val rest = name.removePrefix(HIVE_MESH_PREFIX)
+                    val dashIndex = rest.indexOf('-')
+                    if (dashIndex <= 0) return null
+                    val meshId = rest.substring(0, dashIndex)
+                    val nodeIdStr = rest.substring(dashIndex + 1)
+                    try {
+                        val nodeId = nodeIdStr.toLong(16)
+                        Pair(meshId, nodeId)
+                    } catch (e: NumberFormatException) {
+                        null
+                    }
+                }
+                name.startsWith(HIVE_NAME_PREFIX) -> {
+                    // Legacy format: HIVE-NODEID (no mesh ID)
+                    val nodeIdStr = name.removePrefix(HIVE_NAME_PREFIX)
+                    try {
+                        val nodeId = nodeIdStr.toLong(16)
+                        Pair(null, nodeId)
+                    } catch (e: NumberFormatException) {
+                        null
+                    }
+                }
+                else -> null
+            }
+        }
+
+        /**
+         * Check if a device matches our mesh.
+         *
+         * Returns true if:
+         * - The device has the same mesh ID, OR
+         * - The device has no mesh ID (legacy format - backwards compatible)
+         *
+         * @param ourMeshId Our mesh ID
+         * @param deviceMeshId Device's mesh ID (null for legacy format)
+         * @return true if the device matches our mesh
+         */
+        @JvmStatic
+        fun matchesMesh(ourMeshId: String, deviceMeshId: String?): Boolean {
+            return deviceMeshId == null || deviceMeshId == ourMeshId
+        }
 
         /**
          * Derive a NodeId from a BLE MAC address using the native Rust implementation.
@@ -401,7 +533,7 @@ class HiveBtle(
         try {
             advertiser.startAdvertising(settings, data, scanResponse, advertiseCallback)
             isAdvertising = true
-            Log.i(TAG, "Started advertising as HIVE-${String.format("%08X", nodeId)}")
+            Log.i(TAG, "Started advertising as ${generateDeviceName(meshId, nodeId)}")
         } catch (e: SecurityException) {
             Log.e(TAG, "Missing BLUETOOTH_ADVERTISE permission", e)
             throw e
@@ -631,6 +763,13 @@ class HiveBtle(
         // Don't track ourselves
         if (peerNodeId == nodeId) return
 
+        // Check mesh ID - only auto-connect to peers in the same mesh or legacy peers
+        val sameMesh = matchesMesh(meshId, device.meshId)
+        if (!sameMesh) {
+            Log.d(TAG, "Skipping peer ${String.format("%08X", peerNodeId)} - different mesh (${device.meshId} != $meshId)")
+            return
+        }
+
         val now = System.currentTimeMillis()
         addressToNodeId[device.address] = peerNodeId
 
@@ -644,14 +783,15 @@ class HiveBtle(
             val peer = HivePeer(
                 nodeId = peerNodeId,
                 address = device.address,
-                name = device.name.ifEmpty { "HIVE-${String.format("%08X", peerNodeId)}" },
+                name = device.name.ifEmpty { generateDeviceName(device.meshId ?: meshId, peerNodeId) },
+                meshId = device.meshId,
                 rssi = device.rssi,
                 isConnected = false,
                 lastDocument = null,
                 lastSeen = now
             )
             peers[peerNodeId] = peer
-            Log.i(TAG, "New peer discovered: ${peer.displayName()}")
+            Log.i(TAG, "New peer discovered: ${peer.displayName()} (mesh: ${device.meshId ?: "legacy"})")
 
             // Auto-connect to new peer
             connectToPeer(peer)
@@ -1014,6 +1154,7 @@ data class DiscoveredDevice(
     val name: String,
     val rssi: Int,
     val nodeId: Long?,
+    val meshId: String?,
     val timestampNanos: Long,
     val isHiveDevice: Boolean = false
 )
@@ -1025,15 +1166,24 @@ data class HivePeer(
     val nodeId: Long,
     val address: String,
     val name: String,
+    val meshId: String?,
     var rssi: Int,
     var isConnected: Boolean,
     var lastDocument: HiveDocument?,
     var lastSeen: Long
 ) {
     /**
-     * Get the display name for this peer (HIVE-XXXXXXXX format).
+     * Get the display name for this peer.
+     * Uses new format (HIVE_MESHID-NODEID) if mesh ID is available,
+     * otherwise falls back to legacy format (HIVE-NODEID).
      */
-    fun displayName(): String = "HIVE-${String.format("%08X", nodeId)}"
+    fun displayName(): String {
+        return if (meshId != null) {
+            "HIVE_${meshId}-${String.format("%08X", nodeId)}"
+        } else {
+            "HIVE-${String.format("%08X", nodeId)}"
+        }
+    }
 
     /**
      * Get the current event type from this peer's last document.

--- a/hive-btle/android/src/main/java/com/hive/btle/ScanCallbackProxy.kt
+++ b/hive-btle/android/src/main/java/com/hive/btle/ScanCallbackProxy.kt
@@ -65,28 +65,23 @@ class ScanCallbackProxy(
             )
 
             // Check if this is a HIVE device (by name prefix or service UUID)
-            val isHiveDevice = name.startsWith(HiveBtle.HIVE_NAME_PREFIX) ||
+            val isHiveDevice = name.startsWith(HiveBtle.HIVE_MESH_PREFIX) ||
+                name.startsWith(HiveBtle.HIVE_NAME_PREFIX) ||
                 serviceUuids.any { it.contains("F47A", ignoreCase = true) } ||
                 hiveServiceData != null
 
-            // Parse node ID from name (HIVE-XXXXXXXX format) or service data
-            val nodeId: Long? = when {
-                // Try parsing from name first
-                name.startsWith(HiveBtle.HIVE_NAME_PREFIX) -> {
-                    try {
-                        name.removePrefix(HiveBtle.HIVE_NAME_PREFIX).toLong(16)
-                    } catch (e: NumberFormatException) {
-                        null
-                    }
-                }
-                // Try parsing from service data (4 bytes, big-endian node ID)
-                hiveServiceData != null && hiveServiceData.size >= 4 -> {
-                    ((hiveServiceData[0].toLong() and 0xFF) shl 24) or
+            // Parse mesh ID and node ID from device name
+            // Supports both new format (HIVE_MESHID-NODEID) and legacy format (HIVE-NODEID)
+            val parsed = HiveBtle.parseDeviceName(name)
+            var meshId: String? = parsed?.first
+            var nodeId: Long? = parsed?.second
+
+            // If name parsing failed, try service data (4 bytes, big-endian node ID)
+            if (nodeId == null && hiveServiceData != null && hiveServiceData.size >= 4) {
+                nodeId = ((hiveServiceData[0].toLong() and 0xFF) shl 24) or
                     ((hiveServiceData[1].toLong() and 0xFF) shl 16) or
                     ((hiveServiceData[2].toLong() and 0xFF) shl 8) or
                     (hiveServiceData[3].toLong() and 0xFF)
-                }
-                else -> null
             }
 
             // Debug: log service data if present
@@ -94,7 +89,7 @@ class ScanCallbackProxy(
                 Log.d(TAG, "HIVE service data (${hiveServiceData.size} bytes): ${hiveServiceData.joinToString(" ") { String.format("%02X", it) }}")
             }
 
-            Log.d(TAG, "Scan result: $address ($name) RSSI=$rssi, isHive=$isHiveDevice, nodeId=${nodeId?.let { String.format("%08X", it) }}")
+            Log.d(TAG, "Scan result: $address ($name) RSSI=$rssi, isHive=$isHiveDevice, meshId=$meshId, nodeId=${nodeId?.let { String.format("%08X", it) }}")
 
             // Create discovered device and invoke callback
             val discoveredDevice = DiscoveredDevice(
@@ -102,6 +97,7 @@ class ScanCallbackProxy(
                 name = name,
                 rssi = rssi,
                 nodeId = nodeId,
+                meshId = meshId,
                 timestampNanos = result.timestampNanos,
                 isHiveDevice = isHiveDevice
             )


### PR DESCRIPTION
## Summary

Implements mesh isolation for Android by adding mesh ID to BLE device names as specified in Issue #461.

### Changes

**hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt:**
- Add `meshId` constructor parameter with `DEFAULT_MESH_ID = "DEMO"`
- Add `getMeshId()` method
- Add static methods: `generateDeviceName()`, `parseDeviceName()`, `matchesMesh()`
- Update `DiscoveredDevice` and `HivePeer` data classes with `meshId` field
- Add mesh filtering in `onDeviceDiscovered()` - skip peers from different meshes
- Update advertising log to use new format

**hive-btle/android/src/main/java/com/hive/btle/ScanCallbackProxy.kt:**
- Update HIVE device detection to check both `HIVE_` and `HIVE-` prefixes
- Use `HiveBtle.parseDeviceName()` to parse both new and legacy formats
- Add `meshId` to `DiscoveredDevice` creation

**examples/android-hive-demo/app/src/main/java/com/hive/demo/MainActivity.kt:**
- Update UI to display node ID in new format (e.g., `HIVE_DEMO-12345678`)
- Update ACK status display to use new format

### Device Name Format

- **New format:** `HIVE_<MESH_ID>-<NODE_ID>` (e.g., `HIVE_DEMO-12345678`)
- **Legacy format:** `HIVE-<NODE_ID>` (still supported for backwards compatibility)

### Backwards Compatibility

Legacy devices advertising `HIVE-NODEID` format (with `meshId = null`) are allowed to connect to any mesh, ensuring interoperability with older firmware.

## Test plan

- [ ] Build Android demo app: `./gradlew assembleDebug`
- [ ] Verify nodes advertise with new format `HIVE_DEMO-12345678`
- [ ] Verify nodes in same mesh can discover and connect
- [ ] Verify nodes in different meshes are skipped (check logcat for "different mesh" message)
- [ ] Verify legacy `HIVE-NODEID` devices can still connect

Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)