### PR TITLE
feat(hive-btle): Add iOS GATT server read/write handlers and LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024-2025 (r)evolve - Revolve Team LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/hive-btle/src/platform/apple/delegates.rs
+++ b/hive-btle/src/platform/apple/delegates.rs
@@ -17,10 +17,13 @@ use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
 use objc2::{declare_class, msg_send_id, mutability, ClassType, DeclaredClass};
 use objc2_core_bluetooth::{
-    CBCentralManager, CBCentralManagerDelegate, CBCharacteristic, CBPeripheral,
-    CBPeripheralDelegate, CBPeripheralManager, CBPeripheralManagerDelegate, CBService,
+    CBATTError, CBATTRequest, CBCentralManager, CBCentralManagerDelegate, CBCharacteristic,
+    CBPeripheral, CBPeripheralDelegate, CBPeripheralManager, CBPeripheralManagerDelegate,
+    CBService,
 };
-use objc2_foundation::{NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSString};
+use objc2_foundation::{
+    NSArray, NSData, NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSString,
+};
 use tokio::sync::mpsc;
 
 use crate::NodeId;
@@ -597,12 +600,15 @@ impl RustPeripheralDelegate {
 /// Ivars for RustPeripheralManagerDelegate
 pub struct PeripheralManagerDelegateIvars {
     event_tx: Mutex<Option<mpsc::Sender<PeripheralManagerEvent>>>,
+    /// Stored characteristic values by UUID (for responding to read requests)
+    characteristic_values: Mutex<HashMap<String, Vec<u8>>>,
 }
 
 impl Default for PeripheralManagerDelegateIvars {
     fn default() -> Self {
         Self {
             event_tx: Mutex::new(None),
+            characteristic_values: Mutex::new(HashMap::new()),
         }
     }
 }
@@ -691,6 +697,143 @@ declare_class!(
                 }
             }
         }
+
+        #[method(peripheralManager:didReceiveReadRequest:)]
+        fn peripheral_manager_did_receive_read_request(
+            &self,
+            peripheral: &CBPeripheralManager,
+            request: &CBATTRequest,
+        ) {
+            let characteristic_uuid = unsafe {
+                request.characteristic().UUID().UUIDString().to_string()
+            };
+            let offset = unsafe { request.offset() } as usize;
+            let central_id = unsafe {
+                request.central().identifier().UUIDString().to_string()
+            };
+
+            log::debug!(
+                "Read request from {} for characteristic {} at offset {}",
+                central_id,
+                characteristic_uuid,
+                offset
+            );
+
+            // Look up the characteristic value
+            let response_result = if let Ok(values) = self.ivars().characteristic_values.lock() {
+                if let Some(value) = values.get(&characteristic_uuid) {
+                    if offset <= value.len() {
+                        // Set the response value (from offset to end)
+                        let response_data = &value[offset..];
+                        unsafe {
+                            let ns_data = NSData::with_bytes(response_data);
+                            request.setValue(Some(&ns_data));
+                        }
+                        CBATTError::Success
+                    } else {
+                        CBATTError::InvalidOffset
+                    }
+                } else {
+                    log::warn!("No value stored for characteristic {}", characteristic_uuid);
+                    CBATTError::AttributeNotFound
+                }
+            } else {
+                CBATTError::UnlikelyError
+            };
+
+            // Respond to the request
+            unsafe {
+                peripheral.respondToRequest_withResult(request, response_result);
+            }
+
+            // Send event to Rust code
+            if let Ok(guard) = self.ivars().event_tx.lock() {
+                if let Some(tx) = guard.as_ref() {
+                    let _ = tx.try_send(PeripheralManagerEvent::ReadRequest {
+                        request_id: 0, // CoreBluetooth handles request tracking internally
+                        central_identifier: central_id,
+                        characteristic_uuid,
+                        offset,
+                    });
+                }
+            }
+        }
+
+        #[method(peripheralManager:didReceiveWriteRequests:)]
+        fn peripheral_manager_did_receive_write_requests(
+            &self,
+            peripheral: &CBPeripheralManager,
+            requests: &NSArray<CBATTRequest>,
+        ) {
+            log::debug!("Received {} write request(s)", requests.len());
+
+            // Process all write requests
+            for i in 0..requests.len() {
+                let request = &requests[i];
+
+                let characteristic_uuid = unsafe {
+                    request.characteristic().UUID().UUIDString().to_string()
+                };
+                let offset = unsafe { request.offset() } as usize;
+                let central_id = unsafe {
+                    request.central().identifier().UUIDString().to_string()
+                };
+                let value = unsafe {
+                    request.value()
+                        .map(|d| d.bytes().to_vec())
+                        .unwrap_or_default()
+                };
+
+                log::debug!(
+                    "Write request from {} for {} at offset {}: {} bytes",
+                    central_id,
+                    characteristic_uuid,
+                    offset,
+                    value.len()
+                );
+
+                // Store the new value
+                if let Ok(mut values) = self.ivars().characteristic_values.lock() {
+                    if offset == 0 {
+                        // Replace entire value
+                        values.insert(characteristic_uuid.clone(), value.clone());
+                    } else {
+                        // Append at offset (or extend if needed)
+                        let entry = values.entry(characteristic_uuid.clone()).or_default();
+                        if offset <= entry.len() {
+                            entry.truncate(offset);
+                            entry.extend_from_slice(&value);
+                        } else {
+                            // Pad with zeros if writing past end
+                            entry.resize(offset, 0);
+                            entry.extend_from_slice(&value);
+                        }
+                    }
+                }
+
+                // Send event to Rust code
+                if let Ok(guard) = self.ivars().event_tx.lock() {
+                    if let Some(tx) = guard.as_ref() {
+                        let _ = tx.try_send(PeripheralManagerEvent::WriteRequest {
+                            request_id: i as u64,
+                            central_identifier: central_id,
+                            characteristic_uuid,
+                            value,
+                            offset,
+                            response_needed: true, // CoreBluetooth always needs a response
+                        });
+                    }
+                }
+            }
+
+            // Respond to the first request (CoreBluetooth requirement)
+            // All requests in the array share the same response
+            if !requests.is_empty() {
+                unsafe {
+                    peripheral.respondToRequest_withResult(&requests[0], CBATTError::Success);
+                }
+            }
+        }
     }
 );
 
@@ -700,6 +843,7 @@ impl RustPeripheralManagerDelegate {
         let this = Self::alloc();
         let this = this.set_ivars(PeripheralManagerDelegateIvars {
             event_tx: Mutex::new(Some(event_tx)),
+            characteristic_values: Mutex::new(HashMap::new()),
         });
         unsafe { msg_send_id![super(this), init] }
     }
@@ -707,6 +851,32 @@ impl RustPeripheralManagerDelegate {
     /// Get as a protocol object for setting as delegate
     pub fn as_protocol(&self) -> &ProtocolObject<dyn CBPeripheralManagerDelegate> {
         ProtocolObject::from_ref(self)
+    }
+
+    /// Set the value for a characteristic (used for read requests)
+    ///
+    /// This value will be returned when a central device reads the characteristic.
+    pub fn set_characteristic_value(&self, characteristic_uuid: &str, value: Vec<u8>) {
+        if let Ok(mut values) = self.ivars().characteristic_values.lock() {
+            values.insert(characteristic_uuid.to_string(), value);
+            log::debug!(
+                "Set characteristic {} value ({} bytes)",
+                characteristic_uuid,
+                values
+                    .get(characteristic_uuid)
+                    .map(|v| v.len())
+                    .unwrap_or(0)
+            );
+        }
+    }
+
+    /// Get the current value for a characteristic
+    pub fn get_characteristic_value(&self, characteristic_uuid: &str) -> Option<Vec<u8>> {
+        if let Ok(values) = self.ivars().characteristic_values.lock() {
+            values.get(characteristic_uuid).cloned()
+        } else {
+            None
+        }
     }
 }
 

--- a/hive-btle/src/platform/apple/peripheral.rs
+++ b/hive-btle/src/platform/apple/peripheral.rs
@@ -274,6 +274,11 @@ impl PeripheralManager {
                 "Registered HIVE service with node ID {:08X}",
                 node_id.as_u32()
             );
+
+            // Set initial characteristic values in the delegate for read requests
+            // Node Info (0001) - contains the node ID
+            self.delegate
+                .set_characteristic_value("0001", node_id.as_u32().to_le_bytes().to_vec());
         }
         // All ObjC objects are now dropped, safe to await
 
@@ -505,6 +510,20 @@ impl PeripheralManager {
     pub async fn is_advertising(&self) -> bool {
         // Use the actual CoreBluetooth state
         unsafe { self.manager.isAdvertising() }
+    }
+
+    /// Set the value for a characteristic
+    ///
+    /// This value will be returned when a central device reads the characteristic.
+    /// Use this to set sync data or other readable values.
+    pub fn set_characteristic_value(&self, characteristic_uuid: &str, value: Vec<u8>) {
+        self.delegate
+            .set_characteristic_value(characteristic_uuid, value);
+    }
+
+    /// Get the current value for a characteristic
+    pub fn get_characteristic_value(&self, characteristic_uuid: &str) -> Option<Vec<u8>> {
+        self.delegate.get_characteristic_value(characteristic_uuid)
     }
 
     /// Send notification to subscribed centrals


### PR DESCRIPTION
## Summary
- Add Apache-2.0 LICENSE file to repository root (required for crates.io publishing)
- Implement iOS GATT server read/write request handlers for cross-platform testing

## Changes

### LICENSE file
- Added Apache-2.0 license text at repository root
- Copyright: 2024-2025 (r)evolve - Revolve Team LLC

### iOS GATT Server Handlers (delegates.rs)
- Implemented `peripheralManager:didReceiveReadRequest:` delegate method
  - Looks up stored characteristic value
  - Sets response data on the CBATTRequest
  - Responds with CBATTError::Success or appropriate error
- Implemented `peripheralManager:didReceiveWriteRequests:` delegate method
  - Processes all write requests in the array
  - Stores new values in characteristic_values HashMap
  - Sends events to Rust code
  - Responds with success
- Added `characteristic_values` storage in delegate ivars
- Added `set_characteristic_value()` and `get_characteristic_value()` helper methods

### PeripheralManager (peripheral.rs)
- Sets initial node ID value in delegate when HIVE service is registered
- Added public `set_characteristic_value()` and `get_characteristic_value()` methods

## Test plan
- [ ] Verify iOS app builds with new delegate methods
- [ ] Test Android connecting to iOS and reading Node Info characteristic
- [ ] Test Android writing to iOS characteristics
- [ ] Verify written values are stored and returned on subsequent reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)