### PR TITLE
feat(hive-btle): Centralize peer management and document sync (Issue #482)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "objc2",
  "objc2-core-bluetooth",
  "objc2-foundation",
+ "spin 0.9.8",
  "thiserror 2.0.17",
  "tokio",
  "tokio-test",

--- a/docs/adr/041-multi-transport-embedded-integration.md
+++ b/docs/adr/041-multi-transport-embedded-integration.md
@@ -1,0 +1,359 @@
+# ADR-041: Multi-Transport Architecture and Embedded Integration
+
+**Status**: Accepted
+**Date**: 2024-12-22
+**Authors**: Kit Plummer, Claude
+**Organization**: (r)evolve - Revolve Team LLC (https://revolveteam.com)
+**Relates To**: ADR-035 (HIVE-Lite Embedded Nodes), ADR-039 (HIVE-BTLE Mesh Transport), ADR-032 (Pluggable Transport Abstraction), ADR-007 (Automerge Sync Engine), ADR-011 (Ditto vs AutomergeIroh)
+
+---
+
+## Executive Summary
+
+This ADR defines how HIVE supports multiple simultaneous transports (AutomergeIroh, hive-btle, future transports) and how embedded devices integrate with full HIVE nodes. The key insight is that Automerge is too resource-intensive for embedded targets (ESP32, Pico), requiring a **gateway translation architecture** where full HIVE nodes translate between Automerge documents and hive-btle's lightweight CRDT format.
+
+---
+
+## Context
+
+### The Multi-Transport Reality
+
+HIVE must operate across diverse network conditions:
+
+| Scenario | Transport | Bandwidth | Typical Nodes |
+|----------|-----------|-----------|---------------|
+| Full connectivity | Iroh (QUIC/UDP) | High (Mbps) | Phones, servers, laptops |
+| BLE mesh | hive-btle | Low (Kbps) | Wearables, sensors, embedded |
+| Degraded network | Either/both | Variable | All nodes adapt |
+| Air-gapped | BLE only | Very low | Field operations |
+
+A phone running HIVE may have both transports active simultaneously:
+- WiFi/cellular: Syncing with cloud/HQ via Iroh
+- BLE: Syncing with nearby embedded sensors via hive-btle
+
+### The Automerge Problem
+
+Per ADR-007 and ADR-011, HIVE's primary sync engine is AutomergeIroh - Automerge CRDTs synced via Iroh networking. However:
+
+**Automerge Resource Requirements:**
+- Binary size: ~2-3MB compiled
+- Runtime RAM: 10-100MB+ depending on document size
+- Requires `std` library (heap allocation, threading)
+- Document history accumulates unbounded
+
+**ESP32/Pico Constraints (per ADR-035):**
+- Total RAM: 520KB (ESP32) / 264KB (Pico)
+- Available for app: ~256KB after OS/stack
+- No `std` - `no_std` embedded Rust only
+- Flash: 4-16MB (binary + data)
+
+**Conclusion**: Automerge cannot run on embedded targets. We need an alternative.
+
+### Current Backend Situation
+
+HIVE currently supports two sync backends:
+1. **AutomergeIroh** - Open source, Automerge CRDTs + Iroh transport
+2. **Ditto** - Commercial, proprietary CRDTs + proprietary transport
+
+hive-btle introduces a third CRDT implementation (GCounter, LWW-Register, etc.) optimized for embedded. This creates a potential fragmentation problem.
+
+---
+
+## Decision
+
+### Architecture: Gateway Translation Model
+
+Full HIVE nodes act as **gateways** that translate between Automerge documents and hive-btle's lightweight format:
+
+```
+┌────────────────────────────────────────────────────────────────────────────┐
+│                        Full HIVE Node (Phone/Server)                        │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │                         AutomergeIroh                                 │  │
+│  │              (Full Automerge documents, sync via Iroh)                │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+│                                    ↕                                        │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │                      Translation Layer                                │  │
+│  │         (Maps hive-btle primitives ↔ Automerge document fields)       │  │
+│  │                      OWNED BY HIVE REPO                               │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+│                                    ↕                                        │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │                          hive-btle                                    │  │
+│  │              (BLE transport + lightweight CRDTs for embedded)         │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────────────┘
+                                     ↕ BLE
+┌────────────────────────────────────────────────────────────────────────────┐
+│                      Embedded Node (ESP32/Pico)                             │
+│  ┌──────────────────────────────────────────────────────────────────────┐  │
+│  │                          hive-btle                                    │  │
+│  │          (BLE transport + lightweight CRDTs, standalone)              │  │
+│  └──────────────────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Key Principles
+
+#### 1. Schema Ownership Lives in HIVE
+
+The canonical schema definition lives in the HIVE repository, not in hive-btle:
+
+| Component | Owner | Description |
+|-----------|-------|-------------|
+| **Schema definition** | HIVE repo | Canonical field names, types, semantics |
+| **Automerge representation** | HIVE repo | Full documents for std nodes |
+| **Lightweight representation** | hive-btle | Embedded-friendly projection |
+| **Translation logic** | HIVE repo | Maps between representations |
+| **BLE transport** | hive-btle | Document-agnostic byte transport |
+
+#### 2. hive-btle is Transport + Lightweight CRDTs
+
+hive-btle provides two things:
+1. **BLE Transport**: Discovery, connections, GATT, chunking - document agnostic
+2. **Lightweight CRDTs**: GCounter, LWW-Register, Peripheral - the "embedded projection" of HIVE schema
+
+The lightweight CRDTs exist because embedded devices can't run Automerge. They represent the **same semantic data** as the full schema, just in a format that fits in 256KB RAM.
+
+#### 3. hive-btle Can Stand Alone
+
+hive-btle must be usable independently for:
+- Pure embedded deployments (ESP32 mesh without any full HIVE nodes)
+- Open source release (standalone BLE mesh library)
+- Testing and development
+
+When used standalone, the lightweight CRDTs ARE the schema. When integrated with full HIVE, they become a projection that gets translated.
+
+#### 4. BLE-First Schema Design
+
+HIVE's schema should be designed with BLE constraints in mind:
+
+```
+DESIGN PRINCIPLE: If it works well on BLE, it works everywhere.
+High-bandwidth transports just make it faster.
+```
+
+Benefits:
+- Efficient sync across all transports
+- No "lossy" translation for embedded
+- Better battery life even on high-bandwidth transports
+- Simpler mental model
+
+### Integration Points
+
+#### Full HIVE Node Receiving from Embedded
+
+```rust
+// In HIVE repo (not hive-btle)
+impl TranslationLayer {
+    /// Receive lightweight document from BLE, update Automerge
+    fn on_ble_document_received(&mut self, data: &[u8]) -> Result<()> {
+        // Decode hive-btle format
+        let lite_doc = hive_btle::HiveDocument::decode(data)?;
+
+        // Extract fields and map to Automerge document
+        let node_id = lite_doc.node_id;
+        let counter_value = lite_doc.counter.value();
+
+        if let Some(peripheral) = lite_doc.peripheral {
+            // Map peripheral fields to Automerge document
+            self.automerge_doc.put(
+                &format!("/sensors/{}/counter", node_id),
+                counter_value
+            )?;
+
+            if let Some(event) = peripheral.last_event {
+                match event.event_type {
+                    EventType::Emergency => {
+                        self.automerge_doc.put(
+                            &format!("/alerts/{}/emergency", node_id),
+                            event.timestamp
+                        )?;
+                    }
+                    EventType::Ack => {
+                        self.automerge_doc.put(
+                            &format!("/alerts/{}/ack", node_id),
+                            event.timestamp
+                        )?;
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+```
+
+#### Full HIVE Node Sending to Embedded
+
+```rust
+// In HIVE repo (not hive-btle)
+impl TranslationLayer {
+    /// Build lightweight document from Automerge for BLE broadcast
+    fn build_ble_document(&self) -> Vec<u8> {
+        let mut doc = hive_btle::HiveDocument::new(self.node_id);
+
+        // Extract relevant fields from Automerge
+        // Only include what embedded nodes need
+        if let Some(emergency_ts) = self.automerge_doc.get("/alerts/active/emergency") {
+            doc.peripheral.as_mut().unwrap().set_event(
+                hive_btle::EventType::Emergency,
+                emergency_ts
+            );
+        }
+
+        doc.encode()
+    }
+}
+```
+
+### Transport Abstraction
+
+For true multi-transport support, HIVE should have a transport abstraction:
+
+```rust
+// In HIVE repo
+trait HiveTransport {
+    /// Send data to a peer
+    async fn send(&self, peer_id: &NodeId, data: &[u8]) -> Result<()>;
+
+    /// Receive data from peers
+    fn receive(&self) -> impl Stream<Item = (NodeId, Vec<u8>)>;
+
+    /// Get connected peers
+    fn peers(&self) -> Vec<NodeId>;
+
+    /// Transport capabilities
+    fn capabilities(&self) -> TransportCapabilities;
+}
+
+// Implementations
+struct IrohTransport { /* AutomergeIroh */ }
+struct BleTransport { /* hive-btle */ }
+
+// Transport manager selects best transport per peer
+struct TransportManager {
+    transports: Vec<Box<dyn HiveTransport>>,
+}
+
+impl TransportManager {
+    fn send(&self, peer_id: &NodeId, data: &[u8]) -> Result<()> {
+        // Try transports in priority order
+        // Fall back to lower-bandwidth if higher fails
+        for transport in &self.transports {
+            if transport.can_reach(peer_id) {
+                return transport.send(peer_id, data).await;
+            }
+        }
+        Err(Error::NoPeerRoute)
+    }
+}
+```
+
+### Graceful Degradation
+
+When network conditions change:
+
+| Scenario | Behavior |
+|----------|----------|
+| Full connectivity | Use Iroh for full Automerge sync |
+| WiFi fails, BLE available | Fall back to BLE, sync lightweight format |
+| Only BLE available | Full HIVE nodes act as BLE mesh participants |
+| BLE to embedded | Translate and sync lightweight format |
+
+The translation layer ensures data flows correctly regardless of which transport is active.
+
+---
+
+## Consequences
+
+### Positive
+
+1. **Embedded devices can participate** - No Automerge requirement
+2. **Clean separation** - hive-btle is standalone and useful independently
+3. **Single source of truth** - Schema owned by HIVE, not duplicated
+4. **Graceful degradation** - BLE works when WiFi fails
+5. **OSS-friendly** - hive-btle can be released standalone
+
+### Negative
+
+1. **Translation complexity** - Must maintain mapping between formats
+2. **Potential data loss** - Lightweight format is a subset of full schema
+3. **Two CRDT implementations** - Automerge + hive-btle lightweight
+4. **Testing surface** - Must test translation correctness
+
+### Neutral
+
+1. **Schema design constraint** - Must consider BLE limits when designing schema
+2. **Documentation burden** - Must document what maps where
+
+---
+
+## Schema Mapping Guidelines
+
+When designing HIVE schema, consider BLE representation:
+
+| Full Schema Field | BLE Representation | Notes |
+|-------------------|-------------------|-------|
+| Node status | GCounter + Peripheral | Activity tracking |
+| Emergency events | EventType::Emergency | Immediate priority |
+| ACK responses | EventType::Ack | Confirmation |
+| Position | Future: Position struct | GPS-equipped devices |
+| Sensor readings | LWW-Register values | In Peripheral extension |
+| Complex documents | NOT synced to embedded | Stay on full nodes |
+| History/audit | NOT synced to embedded | Stay on full nodes |
+
+**Rule of thumb**: If it needs to reach a wearable or sensor, it must fit in the lightweight format.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Document Architecture (This ADR)
+- [x] Define gateway translation model
+- [x] Clarify ownership (schema in HIVE, transport in hive-btle)
+- [x] Document integration points
+
+### Phase 2: hive-btle Standalone (Current Work)
+- [x] Lightweight CRDTs (GCounter, Peripheral)
+- [x] HiveDocument wire format
+- [x] PeerManager, DocumentSync
+- [ ] HiveMesh facade
+- [ ] Platform bindings (UniFFI, JNI)
+
+### Phase 3: HIVE Translation Layer (Future)
+- [ ] Define schema-to-lightweight mapping
+- [ ] Implement TranslationLayer in HIVE repo
+- [ ] Integrate with AutomergeIroh documents
+
+### Phase 4: Transport Abstraction (Future)
+- [ ] Define HiveTransport trait
+- [ ] Implement for Iroh
+- [ ] Implement for hive-btle
+- [ ] TransportManager with fallback logic
+
+---
+
+## References
+
+- ADR-007: Automerge-Based Sync Engine
+- ADR-011: Ditto vs AutomergeIroh Analysis
+- ADR-032: Pluggable Transport Abstraction
+- ADR-035: HIVE-Lite Embedded Nodes
+- ADR-039: HIVE-BTLE Mesh Transport Crate
+- [Automerge](https://automerge.org/) - CRDT library
+- [Iroh](https://iroh.computer/) - P2P networking
+
+---
+
+## Decision Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2024-12-22 | Gateway translation model | Automerge too heavy for ESP32, need lightweight alternative |
+| 2024-12-22 | Schema ownership in HIVE | Single source of truth, hive-btle is projection |
+| 2024-12-22 | hive-btle standalone capability | OSS release, pure embedded deployments |
+| 2024-12-22 | BLE-first schema design | If it works on BLE, it works everywhere |

--- a/hive-btle/Cargo.toml
+++ b/hive-btle/Cargo.toml
@@ -47,6 +47,9 @@ log = "0.4"
 # Error handling
 thiserror = { version = "2.0", default-features = false }
 
+# Spin locks for no_std
+spin = { version = "0.9", default-features = false, features = ["rwlock"] }
+
 # Async runtime (optional, for std platforms)
 tokio = { version = "1.42", features = ["sync", "time", "macros", "rt-multi-thread"], optional = true }
 

--- a/hive-btle/README.md
+++ b/hive-btle/README.md
@@ -98,6 +98,48 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Architecture
 
+### Standalone vs HIVE Integration
+
+hive-btle is designed for **dual use**:
+
+1. **Standalone**: Pure embedded mesh (ESP32/Pico devices) without any full HIVE nodes
+2. **HIVE Integration**: BLE transport for full HIVE nodes, with gateway translation to Automerge
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         HIVE Integration Mode                            │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │                    Full HIVE Node (Phone)                          │  │
+│  │  ┌─────────────────────────────────────────────────────────────┐  │  │
+│  │  │                   AutomergeIroh                              │  │  │
+│  │  │             (Full CRDT documents)                            │  │  │
+│  │  └─────────────────────────────────────────────────────────────┘  │  │
+│  │                            ↕                                       │  │
+│  │  ┌─────────────────────────────────────────────────────────────┐  │  │
+│  │  │              Translation Layer (HIVE repo)                   │  │  │
+│  │  │        Maps: Automerge ↔ hive-btle lightweight               │  │  │
+│  │  └─────────────────────────────────────────────────────────────┘  │  │
+│  │                            ↕                                       │  │
+│  │  ┌─────────────────────────────────────────────────────────────┐  │  │
+│  │  │                      hive-btle                               │  │  │
+│  │  │            (BLE transport + lightweight CRDTs)               │  │  │
+│  │  └─────────────────────────────────────────────────────────────┘  │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+│                                ↕ BLE                                     │
+│  ┌───────────────────────────────────────────────────────────────────┐  │
+│  │               Embedded Node (ESP32/Pico)                           │  │
+│  │                        hive-btle                                   │  │
+│  │              (standalone, lightweight CRDTs)                       │  │
+│  └───────────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Why two modes?** Automerge is too resource-intensive for embedded targets (requires ~10MB+ RAM, `std` library). hive-btle's lightweight CRDTs (GCounter, Peripheral) provide the same semantics in <256KB RAM. Full HIVE nodes translate between formats.
+
+See [ADR-041](docs/adr/041-multi-transport-embedded-integration.md) for the full architectural rationale.
+
+### Component Architecture
+
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                      Application                             │
@@ -208,10 +250,9 @@ cargo test sync::
 
 ## Related Documentation
 
-- [ADR-039: HIVE-BTLE Mesh Transport](docs/adr/039-hive-btle-mesh-transport.md) - Full architecture design
-- [Implementation Kickstart](hive-btle-implementation-kickstart.md) - Getting started guide
-- [M5Stack-Samsung Test Plan](hive-btle-m5stack-samsung-test-plan.md) - Hardware test procedures
-- [Quick Start Guide](hive-btle-quickstart-guide.md) - Rapid prototyping guide
+- [ADR-039: HIVE-BTLE Mesh Transport](../docs/adr/039-hive-btle-mesh-transport.md) - Full architecture design
+- [ADR-041: Multi-Transport Integration](../docs/adr/041-multi-transport-embedded-integration.md) - HIVE integration architecture
+- [ADR-035: HIVE-Lite Embedded Nodes](../docs/adr/035-hive-lite-embedded-nodes.md) - Embedded node design
 
 ## Contributing
 

--- a/hive-btle/src/document.rs
+++ b/hive-btle/src/document.rs
@@ -1,0 +1,360 @@
+//! HIVE Document wire format for BLE mesh sync
+//!
+//! This module provides the unified document format used across all platforms
+//! (iOS, Android, ESP32) for mesh synchronization. The format is designed for
+//! efficient BLE transmission while supporting CRDT semantics.
+//!
+//! ## Wire Format
+//!
+//! ```text
+//! Header (8 bytes):
+//!   version:  4 bytes (LE) - document version number
+//!   node_id:  4 bytes (LE) - source node identifier
+//!
+//! GCounter (4 + N*12 bytes):
+//!   num_entries: 4 bytes (LE)
+//!   entries[N]:
+//!     node_id: 4 bytes (LE)
+//!     count:   8 bytes (LE)
+//!
+//! Extended Section (optional, when peripheral data present):
+//!   marker:         1 byte (0xAB)
+//!   reserved:       1 byte
+//!   peripheral_len: 2 bytes (LE)
+//!   peripheral:     variable (34-43 bytes)
+//! ```
+
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+use crate::sync::crdt::{EventType, GCounter, Peripheral, PeripheralEvent};
+use crate::NodeId;
+
+/// Marker byte indicating extended section with peripheral data
+pub const EXTENDED_MARKER: u8 = 0xAB;
+
+/// Minimum document size (header only, no counter entries)
+pub const MIN_DOCUMENT_SIZE: usize = 8;
+
+/// A HIVE document for mesh synchronization
+///
+/// Contains header information, a CRDT G-Counter for tracking mesh activity,
+/// and optional peripheral data for events.
+#[derive(Debug, Clone)]
+pub struct HiveDocument {
+    /// Document version (incremented on each change)
+    pub version: u32,
+
+    /// Source node ID that created/last modified this document
+    pub node_id: NodeId,
+
+    /// CRDT G-Counter tracking activity across the mesh
+    pub counter: GCounter,
+
+    /// Optional peripheral data (sensor info, events)
+    pub peripheral: Option<Peripheral>,
+}
+
+impl Default for HiveDocument {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            node_id: NodeId::default(),
+            counter: GCounter::new(),
+            peripheral: None,
+        }
+    }
+}
+
+impl HiveDocument {
+    /// Create a new document for the given node
+    pub fn new(node_id: NodeId) -> Self {
+        Self {
+            version: 1,
+            node_id,
+            counter: GCounter::new(),
+            peripheral: None,
+        }
+    }
+
+    /// Create with an initial peripheral
+    pub fn with_peripheral(mut self, peripheral: Peripheral) -> Self {
+        self.peripheral = Some(peripheral);
+        self
+    }
+
+    /// Increment the document version
+    pub fn increment_version(&mut self) {
+        self.version = self.version.wrapping_add(1);
+    }
+
+    /// Increment the counter for this node
+    pub fn increment_counter(&mut self) {
+        self.counter.increment(&self.node_id, 1);
+        self.increment_version();
+    }
+
+    /// Set an event on the peripheral
+    pub fn set_event(&mut self, event_type: EventType, timestamp: u64) {
+        if let Some(ref mut peripheral) = self.peripheral {
+            peripheral.set_event(event_type, timestamp);
+            self.increment_counter();
+        }
+    }
+
+    /// Clear the event from the peripheral
+    pub fn clear_event(&mut self) {
+        if let Some(ref mut peripheral) = self.peripheral {
+            peripheral.clear_event();
+            self.increment_version();
+        }
+    }
+
+    /// Merge with another document using CRDT semantics
+    ///
+    /// Returns true if our state changed (useful for triggering re-broadcast)
+    pub fn merge(&mut self, other: &HiveDocument) -> bool {
+        let old_value = self.counter.value();
+        self.counter.merge(&other.counter);
+        let changed = self.counter.value() != old_value;
+        if changed {
+            self.increment_version();
+        }
+        changed
+    }
+
+    /// Get the current event type (if any)
+    pub fn current_event(&self) -> Option<EventType> {
+        self.peripheral
+            .as_ref()
+            .and_then(|p| p.last_event.as_ref())
+            .map(|e| e.event_type)
+    }
+
+    /// Encode to bytes for BLE transmission
+    pub fn encode(&self) -> Vec<u8> {
+        let counter_data = self.counter.encode();
+        let peripheral_data = self.peripheral.as_ref().map(|p| p.encode());
+
+        // Calculate total size
+        let mut size = 8 + counter_data.len(); // header + counter
+        if let Some(ref pdata) = peripheral_data {
+            size += 4 + pdata.len(); // marker + reserved + len + peripheral
+        }
+
+        let mut buf = Vec::with_capacity(size);
+
+        // Header
+        buf.extend_from_slice(&self.version.to_le_bytes());
+        buf.extend_from_slice(&self.node_id.as_u32().to_le_bytes());
+
+        // GCounter
+        buf.extend_from_slice(&counter_data);
+
+        // Extended section (if peripheral present)
+        if let Some(pdata) = peripheral_data {
+            buf.push(EXTENDED_MARKER);
+            buf.push(0); // reserved
+            buf.extend_from_slice(&(pdata.len() as u16).to_le_bytes());
+            buf.extend_from_slice(&pdata);
+        }
+
+        buf
+    }
+
+    /// Decode from bytes received over BLE
+    pub fn decode(data: &[u8]) -> Option<Self> {
+        if data.len() < MIN_DOCUMENT_SIZE {
+            return None;
+        }
+
+        // Header
+        let version = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        let node_id = NodeId::new(u32::from_le_bytes([data[4], data[5], data[6], data[7]]));
+
+        // GCounter (starts at offset 8)
+        let counter = GCounter::decode(&data[8..])?;
+
+        // Calculate where counter ends
+        let num_entries = u32::from_le_bytes([data[8], data[9], data[10], data[11]]) as usize;
+        let counter_end = 8 + 4 + num_entries * 12;
+
+        // Check for extended section
+        let peripheral = if data.len() > counter_end && data[counter_end] == EXTENDED_MARKER {
+            // Parse extended header
+            if data.len() < counter_end + 4 {
+                return None;
+            }
+            let _reserved = data[counter_end + 1];
+            let peripheral_len =
+                u16::from_le_bytes([data[counter_end + 2], data[counter_end + 3]]) as usize;
+
+            let peripheral_start = counter_end + 4;
+            if data.len() < peripheral_start + peripheral_len {
+                return None;
+            }
+
+            Peripheral::decode(&data[peripheral_start..peripheral_start + peripheral_len])
+        } else {
+            None
+        };
+
+        Some(Self {
+            version,
+            node_id,
+            counter,
+            peripheral,
+        })
+    }
+
+    /// Get the total counter value
+    pub fn total_count(&self) -> u64 {
+        self.counter.value()
+    }
+}
+
+/// Result from merging a received document
+#[derive(Debug, Clone)]
+pub struct MergeResult {
+    /// Node ID that sent this document
+    pub source_node: NodeId,
+
+    /// Event contained in the document (if any)
+    pub event: Option<PeripheralEvent>,
+
+    /// Whether the counter changed (indicates new data)
+    pub counter_changed: bool,
+
+    /// Updated total count after merge
+    pub total_count: u64,
+}
+
+impl MergeResult {
+    /// Check if this result contains an emergency event
+    pub fn is_emergency(&self) -> bool {
+        self.event
+            .as_ref()
+            .is_some_and(|e| e.event_type == EventType::Emergency)
+    }
+
+    /// Check if this result contains an ACK event
+    pub fn is_ack(&self) -> bool {
+        self.event
+            .as_ref()
+            .is_some_and(|e| e.event_type == EventType::Ack)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sync::crdt::PeripheralType;
+
+    #[test]
+    fn test_document_encode_decode_minimal() {
+        let node_id = NodeId::new(0x12345678);
+        let doc = HiveDocument::new(node_id);
+
+        let encoded = doc.encode();
+        assert_eq!(encoded.len(), 12); // 8 header + 4 counter (0 entries)
+
+        let decoded = HiveDocument::decode(&encoded).unwrap();
+        assert_eq!(decoded.version, 1);
+        assert_eq!(decoded.node_id.as_u32(), 0x12345678);
+        assert_eq!(decoded.counter.value(), 0);
+        assert!(decoded.peripheral.is_none());
+    }
+
+    #[test]
+    fn test_document_encode_decode_with_counter() {
+        let node_id = NodeId::new(0x12345678);
+        let mut doc = HiveDocument::new(node_id);
+        doc.increment_counter();
+        doc.increment_counter();
+
+        let encoded = doc.encode();
+        // 8 header + 4 num_entries + 1 entry (12 bytes) = 24
+        assert_eq!(encoded.len(), 24);
+
+        let decoded = HiveDocument::decode(&encoded).unwrap();
+        assert_eq!(decoded.counter.value(), 2);
+    }
+
+    #[test]
+    fn test_document_encode_decode_with_peripheral() {
+        let node_id = NodeId::new(0x12345678);
+        let peripheral =
+            Peripheral::new(0xAABBCCDD, PeripheralType::SoldierSensor).with_callsign("ALPHA-1");
+
+        let doc = HiveDocument::new(node_id).with_peripheral(peripheral);
+
+        let encoded = doc.encode();
+        let decoded = HiveDocument::decode(&encoded).unwrap();
+
+        assert!(decoded.peripheral.is_some());
+        let p = decoded.peripheral.unwrap();
+        assert_eq!(p.id, 0xAABBCCDD);
+        assert_eq!(p.callsign_str(), "ALPHA-1");
+    }
+
+    #[test]
+    fn test_document_encode_decode_with_event() {
+        let node_id = NodeId::new(0x12345678);
+        let mut peripheral = Peripheral::new(0xAABBCCDD, PeripheralType::SoldierSensor);
+        peripheral.set_event(EventType::Emergency, 1234567890);
+
+        let doc = HiveDocument::new(node_id).with_peripheral(peripheral);
+
+        let encoded = doc.encode();
+        let decoded = HiveDocument::decode(&encoded).unwrap();
+
+        assert!(decoded.peripheral.is_some());
+        let p = decoded.peripheral.unwrap();
+        assert!(p.last_event.is_some());
+        let event = p.last_event.unwrap();
+        assert_eq!(event.event_type, EventType::Emergency);
+        assert_eq!(event.timestamp, 1234567890);
+    }
+
+    #[test]
+    fn test_document_merge() {
+        let node1 = NodeId::new(0x11111111);
+        let node2 = NodeId::new(0x22222222);
+
+        let mut doc1 = HiveDocument::new(node1);
+        doc1.increment_counter();
+
+        let mut doc2 = HiveDocument::new(node2);
+        doc2.counter.increment(&node2, 3);
+
+        // Merge doc2 into doc1
+        let changed = doc1.merge(&doc2);
+        assert!(changed);
+        assert_eq!(doc1.counter.value(), 4); // 1 + 3
+    }
+
+    #[test]
+    fn test_merge_result_helpers() {
+        let emergency_event = PeripheralEvent::new(EventType::Emergency, 123);
+        let result = MergeResult {
+            source_node: NodeId::new(0x12345678),
+            event: Some(emergency_event),
+            counter_changed: true,
+            total_count: 10,
+        };
+
+        assert!(result.is_emergency());
+        assert!(!result.is_ack());
+
+        let ack_event = PeripheralEvent::new(EventType::Ack, 456);
+        let result = MergeResult {
+            source_node: NodeId::new(0x12345678),
+            event: Some(ack_event),
+            counter_changed: false,
+            total_count: 10,
+        };
+
+        assert!(!result.is_emergency());
+        assert!(result.is_ack());
+    }
+}

--- a/hive-btle/src/document_sync.rs
+++ b/hive-btle/src/document_sync.rs
@@ -1,0 +1,441 @@
+//! Document synchronization for HIVE BLE mesh
+//!
+//! This module provides centralized document state management for HIVE-Lite nodes.
+//! It manages the local CRDT state (GCounter) and handles merging with received documents.
+//!
+//! ## Design Notes
+//!
+//! This implementation uses a simple GCounter for resource-constrained devices (ESP32,
+//! smartwatches). For full HIVE nodes using AutomergeIroh, this component can be replaced
+//! or extended - the observer pattern and BLE transport layer are independent of the
+//! document format.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_btle::document_sync::DocumentSync;
+//! use hive_btle::NodeId;
+//!
+//! let sync = DocumentSync::new(NodeId::new(0x12345678), "SOLDIER-1");
+//!
+//! // Trigger an emergency
+//! let doc_bytes = sync.send_emergency();
+//! // ... broadcast doc_bytes over BLE
+//!
+//! // Handle received document
+//! if let Some(result) = sync.merge_document(&received_data) {
+//!     if result.is_emergency() {
+//!         println!("EMERGENCY from {:08X}", result.source_node.as_u32());
+//!     }
+//! }
+//! ```
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+#[cfg(feature = "std")]
+use std::sync::RwLock;
+
+#[cfg(not(feature = "std"))]
+use spin::RwLock;
+
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use crate::document::{HiveDocument, MergeResult};
+use crate::sync::crdt::{EventType, GCounter, Peripheral, PeripheralType};
+use crate::NodeId;
+
+/// Document synchronization manager for HIVE-Lite nodes
+///
+/// Manages the local CRDT state and handles document serialization/merging.
+/// Thread-safe for use from multiple BLE callbacks.
+///
+/// ## Integration with Full HIVE
+///
+/// This implementation uses a simple GCounter suitable for embedded devices.
+/// For integration with the larger HIVE project using AutomergeIroh:
+/// - The `build_document()` output can be wrapped in an Automerge-compatible format
+/// - The observer events (Emergency, Ack, DocumentSynced) work with any backend
+/// - The BLE transport layer is document-format agnostic
+pub struct DocumentSync {
+    /// Our node ID
+    node_id: NodeId,
+
+    /// CRDT G-Counter for mesh activity tracking
+    counter: RwLock<GCounter>,
+
+    /// Peripheral data (callsign, type, location)
+    peripheral: RwLock<Peripheral>,
+
+    /// Document version (monotonically increasing)
+    version: AtomicU32,
+}
+
+impl DocumentSync {
+    /// Create a new document sync manager
+    pub fn new(node_id: NodeId, callsign: &str) -> Self {
+        let peripheral = Peripheral::new(node_id.as_u32(), PeripheralType::SoldierSensor)
+            .with_callsign(callsign);
+
+        Self {
+            node_id,
+            counter: RwLock::new(GCounter::new()),
+            peripheral: RwLock::new(peripheral),
+            version: AtomicU32::new(1),
+        }
+    }
+
+    /// Create with a specific peripheral type
+    pub fn with_peripheral_type(node_id: NodeId, callsign: &str, ptype: PeripheralType) -> Self {
+        let peripheral = Peripheral::new(node_id.as_u32(), ptype).with_callsign(callsign);
+
+        Self {
+            node_id,
+            counter: RwLock::new(GCounter::new()),
+            peripheral: RwLock::new(peripheral),
+            version: AtomicU32::new(1),
+        }
+    }
+
+    /// Get our node ID
+    pub fn node_id(&self) -> NodeId {
+        self.node_id
+    }
+
+    /// Get the current document version
+    pub fn version(&self) -> u32 {
+        self.version.load(Ordering::Relaxed)
+    }
+
+    /// Get the total counter value
+    pub fn total_count(&self) -> u64 {
+        self.counter.read().unwrap().value()
+    }
+
+    /// Get our counter contribution
+    pub fn local_count(&self) -> u64 {
+        self.counter.read().unwrap().node_count(&self.node_id)
+    }
+
+    /// Get current event type (if any)
+    pub fn current_event(&self) -> Option<EventType> {
+        self.peripheral
+            .read()
+            .unwrap()
+            .last_event
+            .as_ref()
+            .map(|e| e.event_type)
+    }
+
+    /// Check if we're in emergency state
+    pub fn is_emergency_active(&self) -> bool {
+        self.current_event() == Some(EventType::Emergency)
+    }
+
+    /// Check if we've sent an ACK
+    pub fn is_ack_active(&self) -> bool {
+        self.current_event() == Some(EventType::Ack)
+    }
+
+    /// Get the callsign
+    pub fn callsign(&self) -> String {
+        self.peripheral.read().unwrap().callsign_str().to_string()
+    }
+
+    // ==================== State Mutations ====================
+
+    /// Send an emergency - returns the document bytes to broadcast
+    pub fn send_emergency(&self, timestamp: u64) -> Vec<u8> {
+        // Set emergency event
+        {
+            let mut peripheral = self.peripheral.write().unwrap();
+            peripheral.set_event(EventType::Emergency, timestamp);
+        }
+
+        // Increment counter
+        self.increment_counter_internal();
+
+        // Build and return document
+        self.build_document()
+    }
+
+    /// Send an ACK - returns the document bytes to broadcast
+    pub fn send_ack(&self, timestamp: u64) -> Vec<u8> {
+        // Set ACK event
+        {
+            let mut peripheral = self.peripheral.write().unwrap();
+            peripheral.set_event(EventType::Ack, timestamp);
+        }
+
+        // Increment counter
+        self.increment_counter_internal();
+
+        // Build and return document
+        self.build_document()
+    }
+
+    /// Clear the current event
+    pub fn clear_event(&self) {
+        let mut peripheral = self.peripheral.write().unwrap();
+        peripheral.clear_event();
+        self.bump_version();
+    }
+
+    /// Increment the counter (for periodic sync)
+    pub fn increment_counter(&self) {
+        self.increment_counter_internal();
+    }
+
+    // ==================== Document I/O ====================
+
+    /// Build the document for transmission
+    ///
+    /// Returns the encoded bytes ready for BLE GATT write.
+    pub fn build_document(&self) -> Vec<u8> {
+        let counter = self.counter.read().unwrap().clone();
+        let peripheral = self.peripheral.read().unwrap().clone();
+
+        let doc = HiveDocument {
+            version: self.version.load(Ordering::Relaxed),
+            node_id: self.node_id,
+            counter,
+            peripheral: Some(peripheral),
+        };
+
+        doc.encode()
+    }
+
+    /// Merge a received document
+    ///
+    /// Returns `Some(MergeResult)` if the document was valid, `None` otherwise.
+    /// The result contains information about what changed and any events.
+    pub fn merge_document(&self, data: &[u8]) -> Option<MergeResult> {
+        let received = HiveDocument::decode(data)?;
+
+        // Don't process our own documents
+        if received.node_id == self.node_id {
+            return None;
+        }
+
+        // Merge the counter
+        let counter_changed = {
+            let mut counter = self.counter.write().unwrap();
+            let old_value = counter.value();
+            counter.merge(&received.counter);
+            counter.value() != old_value
+        };
+
+        if counter_changed {
+            self.bump_version();
+        }
+
+        // Extract event from received document
+        let event = received
+            .peripheral
+            .as_ref()
+            .and_then(|p| p.last_event.clone());
+
+        Some(MergeResult {
+            source_node: received.node_id,
+            event,
+            counter_changed,
+            total_count: self.total_count(),
+        })
+    }
+
+    /// Create a document from raw bytes (for inspection without merging)
+    pub fn decode_document(data: &[u8]) -> Option<HiveDocument> {
+        HiveDocument::decode(data)
+    }
+
+    // ==================== Internal Helpers ====================
+
+    fn increment_counter_internal(&self) {
+        let mut counter = self.counter.write().unwrap();
+        counter.increment(&self.node_id, 1);
+        drop(counter);
+        self.bump_version();
+    }
+
+    fn bump_version(&self) {
+        self.version.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Result from checking if a document contains an emergency
+#[derive(Debug, Clone)]
+pub struct DocumentCheck {
+    /// Node ID from the document
+    pub node_id: NodeId,
+    /// Whether this document contains an emergency
+    pub is_emergency: bool,
+    /// Whether this document contains an ACK
+    pub is_ack: bool,
+}
+
+impl DocumentCheck {
+    /// Quick check of a document without full parsing
+    pub fn from_document(data: &[u8]) -> Option<Self> {
+        let doc = HiveDocument::decode(data)?;
+
+        let (is_emergency, is_ack) = doc
+            .peripheral
+            .as_ref()
+            .and_then(|p| p.last_event.as_ref())
+            .map(|e| {
+                (
+                    e.event_type == EventType::Emergency,
+                    e.event_type == EventType::Ack,
+                )
+            })
+            .unwrap_or((false, false));
+
+        Some(Self {
+            node_id: doc.node_id,
+            is_emergency,
+            is_ack,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_document_sync_new() {
+        let sync = DocumentSync::new(NodeId::new(0x12345678), "ALPHA-1");
+
+        assert_eq!(sync.node_id().as_u32(), 0x12345678);
+        assert_eq!(sync.version(), 1);
+        assert_eq!(sync.total_count(), 0);
+        assert_eq!(sync.callsign(), "ALPHA-1");
+        assert!(sync.current_event().is_none());
+    }
+
+    #[test]
+    fn test_send_emergency() {
+        let sync = DocumentSync::new(NodeId::new(0x12345678), "ALPHA-1");
+
+        let doc_bytes = sync.send_emergency(1234567890);
+
+        assert!(!doc_bytes.is_empty());
+        assert_eq!(sync.total_count(), 1);
+        assert!(sync.is_emergency_active());
+        assert!(!sync.is_ack_active());
+
+        // Verify we can decode what we sent
+        let doc = HiveDocument::decode(&doc_bytes).unwrap();
+        assert_eq!(doc.node_id.as_u32(), 0x12345678);
+        assert!(doc.peripheral.is_some());
+        let event = doc.peripheral.unwrap().last_event.unwrap();
+        assert_eq!(event.event_type, EventType::Emergency);
+    }
+
+    #[test]
+    fn test_send_ack() {
+        let sync = DocumentSync::new(NodeId::new(0x12345678), "ALPHA-1");
+
+        let doc_bytes = sync.send_ack(1234567890);
+
+        assert!(!doc_bytes.is_empty());
+        assert_eq!(sync.total_count(), 1);
+        assert!(sync.is_ack_active());
+        assert!(!sync.is_emergency_active());
+    }
+
+    #[test]
+    fn test_clear_event() {
+        let sync = DocumentSync::new(NodeId::new(0x12345678), "ALPHA-1");
+
+        sync.send_emergency(1000);
+        assert!(sync.is_emergency_active());
+
+        sync.clear_event();
+        assert!(sync.current_event().is_none());
+    }
+
+    #[test]
+    fn test_merge_document() {
+        let sync1 = DocumentSync::new(NodeId::new(0x11111111), "ALPHA-1");
+        let sync2 = DocumentSync::new(NodeId::new(0x22222222), "BRAVO-1");
+
+        // sync2 sends emergency
+        let doc_bytes = sync2.send_emergency(1000);
+
+        // sync1 receives and merges
+        let result = sync1.merge_document(&doc_bytes);
+        assert!(result.is_some());
+
+        let result = result.unwrap();
+        assert_eq!(result.source_node.as_u32(), 0x22222222);
+        assert!(result.is_emergency());
+        assert!(result.counter_changed);
+        assert_eq!(result.total_count, 1);
+
+        // sync1's local count is still 0, but total includes sync2's contribution
+        assert_eq!(sync1.local_count(), 0);
+        assert_eq!(sync1.total_count(), 1);
+    }
+
+    #[test]
+    fn test_merge_own_document_ignored() {
+        let sync = DocumentSync::new(NodeId::new(0x12345678), "ALPHA-1");
+
+        let doc_bytes = sync.send_emergency(1000);
+
+        // Merging our own document should be ignored
+        let result = sync.merge_document(&doc_bytes);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_version_increments() {
+        let sync = DocumentSync::new(NodeId::new(0x12345678), "ALPHA-1");
+
+        assert_eq!(sync.version(), 1);
+
+        sync.increment_counter();
+        assert_eq!(sync.version(), 2);
+
+        sync.send_emergency(1000);
+        assert_eq!(sync.version(), 3);
+
+        sync.clear_event();
+        assert_eq!(sync.version(), 4);
+    }
+
+    #[test]
+    fn test_document_check() {
+        let sync = DocumentSync::new(NodeId::new(0x12345678), "ALPHA-1");
+
+        let emergency_doc = sync.send_emergency(1000);
+        let check = DocumentCheck::from_document(&emergency_doc).unwrap();
+        assert_eq!(check.node_id.as_u32(), 0x12345678);
+        assert!(check.is_emergency);
+        assert!(!check.is_ack);
+
+        sync.clear_event();
+        let ack_doc = sync.send_ack(2000);
+        let check = DocumentCheck::from_document(&ack_doc).unwrap();
+        assert!(!check.is_emergency);
+        assert!(check.is_ack);
+    }
+
+    #[test]
+    fn test_counter_merge_idempotent() {
+        let sync1 = DocumentSync::new(NodeId::new(0x11111111), "ALPHA-1");
+        let sync2 = DocumentSync::new(NodeId::new(0x22222222), "BRAVO-1");
+
+        // sync2 sends something
+        let doc_bytes = sync2.send_emergency(1000);
+
+        // sync1 merges twice - second should not change counter
+        let result1 = sync1.merge_document(&doc_bytes).unwrap();
+        assert!(result1.counter_changed);
+        assert_eq!(sync1.total_count(), 1);
+
+        let result2 = sync1.merge_document(&doc_bytes).unwrap();
+        assert!(!result2.counter_changed); // No change on re-merge
+        assert_eq!(sync1.total_count(), 1);
+    }
+}

--- a/hive-btle/src/hive_mesh.rs
+++ b/hive-btle/src/hive_mesh.rs
@@ -1,0 +1,781 @@
+//! HiveMesh - Unified mesh management facade
+//!
+//! This module provides the main entry point for HIVE BLE mesh operations.
+//! It composes peer management, document sync, and observer notifications
+//! into a single interface that platform implementations can use.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_btle::hive_mesh::{HiveMesh, HiveMeshConfig};
+//! use hive_btle::observer::{HiveEvent, HiveObserver};
+//! use hive_btle::NodeId;
+//! use std::sync::Arc;
+//!
+//! // Create mesh configuration
+//! let config = HiveMeshConfig::new(NodeId::new(0x12345678), "ALPHA-1", "DEMO");
+//!
+//! // Create mesh instance
+//! let mesh = HiveMesh::new(config);
+//!
+//! // Add observer for events
+//! struct MyObserver;
+//! impl HiveObserver for MyObserver {
+//!     fn on_event(&self, event: HiveEvent) {
+//!         println!("Event: {:?}", event);
+//!     }
+//! }
+//! mesh.add_observer(Arc::new(MyObserver));
+//!
+//! // Platform BLE callbacks
+//! mesh.on_ble_discovered("device-uuid", Some("HIVE_DEMO-AABBCCDD"), -65, Some("DEMO"), now_ms);
+//! mesh.on_ble_connected("device-uuid", now_ms);
+//! mesh.on_ble_data_received("device-uuid", &data, now_ms);
+//!
+//! // Periodic maintenance
+//! if let Some(sync_data) = mesh.tick(now_ms) {
+//!     // Broadcast sync_data to connected peers
+//! }
+//! ```
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, sync::Arc, vec::Vec};
+#[cfg(feature = "std")]
+use std::sync::Arc;
+
+use crate::document_sync::DocumentSync;
+use crate::observer::{DisconnectReason, HiveEvent, HiveObserver};
+use crate::peer::{HivePeer, PeerManagerConfig};
+use crate::peer_manager::PeerManager;
+use crate::sync::crdt::{EventType, PeripheralType};
+use crate::NodeId;
+
+#[cfg(feature = "std")]
+use crate::observer::ObserverManager;
+
+/// Configuration for HiveMesh
+#[derive(Debug, Clone)]
+pub struct HiveMeshConfig {
+    /// Our node ID
+    pub node_id: NodeId,
+
+    /// Our callsign (e.g., "ALPHA-1")
+    pub callsign: String,
+
+    /// Mesh ID to filter peers (e.g., "DEMO")
+    pub mesh_id: String,
+
+    /// Peripheral type for this device
+    pub peripheral_type: PeripheralType,
+
+    /// Peer management configuration
+    pub peer_config: PeerManagerConfig,
+
+    /// Sync interval in milliseconds (how often to broadcast state)
+    pub sync_interval_ms: u64,
+
+    /// Whether to auto-broadcast on emergency/ack
+    pub auto_broadcast_events: bool,
+}
+
+impl HiveMeshConfig {
+    /// Create a new configuration with required fields
+    pub fn new(node_id: NodeId, callsign: &str, mesh_id: &str) -> Self {
+        Self {
+            node_id,
+            callsign: callsign.into(),
+            mesh_id: mesh_id.into(),
+            peripheral_type: PeripheralType::SoldierSensor,
+            peer_config: PeerManagerConfig::with_mesh_id(mesh_id),
+            sync_interval_ms: 5000,
+            auto_broadcast_events: true,
+        }
+    }
+
+    /// Set peripheral type
+    pub fn with_peripheral_type(mut self, ptype: PeripheralType) -> Self {
+        self.peripheral_type = ptype;
+        self
+    }
+
+    /// Set sync interval
+    pub fn with_sync_interval(mut self, interval_ms: u64) -> Self {
+        self.sync_interval_ms = interval_ms;
+        self
+    }
+
+    /// Set peer timeout
+    pub fn with_peer_timeout(mut self, timeout_ms: u64) -> Self {
+        self.peer_config.peer_timeout_ms = timeout_ms;
+        self
+    }
+
+    /// Set max peers (for embedded systems)
+    pub fn with_max_peers(mut self, max: usize) -> Self {
+        self.peer_config.max_peers = max;
+        self
+    }
+}
+
+/// Main facade for HIVE BLE mesh operations
+///
+/// Composes peer management, document sync, and observer notifications.
+/// Platform implementations call into this from their BLE callbacks.
+#[cfg(feature = "std")]
+pub struct HiveMesh {
+    /// Configuration
+    config: HiveMeshConfig,
+
+    /// Peer manager
+    peer_manager: PeerManager,
+
+    /// Document sync
+    document_sync: DocumentSync,
+
+    /// Observer manager
+    observers: ObserverManager,
+
+    /// Last sync broadcast time
+    last_sync_ms: std::sync::atomic::AtomicU64,
+
+    /// Last cleanup time
+    last_cleanup_ms: std::sync::atomic::AtomicU64,
+}
+
+#[cfg(feature = "std")]
+impl HiveMesh {
+    /// Create a new HiveMesh instance
+    pub fn new(config: HiveMeshConfig) -> Self {
+        let peer_manager = PeerManager::new(config.node_id, config.peer_config.clone());
+        let document_sync = DocumentSync::with_peripheral_type(
+            config.node_id,
+            &config.callsign,
+            config.peripheral_type,
+        );
+
+        Self {
+            config,
+            peer_manager,
+            document_sync,
+            observers: ObserverManager::new(),
+            last_sync_ms: std::sync::atomic::AtomicU64::new(0),
+            last_cleanup_ms: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    // ==================== Configuration ====================
+
+    /// Get our node ID
+    pub fn node_id(&self) -> NodeId {
+        self.config.node_id
+    }
+
+    /// Get our callsign
+    pub fn callsign(&self) -> &str {
+        &self.config.callsign
+    }
+
+    /// Get the mesh ID
+    pub fn mesh_id(&self) -> &str {
+        &self.config.mesh_id
+    }
+
+    /// Get the device name for BLE advertising
+    pub fn device_name(&self) -> String {
+        format!(
+            "HIVE_{}-{:08X}",
+            self.config.mesh_id,
+            self.config.node_id.as_u32()
+        )
+    }
+
+    // ==================== Observer Management ====================
+
+    /// Add an observer for mesh events
+    pub fn add_observer(&self, observer: Arc<dyn HiveObserver>) {
+        self.observers.add(observer);
+    }
+
+    /// Remove an observer
+    pub fn remove_observer(&self, observer: &Arc<dyn HiveObserver>) {
+        self.observers.remove(observer);
+    }
+
+    // ==================== User Actions ====================
+
+    /// Send an emergency alert
+    ///
+    /// Returns the document bytes to broadcast to all peers.
+    pub fn send_emergency(&self, timestamp: u64) -> Vec<u8> {
+        let data = self.document_sync.send_emergency(timestamp);
+        self.notify(HiveEvent::MeshStateChanged {
+            peer_count: self.peer_manager.peer_count(),
+            connected_count: self.peer_manager.connected_count(),
+        });
+        data
+    }
+
+    /// Send an ACK response
+    ///
+    /// Returns the document bytes to broadcast to all peers.
+    pub fn send_ack(&self, timestamp: u64) -> Vec<u8> {
+        let data = self.document_sync.send_ack(timestamp);
+        self.notify(HiveEvent::MeshStateChanged {
+            peer_count: self.peer_manager.peer_count(),
+            connected_count: self.peer_manager.connected_count(),
+        });
+        data
+    }
+
+    /// Clear the current event (emergency or ack)
+    pub fn clear_event(&self) {
+        self.document_sync.clear_event();
+    }
+
+    /// Check if emergency is active
+    pub fn is_emergency_active(&self) -> bool {
+        self.document_sync.is_emergency_active()
+    }
+
+    /// Check if ACK is active
+    pub fn is_ack_active(&self) -> bool {
+        self.document_sync.is_ack_active()
+    }
+
+    /// Get current event type
+    pub fn current_event(&self) -> Option<EventType> {
+        self.document_sync.current_event()
+    }
+
+    // ==================== BLE Callbacks (Platform -> Mesh) ====================
+
+    /// Called when a BLE device is discovered
+    ///
+    /// Returns `Some(HivePeer)` if this is a new HIVE peer on our mesh.
+    pub fn on_ble_discovered(
+        &self,
+        identifier: &str,
+        name: Option<&str>,
+        rssi: i8,
+        mesh_id: Option<&str>,
+        now_ms: u64,
+    ) -> Option<HivePeer> {
+        let (node_id, is_new) = self
+            .peer_manager
+            .on_discovered(identifier, name, rssi, mesh_id, now_ms)?;
+
+        let peer = self.peer_manager.get_peer(node_id)?;
+
+        if is_new {
+            self.notify(HiveEvent::PeerDiscovered { peer: peer.clone() });
+            self.notify_mesh_state_changed();
+        }
+
+        Some(peer)
+    }
+
+    /// Called when a BLE connection is established (outgoing)
+    ///
+    /// Returns the NodeId if this identifier is known.
+    pub fn on_ble_connected(&self, identifier: &str, now_ms: u64) -> Option<NodeId> {
+        let node_id = self.peer_manager.on_connected(identifier, now_ms)?;
+        self.notify(HiveEvent::PeerConnected { node_id });
+        self.notify_mesh_state_changed();
+        Some(node_id)
+    }
+
+    /// Called when a BLE connection is lost
+    pub fn on_ble_disconnected(
+        &self,
+        identifier: &str,
+        reason: DisconnectReason,
+    ) -> Option<NodeId> {
+        let (node_id, reason) = self.peer_manager.on_disconnected(identifier, reason)?;
+        self.notify(HiveEvent::PeerDisconnected { node_id, reason });
+        self.notify_mesh_state_changed();
+        Some(node_id)
+    }
+
+    /// Called when a remote device connects to us (incoming connection)
+    ///
+    /// Use this when we're acting as a peripheral and a central connects to us.
+    pub fn on_incoming_connection(&self, identifier: &str, node_id: NodeId, now_ms: u64) -> bool {
+        let is_new = self
+            .peer_manager
+            .on_incoming_connection(identifier, node_id, now_ms);
+
+        if is_new {
+            if let Some(peer) = self.peer_manager.get_peer(node_id) {
+                self.notify(HiveEvent::PeerDiscovered { peer });
+            }
+        }
+
+        self.notify(HiveEvent::PeerConnected { node_id });
+        self.notify_mesh_state_changed();
+
+        is_new
+    }
+
+    /// Called when data is received from a peer
+    ///
+    /// Parses the document, merges it, and generates appropriate events.
+    /// Returns the source NodeId and whether the document contained an event.
+    pub fn on_ble_data_received(
+        &self,
+        identifier: &str,
+        data: &[u8],
+        now_ms: u64,
+    ) -> Option<DataReceivedResult> {
+        // Get node ID from identifier
+        let node_id = self.peer_manager.get_node_id(identifier)?;
+
+        // Merge the document
+        let result = self.document_sync.merge_document(data)?;
+
+        // Record sync
+        self.peer_manager.record_sync(node_id, now_ms);
+
+        // Generate events based on what was received
+        if result.is_emergency() {
+            self.notify(HiveEvent::EmergencyReceived {
+                from_node: result.source_node,
+            });
+        } else if result.is_ack() {
+            self.notify(HiveEvent::AckReceived {
+                from_node: result.source_node,
+            });
+        }
+
+        if result.counter_changed {
+            self.notify(HiveEvent::DocumentSynced {
+                from_node: result.source_node,
+                total_count: result.total_count,
+            });
+        }
+
+        Some(DataReceivedResult {
+            source_node: result.source_node,
+            is_emergency: result.is_emergency(),
+            is_ack: result.is_ack(),
+            counter_changed: result.counter_changed,
+            total_count: result.total_count,
+        })
+    }
+
+    /// Called when data is received but we don't have the identifier mapped
+    ///
+    /// Use this when receiving data from a peripheral we discovered.
+    pub fn on_ble_data_received_from_node(
+        &self,
+        node_id: NodeId,
+        data: &[u8],
+        now_ms: u64,
+    ) -> Option<DataReceivedResult> {
+        // Merge the document
+        let result = self.document_sync.merge_document(data)?;
+
+        // Record sync
+        self.peer_manager.record_sync(node_id, now_ms);
+
+        // Generate events based on what was received
+        if result.is_emergency() {
+            self.notify(HiveEvent::EmergencyReceived {
+                from_node: result.source_node,
+            });
+        } else if result.is_ack() {
+            self.notify(HiveEvent::AckReceived {
+                from_node: result.source_node,
+            });
+        }
+
+        if result.counter_changed {
+            self.notify(HiveEvent::DocumentSynced {
+                from_node: result.source_node,
+                total_count: result.total_count,
+            });
+        }
+
+        Some(DataReceivedResult {
+            source_node: result.source_node,
+            is_emergency: result.is_emergency(),
+            is_ack: result.is_ack(),
+            counter_changed: result.counter_changed,
+            total_count: result.total_count,
+        })
+    }
+
+    // ==================== Periodic Maintenance ====================
+
+    /// Periodic tick - call this regularly (e.g., every second)
+    ///
+    /// Performs:
+    /// - Stale peer cleanup
+    /// - Periodic sync broadcast (if interval elapsed)
+    ///
+    /// Returns `Some(data)` if a sync broadcast is needed.
+    pub fn tick(&self, now_ms: u64) -> Option<Vec<u8>> {
+        use std::sync::atomic::Ordering;
+
+        // Cleanup stale peers
+        let last_cleanup = self.last_cleanup_ms.load(Ordering::Relaxed);
+        if now_ms.saturating_sub(last_cleanup) >= self.config.peer_config.cleanup_interval_ms {
+            self.last_cleanup_ms.store(now_ms, Ordering::Relaxed);
+            let removed = self.peer_manager.cleanup_stale(now_ms);
+            for node_id in &removed {
+                self.notify(HiveEvent::PeerLost { node_id: *node_id });
+            }
+            if !removed.is_empty() {
+                self.notify_mesh_state_changed();
+            }
+        }
+
+        // Check if sync broadcast is needed
+        let last_sync = self.last_sync_ms.load(Ordering::Relaxed);
+        if now_ms.saturating_sub(last_sync) >= self.config.sync_interval_ms {
+            self.last_sync_ms.store(now_ms, Ordering::Relaxed);
+            // Only broadcast if we have connected peers
+            if self.peer_manager.connected_count() > 0 {
+                return Some(self.document_sync.build_document());
+            }
+        }
+
+        None
+    }
+
+    // ==================== State Queries ====================
+
+    /// Get all known peers
+    pub fn get_peers(&self) -> Vec<HivePeer> {
+        self.peer_manager.get_peers()
+    }
+
+    /// Get connected peers only
+    pub fn get_connected_peers(&self) -> Vec<HivePeer> {
+        self.peer_manager.get_connected_peers()
+    }
+
+    /// Get a specific peer by NodeId
+    pub fn get_peer(&self, node_id: NodeId) -> Option<HivePeer> {
+        self.peer_manager.get_peer(node_id)
+    }
+
+    /// Get peer count
+    pub fn peer_count(&self) -> usize {
+        self.peer_manager.peer_count()
+    }
+
+    /// Get connected peer count
+    pub fn connected_count(&self) -> usize {
+        self.peer_manager.connected_count()
+    }
+
+    /// Get total counter value
+    pub fn total_count(&self) -> u64 {
+        self.document_sync.total_count()
+    }
+
+    /// Get document version
+    pub fn document_version(&self) -> u32 {
+        self.document_sync.version()
+    }
+
+    /// Build current document for transmission
+    pub fn build_document(&self) -> Vec<u8> {
+        self.document_sync.build_document()
+    }
+
+    /// Get peers that should be synced with
+    pub fn peers_needing_sync(&self, now_ms: u64) -> Vec<HivePeer> {
+        self.peer_manager.peers_needing_sync(now_ms)
+    }
+
+    // ==================== Internal Helpers ====================
+
+    fn notify(&self, event: HiveEvent) {
+        self.observers.notify(event);
+    }
+
+    fn notify_mesh_state_changed(&self) {
+        self.notify(HiveEvent::MeshStateChanged {
+            peer_count: self.peer_manager.peer_count(),
+            connected_count: self.peer_manager.connected_count(),
+        });
+    }
+}
+
+/// Result from receiving BLE data
+#[derive(Debug, Clone)]
+pub struct DataReceivedResult {
+    /// Node that sent this data
+    pub source_node: NodeId,
+
+    /// Whether this contained an emergency event
+    pub is_emergency: bool,
+
+    /// Whether this contained an ACK event
+    pub is_ack: bool,
+
+    /// Whether the counter changed (new data)
+    pub counter_changed: bool,
+
+    /// Updated total count
+    pub total_count: u64,
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use crate::observer::CollectingObserver;
+
+    fn create_mesh(node_id: u32, callsign: &str) -> HiveMesh {
+        let config = HiveMeshConfig::new(NodeId::new(node_id), callsign, "TEST");
+        HiveMesh::new(config)
+    }
+
+    #[test]
+    fn test_mesh_creation() {
+        let mesh = create_mesh(0x12345678, "ALPHA-1");
+
+        assert_eq!(mesh.node_id().as_u32(), 0x12345678);
+        assert_eq!(mesh.callsign(), "ALPHA-1");
+        assert_eq!(mesh.mesh_id(), "TEST");
+        assert_eq!(mesh.device_name(), "HIVE_TEST-12345678");
+    }
+
+    #[test]
+    fn test_peer_discovery() {
+        let mesh = create_mesh(0x11111111, "ALPHA-1");
+        let observer = Arc::new(CollectingObserver::new());
+        mesh.add_observer(observer.clone());
+
+        // Discover a peer
+        let peer = mesh.on_ble_discovered(
+            "device-uuid",
+            Some("HIVE_TEST-22222222"),
+            -65,
+            Some("TEST"),
+            1000,
+        );
+
+        assert!(peer.is_some());
+        let peer = peer.unwrap();
+        assert_eq!(peer.node_id.as_u32(), 0x22222222);
+
+        // Check events were generated
+        let events = observer.events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::PeerDiscovered { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::MeshStateChanged { .. })));
+    }
+
+    #[test]
+    fn test_connection_lifecycle() {
+        let mesh = create_mesh(0x11111111, "ALPHA-1");
+        let observer = Arc::new(CollectingObserver::new());
+        mesh.add_observer(observer.clone());
+
+        // Discover and connect
+        mesh.on_ble_discovered(
+            "device-uuid",
+            Some("HIVE_TEST-22222222"),
+            -65,
+            Some("TEST"),
+            1000,
+        );
+
+        let node_id = mesh.on_ble_connected("device-uuid", 2000);
+        assert_eq!(node_id, Some(NodeId::new(0x22222222)));
+        assert_eq!(mesh.connected_count(), 1);
+
+        // Disconnect
+        let node_id = mesh.on_ble_disconnected("device-uuid", DisconnectReason::RemoteRequest);
+        assert_eq!(node_id, Some(NodeId::new(0x22222222)));
+        assert_eq!(mesh.connected_count(), 0);
+
+        // Check events
+        let events = observer.events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::PeerConnected { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::PeerDisconnected { .. })));
+    }
+
+    #[test]
+    fn test_emergency_flow() {
+        let mesh1 = create_mesh(0x11111111, "ALPHA-1");
+        let mesh2 = create_mesh(0x22222222, "BRAVO-1");
+
+        let observer2 = Arc::new(CollectingObserver::new());
+        mesh2.add_observer(observer2.clone());
+
+        // mesh1 sends emergency
+        let doc = mesh1.send_emergency(1000);
+        assert!(mesh1.is_emergency_active());
+
+        // mesh2 receives it
+        let result = mesh2.on_ble_data_received_from_node(NodeId::new(0x11111111), &doc, 1000);
+
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.is_emergency);
+        assert_eq!(result.source_node.as_u32(), 0x11111111);
+
+        // Check events on mesh2
+        let events = observer2.events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::EmergencyReceived { .. })));
+    }
+
+    #[test]
+    fn test_ack_flow() {
+        let mesh1 = create_mesh(0x11111111, "ALPHA-1");
+        let mesh2 = create_mesh(0x22222222, "BRAVO-1");
+
+        let observer2 = Arc::new(CollectingObserver::new());
+        mesh2.add_observer(observer2.clone());
+
+        // mesh1 sends ACK
+        let doc = mesh1.send_ack(1000);
+        assert!(mesh1.is_ack_active());
+
+        // mesh2 receives it
+        let result = mesh2.on_ble_data_received_from_node(NodeId::new(0x11111111), &doc, 1000);
+
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert!(result.is_ack);
+
+        // Check events on mesh2
+        let events = observer2.events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::AckReceived { .. })));
+    }
+
+    #[test]
+    fn test_tick_cleanup() {
+        let config = HiveMeshConfig::new(NodeId::new(0x11111111), "ALPHA-1", "TEST")
+            .with_peer_timeout(10_000);
+        let mesh = HiveMesh::new(config);
+
+        let observer = Arc::new(CollectingObserver::new());
+        mesh.add_observer(observer.clone());
+
+        // Discover a peer
+        mesh.on_ble_discovered(
+            "device-uuid",
+            Some("HIVE_TEST-22222222"),
+            -65,
+            Some("TEST"),
+            1000,
+        );
+        assert_eq!(mesh.peer_count(), 1);
+
+        // Tick at t=5000 - not stale yet
+        mesh.tick(5000);
+        assert_eq!(mesh.peer_count(), 1);
+
+        // Tick at t=20000 - peer is stale (10s timeout exceeded)
+        mesh.tick(20000);
+        assert_eq!(mesh.peer_count(), 0);
+
+        // Check PeerLost event
+        let events = observer.events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::PeerLost { .. })));
+    }
+
+    #[test]
+    fn test_tick_sync_broadcast() {
+        let config = HiveMeshConfig::new(NodeId::new(0x11111111), "ALPHA-1", "TEST")
+            .with_sync_interval(5000);
+        let mesh = HiveMesh::new(config);
+
+        // Discover and connect a peer first
+        mesh.on_ble_discovered(
+            "device-uuid",
+            Some("HIVE_TEST-22222222"),
+            -65,
+            Some("TEST"),
+            1000,
+        );
+        mesh.on_ble_connected("device-uuid", 1000);
+
+        // First tick at t=0 sets last_sync
+        let _result = mesh.tick(0);
+        // May or may not broadcast depending on initial state
+
+        // Tick before interval - no broadcast
+        let result = mesh.tick(3000);
+        assert!(result.is_none());
+
+        // After interval - should broadcast
+        let result = mesh.tick(6000);
+        assert!(result.is_some());
+
+        // Immediate second tick - no broadcast (interval not elapsed)
+        let result = mesh.tick(6100);
+        assert!(result.is_none());
+
+        // After another interval - should broadcast again
+        let result = mesh.tick(12000);
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_incoming_connection() {
+        let mesh = create_mesh(0x11111111, "ALPHA-1");
+        let observer = Arc::new(CollectingObserver::new());
+        mesh.add_observer(observer.clone());
+
+        // Incoming connection from unknown peer
+        let is_new = mesh.on_incoming_connection("central-uuid", NodeId::new(0x22222222), 1000);
+
+        assert!(is_new);
+        assert_eq!(mesh.peer_count(), 1);
+        assert_eq!(mesh.connected_count(), 1);
+
+        // Check events
+        let events = observer.events();
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::PeerDiscovered { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, HiveEvent::PeerConnected { .. })));
+    }
+
+    #[test]
+    fn test_mesh_filtering() {
+        let mesh = create_mesh(0x11111111, "ALPHA-1");
+
+        // Wrong mesh - ignored
+        let peer = mesh.on_ble_discovered(
+            "device-uuid-1",
+            Some("HIVE_OTHER-22222222"),
+            -65,
+            Some("OTHER"),
+            1000,
+        );
+        assert!(peer.is_none());
+        assert_eq!(mesh.peer_count(), 0);
+
+        // Correct mesh - accepted
+        let peer = mesh.on_ble_discovered(
+            "device-uuid-2",
+            Some("HIVE_TEST-33333333"),
+            -65,
+            Some("TEST"),
+            1000,
+        );
+        assert!(peer.is_some());
+        assert_eq!(mesh.peer_count(), 1);
+    }
+}

--- a/hive-btle/src/lib.rs
+++ b/hive-btle/src/lib.rs
@@ -89,9 +89,15 @@ extern crate alloc;
 
 pub mod config;
 pub mod discovery;
+pub mod document;
+pub mod document_sync;
 pub mod error;
 pub mod gatt;
+pub mod hive_mesh;
 pub mod mesh;
+pub mod observer;
+pub mod peer;
+pub mod peer_manager;
 pub mod phy;
 pub mod platform;
 pub mod power;
@@ -117,6 +123,17 @@ pub use platform::{BleAdapter, ConnectionEvent, DisconnectReason, DiscoveredDevi
 pub use power::{BatteryState, RadioScheduler, SyncPriority};
 pub use sync::{GattSyncProtocol, SyncConfig, SyncState};
 pub use transport::{BleConnection, BluetoothLETransport, MeshTransport, TransportCapabilities};
+
+// New centralized mesh management types
+pub use document::{HiveDocument, MergeResult, EXTENDED_MARKER};
+pub use document_sync::{DocumentCheck, DocumentSync};
+#[cfg(feature = "std")]
+pub use hive_mesh::{DataReceivedResult, HiveMesh, HiveMeshConfig};
+#[cfg(feature = "std")]
+pub use observer::{CollectingObserver, ObserverManager};
+pub use observer::{DisconnectReason as HiveDisconnectReason, HiveEvent, HiveObserver};
+pub use peer::{HivePeer, PeerManagerConfig, SignalStrength};
+pub use peer_manager::PeerManager;
 
 /// HIVE BLE Service UUID (128-bit)
 ///
@@ -151,7 +168,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 ///
 /// Represents a unique node in the HIVE mesh. For BLE, this is typically
 /// derived from the Bluetooth MAC address or a configured value.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 pub struct NodeId {
     /// 32-bit node identifier
     id: u32,

--- a/hive-btle/src/observer.rs
+++ b/hive-btle/src/observer.rs
@@ -1,0 +1,339 @@
+//! Observer pattern for HIVE mesh events
+//!
+//! This module provides the event types and observer trait for receiving
+//! notifications about mesh state changes. Platform implementations register
+//! observers to receive callbacks when peers are discovered, connected,
+//! disconnected, or when documents are synced.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_btle::observer::{HiveEvent, HiveObserver};
+//!
+//! struct MyObserver;
+//!
+//! impl HiveObserver for MyObserver {
+//!     fn on_event(&self, event: HiveEvent) {
+//!         match event {
+//!             HiveEvent::PeerDiscovered { peer } => {
+//!                 println!("Discovered: {}", peer.display_name());
+//!             }
+//!             HiveEvent::EmergencyReceived { from_node } => {
+//!                 println!("EMERGENCY from {:08X}", from_node.as_u32());
+//!             }
+//!             _ => {}
+//!         }
+//!     }
+//! }
+//! ```
+
+#[cfg(not(feature = "std"))]
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+#[cfg(feature = "std")]
+use std::sync::Arc;
+
+use crate::peer::HivePeer;
+use crate::sync::crdt::EventType;
+use crate::NodeId;
+
+/// Events emitted by the HIVE mesh
+///
+/// These events notify observers about changes in mesh state, peer lifecycle,
+/// and document synchronization.
+#[derive(Debug, Clone)]
+pub enum HiveEvent {
+    // ==================== Peer Lifecycle Events ====================
+    /// A new peer was discovered via BLE scanning
+    PeerDiscovered {
+        /// The discovered peer
+        peer: HivePeer,
+    },
+
+    /// A peer connected to us (either direction)
+    PeerConnected {
+        /// Node ID of the connected peer
+        node_id: NodeId,
+    },
+
+    /// A peer disconnected
+    PeerDisconnected {
+        /// Node ID of the disconnected peer
+        node_id: NodeId,
+        /// Reason for disconnection
+        reason: DisconnectReason,
+    },
+
+    /// A peer was removed due to timeout (stale)
+    PeerLost {
+        /// Node ID of the lost peer
+        node_id: NodeId,
+    },
+
+    // ==================== Mesh Events ====================
+    /// An emergency event was received from a peer
+    EmergencyReceived {
+        /// Node ID that sent the emergency
+        from_node: NodeId,
+    },
+
+    /// An ACK event was received from a peer
+    AckReceived {
+        /// Node ID that sent the ACK
+        from_node: NodeId,
+    },
+
+    /// A generic event was received from a peer
+    EventReceived {
+        /// Node ID that sent the event
+        from_node: NodeId,
+        /// Type of event
+        event_type: EventType,
+    },
+
+    /// A document was synced with a peer
+    DocumentSynced {
+        /// Node ID that we synced with
+        from_node: NodeId,
+        /// Updated total counter value
+        total_count: u64,
+    },
+
+    // ==================== Mesh State Events ====================
+    /// Mesh state changed (peer count, connected count)
+    MeshStateChanged {
+        /// Total number of known peers
+        peer_count: usize,
+        /// Number of connected peers
+        connected_count: usize,
+    },
+
+    /// All peers have acknowledged an emergency
+    AllPeersAcked {
+        /// Number of peers that acknowledged
+        ack_count: usize,
+    },
+}
+
+impl HiveEvent {
+    /// Create a peer discovered event
+    pub fn peer_discovered(peer: HivePeer) -> Self {
+        Self::PeerDiscovered { peer }
+    }
+
+    /// Create a peer connected event
+    pub fn peer_connected(node_id: NodeId) -> Self {
+        Self::PeerConnected { node_id }
+    }
+
+    /// Create a peer disconnected event
+    pub fn peer_disconnected(node_id: NodeId, reason: DisconnectReason) -> Self {
+        Self::PeerDisconnected { node_id, reason }
+    }
+
+    /// Create a peer lost event (timeout)
+    pub fn peer_lost(node_id: NodeId) -> Self {
+        Self::PeerLost { node_id }
+    }
+
+    /// Create an emergency received event
+    pub fn emergency_received(from_node: NodeId) -> Self {
+        Self::EmergencyReceived { from_node }
+    }
+
+    /// Create an ACK received event
+    pub fn ack_received(from_node: NodeId) -> Self {
+        Self::AckReceived { from_node }
+    }
+
+    /// Create a generic event received
+    pub fn event_received(from_node: NodeId, event_type: EventType) -> Self {
+        Self::EventReceived {
+            from_node,
+            event_type,
+        }
+    }
+
+    /// Create a document synced event
+    pub fn document_synced(from_node: NodeId, total_count: u64) -> Self {
+        Self::DocumentSynced {
+            from_node,
+            total_count,
+        }
+    }
+}
+
+/// Reason for peer disconnection
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DisconnectReason {
+    /// Local initiated disconnect
+    LocalRequest,
+    /// Remote peer initiated disconnect
+    RemoteRequest,
+    /// Connection timed out
+    Timeout,
+    /// BLE link lost
+    LinkLoss,
+    /// Connection failed
+    ConnectionFailed,
+    /// Unknown reason
+    #[default]
+    Unknown,
+}
+
+/// Observer trait for receiving HIVE mesh events
+///
+/// Implement this trait to receive callbacks when mesh events occur.
+/// Observers must be thread-safe (Send + Sync) as they may be called
+/// from any thread.
+///
+/// ## Platform Notes
+///
+/// - **iOS/macOS**: Wrap in a Swift class that conforms to this protocol via UniFFI
+/// - **Android**: Implement via JNI callback interface
+/// - **ESP32**: Use direct Rust implementation with static callbacks
+pub trait HiveObserver: Send + Sync {
+    /// Called when a mesh event occurs
+    ///
+    /// This method should return quickly to avoid blocking the mesh.
+    /// If heavy processing is needed, dispatch to another thread.
+    fn on_event(&self, event: HiveEvent);
+}
+
+/// A simple observer that collects events into a vector (useful for testing)
+#[cfg(feature = "std")]
+#[derive(Debug, Default)]
+pub struct CollectingObserver {
+    events: std::sync::Mutex<Vec<HiveEvent>>,
+}
+
+#[cfg(feature = "std")]
+impl CollectingObserver {
+    /// Create a new collecting observer
+    pub fn new() -> Self {
+        Self {
+            events: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Get all collected events
+    pub fn events(&self) -> Vec<HiveEvent> {
+        self.events.lock().unwrap().clone()
+    }
+
+    /// Clear collected events
+    pub fn clear(&self) {
+        self.events.lock().unwrap().clear();
+    }
+
+    /// Get count of collected events
+    pub fn count(&self) -> usize {
+        self.events.lock().unwrap().len()
+    }
+}
+
+#[cfg(feature = "std")]
+impl HiveObserver for CollectingObserver {
+    fn on_event(&self, event: HiveEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+}
+
+/// Helper to manage multiple observers
+#[cfg(feature = "std")]
+pub struct ObserverManager {
+    observers: std::sync::RwLock<Vec<Arc<dyn HiveObserver>>>,
+}
+
+#[cfg(feature = "std")]
+impl Default for ObserverManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "std")]
+impl ObserverManager {
+    /// Create a new observer manager
+    pub fn new() -> Self {
+        Self {
+            observers: std::sync::RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Add an observer
+    pub fn add(&self, observer: Arc<dyn HiveObserver>) {
+        self.observers.write().unwrap().push(observer);
+    }
+
+    /// Remove an observer (by Arc pointer equality)
+    pub fn remove(&self, observer: &Arc<dyn HiveObserver>) {
+        self.observers
+            .write()
+            .unwrap()
+            .retain(|o| !Arc::ptr_eq(o, observer));
+    }
+
+    /// Notify all observers of an event
+    pub fn notify(&self, event: HiveEvent) {
+        let observers = self.observers.read().unwrap();
+        for observer in observers.iter() {
+            observer.on_event(event.clone());
+        }
+    }
+
+    /// Get the number of registered observers
+    pub fn count(&self) -> usize {
+        self.observers.read().unwrap().len()
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_collecting_observer() {
+        let observer = CollectingObserver::new();
+
+        observer.on_event(HiveEvent::peer_connected(NodeId::new(0x12345678)));
+        observer.on_event(HiveEvent::emergency_received(NodeId::new(0x87654321)));
+
+        assert_eq!(observer.count(), 2);
+
+        let events = observer.events();
+        assert!(matches!(events[0], HiveEvent::PeerConnected { .. }));
+        assert!(matches!(events[1], HiveEvent::EmergencyReceived { .. }));
+
+        observer.clear();
+        assert_eq!(observer.count(), 0);
+    }
+
+    #[test]
+    fn test_observer_manager() {
+        let manager = ObserverManager::new();
+
+        // Keep concrete references for count checks
+        let obs1_concrete = Arc::new(CollectingObserver::new());
+        let obs2_concrete = Arc::new(CollectingObserver::new());
+        let observer1: Arc<dyn HiveObserver> = obs1_concrete.clone();
+        let observer2: Arc<dyn HiveObserver> = obs2_concrete.clone();
+
+        manager.add(observer1.clone());
+        manager.add(observer2.clone());
+
+        assert_eq!(manager.count(), 2);
+
+        manager.notify(HiveEvent::peer_connected(NodeId::new(0x12345678)));
+
+        assert_eq!(obs1_concrete.count(), 1);
+        assert_eq!(obs2_concrete.count(), 1);
+
+        manager.remove(&observer1);
+        assert_eq!(manager.count(), 1);
+
+        manager.notify(HiveEvent::peer_lost(NodeId::new(0x12345678)));
+
+        assert_eq!(obs1_concrete.count(), 1); // Not notified
+        assert_eq!(obs2_concrete.count(), 2); // Got both events
+    }
+}

--- a/hive-btle/src/peer.rs
+++ b/hive-btle/src/peer.rs
@@ -1,0 +1,269 @@
+//! Peer management types for HIVE BLE mesh
+//!
+//! This module provides the core peer representation and configuration
+//! for centralized peer management across all platforms (iOS, Android, ESP32).
+
+#[cfg(not(feature = "std"))]
+use alloc::{string::String, vec::Vec};
+
+use crate::NodeId;
+
+/// Unified peer representation across all platforms
+///
+/// Represents a discovered or connected HIVE mesh peer with all
+/// relevant metadata for mesh operations.
+#[derive(Debug, Clone)]
+pub struct HivePeer {
+    /// HIVE node identifier (32-bit)
+    pub node_id: NodeId,
+
+    /// Platform-specific BLE identifier
+    /// - iOS: CBPeripheral UUID string
+    /// - Android: MAC address string
+    /// - ESP32: MAC address or NimBLE handle
+    pub identifier: String,
+
+    /// Mesh ID this peer belongs to (e.g., "DEMO")
+    pub mesh_id: Option<String>,
+
+    /// Advertised device name (e.g., "HIVE_DEMO-12345678")
+    pub name: Option<String>,
+
+    /// Last known signal strength (RSSI in dBm)
+    pub rssi: i8,
+
+    /// Whether we have an active BLE connection to this peer
+    pub is_connected: bool,
+
+    /// Timestamp when this peer was last seen (milliseconds since epoch/boot)
+    pub last_seen_ms: u64,
+}
+
+impl HivePeer {
+    /// Create a new peer from discovery data
+    pub fn new(
+        node_id: NodeId,
+        identifier: String,
+        mesh_id: Option<String>,
+        name: Option<String>,
+        rssi: i8,
+    ) -> Self {
+        Self {
+            node_id,
+            identifier,
+            mesh_id,
+            name,
+            rssi,
+            is_connected: false,
+            last_seen_ms: 0,
+        }
+    }
+
+    /// Update the peer's last seen timestamp
+    pub fn touch(&mut self, now_ms: u64) {
+        self.last_seen_ms = now_ms;
+    }
+
+    /// Check if this peer is stale (not seen within timeout)
+    pub fn is_stale(&self, now_ms: u64, timeout_ms: u64) -> bool {
+        if self.last_seen_ms == 0 {
+            return false; // Never seen, don't consider stale
+        }
+        now_ms.saturating_sub(self.last_seen_ms) > timeout_ms
+    }
+
+    /// Get display name for this peer
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(self.identifier.as_str())
+    }
+
+    /// Get signal strength category
+    pub fn signal_strength(&self) -> SignalStrength {
+        match self.rssi {
+            r if r >= -50 => SignalStrength::Excellent,
+            r if r >= -70 => SignalStrength::Good,
+            r if r >= -85 => SignalStrength::Fair,
+            _ => SignalStrength::Weak,
+        }
+    }
+}
+
+impl Default for HivePeer {
+    fn default() -> Self {
+        Self {
+            node_id: NodeId::default(),
+            identifier: String::new(),
+            mesh_id: None,
+            name: None,
+            rssi: -100,
+            is_connected: false,
+            last_seen_ms: 0,
+        }
+    }
+}
+
+/// Signal strength categories for display
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignalStrength {
+    /// RSSI >= -50 dBm
+    Excellent,
+    /// RSSI >= -70 dBm
+    Good,
+    /// RSSI >= -85 dBm
+    Fair,
+    /// RSSI < -85 dBm
+    Weak,
+}
+
+/// Configuration for the PeerManager
+///
+/// Provides configurable timeouts and behaviors for peer management.
+/// All time values are in milliseconds.
+#[derive(Debug, Clone)]
+pub struct PeerManagerConfig {
+    /// Time after which a peer is considered stale and removed (default: 45000ms)
+    pub peer_timeout_ms: u64,
+
+    /// How often to run cleanup of stale peers (default: 10000ms)
+    pub cleanup_interval_ms: u64,
+
+    /// How often to sync documents with peers (default: 5000ms)
+    pub sync_interval_ms: u64,
+
+    /// Minimum time between syncs to the same peer (default: 30000ms)
+    /// Prevents "thrashing" when peers keep reconnecting
+    pub sync_cooldown_ms: u64,
+
+    /// Whether to automatically connect to discovered peers (default: true)
+    pub auto_connect: bool,
+
+    /// Local mesh ID for filtering peers (e.g., "DEMO")
+    pub mesh_id: String,
+
+    /// Maximum number of tracked peers (for no_std/embedded, default: 8)
+    pub max_peers: usize,
+}
+
+impl Default for PeerManagerConfig {
+    fn default() -> Self {
+        Self {
+            peer_timeout_ms: 45_000,     // 45 seconds
+            cleanup_interval_ms: 10_000, // 10 seconds
+            sync_interval_ms: 5_000,     // 5 seconds
+            sync_cooldown_ms: 30_000,    // 30 seconds
+            auto_connect: true,
+            mesh_id: String::from("DEMO"),
+            max_peers: 8,
+        }
+    }
+}
+
+impl PeerManagerConfig {
+    /// Create a new config with the specified mesh ID
+    pub fn with_mesh_id(mesh_id: impl Into<String>) -> Self {
+        Self {
+            mesh_id: mesh_id.into(),
+            ..Default::default()
+        }
+    }
+
+    /// Set peer timeout
+    pub fn peer_timeout(mut self, timeout_ms: u64) -> Self {
+        self.peer_timeout_ms = timeout_ms;
+        self
+    }
+
+    /// Set sync interval
+    pub fn sync_interval(mut self, interval_ms: u64) -> Self {
+        self.sync_interval_ms = interval_ms;
+        self
+    }
+
+    /// Set auto-connect behavior
+    pub fn auto_connect(mut self, enabled: bool) -> Self {
+        self.auto_connect = enabled;
+        self
+    }
+
+    /// Set max peers (for embedded systems)
+    pub fn max_peers(mut self, max: usize) -> Self {
+        self.max_peers = max;
+        self
+    }
+
+    /// Check if a device mesh ID matches our mesh
+    ///
+    /// Returns true if:
+    /// - Device mesh ID matches our mesh ID exactly, OR
+    /// - Device mesh ID is None (legacy device, matches any mesh)
+    pub fn matches_mesh(&self, device_mesh_id: Option<&str>) -> bool {
+        match device_mesh_id {
+            Some(id) => id == self.mesh_id,
+            None => true, // Legacy devices match any mesh
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_peer_stale_detection() {
+        let mut peer = HivePeer::new(
+            NodeId::new(0x12345678),
+            "test-id".into(),
+            Some("DEMO".into()),
+            Some("HIVE_DEMO-12345678".into()),
+            -70,
+        );
+
+        // Fresh peer is not stale
+        peer.touch(1000);
+        assert!(!peer.is_stale(2000, 45_000));
+
+        // Peer becomes stale after timeout
+        assert!(peer.is_stale(50_000, 45_000));
+    }
+
+    #[test]
+    fn test_signal_strength() {
+        let peer_excellent = HivePeer {
+            rssi: -45,
+            ..Default::default()
+        };
+        assert_eq!(peer_excellent.signal_strength(), SignalStrength::Excellent);
+
+        let peer_good = HivePeer {
+            rssi: -65,
+            ..Default::default()
+        };
+        assert_eq!(peer_good.signal_strength(), SignalStrength::Good);
+
+        let peer_fair = HivePeer {
+            rssi: -80,
+            ..Default::default()
+        };
+        assert_eq!(peer_fair.signal_strength(), SignalStrength::Fair);
+
+        let peer_weak = HivePeer {
+            rssi: -95,
+            ..Default::default()
+        };
+        assert_eq!(peer_weak.signal_strength(), SignalStrength::Weak);
+    }
+
+    #[test]
+    fn test_mesh_matching() {
+        let config = PeerManagerConfig::with_mesh_id("ALPHA");
+
+        // Exact match
+        assert!(config.matches_mesh(Some("ALPHA")));
+
+        // No match
+        assert!(!config.matches_mesh(Some("BETA")));
+
+        // Legacy device (no mesh ID) matches any
+        assert!(config.matches_mesh(None));
+    }
+}

--- a/hive-btle/src/peer_manager.rs
+++ b/hive-btle/src/peer_manager.rs
@@ -1,0 +1,622 @@
+//! Peer management for HIVE BLE mesh
+//!
+//! This module provides centralized peer tracking, connection management,
+//! and sync scheduling. It replaces the duplicated peer management logic
+//! that was previously in iOS, Android, and ESP32 implementations.
+//!
+//! ## Usage
+//!
+//! ```ignore
+//! use hive_btle::peer_manager::PeerManager;
+//! use hive_btle::peer::PeerManagerConfig;
+//! use hive_btle::NodeId;
+//!
+//! let config = PeerManagerConfig::with_mesh_id("DEMO");
+//! let manager = PeerManager::new(NodeId::new(0x12345678), config);
+//!
+//! // Called by platform BLE adapter on discovery
+//! if let Some(node_id) = manager.on_discovered("device-uuid", Some("HIVE_DEMO-AABBCCDD"), -70, Some("DEMO")) {
+//!     println!("Discovered peer: {:08X}", node_id.as_u32());
+//! }
+//! ```
+
+#[cfg(not(feature = "std"))]
+use alloc::{
+    collections::BTreeMap,
+    string::{String, ToString},
+    vec::Vec,
+};
+#[cfg(feature = "std")]
+use std::collections::BTreeMap;
+#[cfg(feature = "std")]
+use std::sync::RwLock;
+
+#[cfg(not(feature = "std"))]
+use spin::RwLock;
+
+use crate::observer::{DisconnectReason, HiveEvent};
+use crate::peer::{HivePeer, PeerManagerConfig};
+use crate::NodeId;
+
+/// Centralized peer manager for HIVE mesh
+///
+/// Tracks discovered peers, their connection state, and sync history.
+/// Thread-safe and designed for use from platform BLE callbacks.
+pub struct PeerManager {
+    /// Configuration
+    config: PeerManagerConfig,
+
+    /// Our node ID
+    node_id: NodeId,
+
+    /// Peers indexed by NodeId
+    #[cfg(feature = "std")]
+    peers: RwLock<BTreeMap<NodeId, HivePeer>>,
+    #[cfg(not(feature = "std"))]
+    peers: RwLock<BTreeMap<NodeId, HivePeer>>,
+
+    /// Map from platform identifier to NodeId for quick lookup
+    #[cfg(feature = "std")]
+    identifier_map: RwLock<BTreeMap<String, NodeId>>,
+    #[cfg(not(feature = "std"))]
+    identifier_map: RwLock<BTreeMap<String, NodeId>>,
+
+    /// Last sync timestamp per peer (for cooldown)
+    #[cfg(feature = "std")]
+    sync_history: RwLock<BTreeMap<NodeId, u64>>,
+    #[cfg(not(feature = "std"))]
+    sync_history: RwLock<BTreeMap<NodeId, u64>>,
+}
+
+impl PeerManager {
+    /// Create a new peer manager
+    pub fn new(node_id: NodeId, config: PeerManagerConfig) -> Self {
+        Self {
+            config,
+            node_id,
+            peers: RwLock::new(BTreeMap::new()),
+            identifier_map: RwLock::new(BTreeMap::new()),
+            sync_history: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    /// Get our node ID
+    pub fn node_id(&self) -> NodeId {
+        self.node_id
+    }
+
+    /// Get the mesh ID
+    pub fn mesh_id(&self) -> &str {
+        &self.config.mesh_id
+    }
+
+    /// Check if a device mesh ID matches our mesh
+    pub fn matches_mesh(&self, device_mesh_id: Option<&str>) -> bool {
+        self.config.matches_mesh(device_mesh_id)
+    }
+
+    /// Handle a discovered BLE device
+    ///
+    /// Called by the platform BLE adapter when a device is discovered during scanning.
+    /// Parses the device name to extract NodeId and mesh ID.
+    ///
+    /// Returns `Some((node_id, is_new))` if this is a HIVE device on our mesh,
+    /// where `is_new` indicates if this is a newly discovered peer.
+    /// Returns `None` if the device should be ignored.
+    pub fn on_discovered(
+        &self,
+        identifier: &str,
+        name: Option<&str>,
+        rssi: i8,
+        mesh_id: Option<&str>,
+        now_ms: u64,
+    ) -> Option<(NodeId, bool)> {
+        // Check mesh ID match
+        if !self.matches_mesh(mesh_id) {
+            return None;
+        }
+
+        // Parse node ID from name (format: "HIVE_MESH-XXXXXXXX")
+        let node_id = parse_node_id_from_name(name)?;
+
+        // Don't track ourselves
+        if node_id == self.node_id {
+            return None;
+        }
+
+        let mut peers = self.peers.write().unwrap();
+        let mut id_map = self.identifier_map.write().unwrap();
+
+        // Check if we already have this peer by identifier (different device, same node)
+        if let Some(&existing_node_id) = id_map.get(identifier) {
+            if existing_node_id != node_id {
+                // Identifier changed node IDs - remove old mapping
+                peers.remove(&existing_node_id);
+            }
+        }
+
+        // Check max peers limit
+        if peers.len() >= self.config.max_peers && !peers.contains_key(&node_id) {
+            return None; // At capacity
+        }
+
+        let is_new = !peers.contains_key(&node_id);
+
+        // Update or insert peer
+        let peer = peers.entry(node_id).or_insert_with(|| {
+            HivePeer::new(
+                node_id,
+                identifier.to_string(),
+                mesh_id.map(|s| s.to_string()),
+                name.map(|s| s.to_string()),
+                rssi,
+            )
+        });
+
+        // Update existing peer
+        peer.rssi = rssi;
+        peer.touch(now_ms);
+        if let Some(n) = name {
+            peer.name = Some(n.to_string());
+        }
+
+        // Update identifier map
+        id_map.insert(identifier.to_string(), node_id);
+
+        Some((node_id, is_new))
+    }
+
+    /// Handle a peer connection
+    ///
+    /// Called by the platform BLE adapter when a connection is established.
+    /// Returns the NodeId if found, or None if this identifier is unknown.
+    pub fn on_connected(&self, identifier: &str, now_ms: u64) -> Option<NodeId> {
+        let id_map = self.identifier_map.read().unwrap();
+        let node_id = id_map.get(identifier).copied()?;
+        drop(id_map);
+
+        let mut peers = self.peers.write().unwrap();
+        if let Some(peer) = peers.get_mut(&node_id) {
+            peer.is_connected = true;
+            peer.touch(now_ms);
+        }
+
+        Some(node_id)
+    }
+
+    /// Handle a peer disconnection
+    ///
+    /// Called by the platform BLE adapter when a connection is lost.
+    /// Returns the NodeId and disconnect reason if found.
+    pub fn on_disconnected(
+        &self,
+        identifier: &str,
+        reason: DisconnectReason,
+    ) -> Option<(NodeId, DisconnectReason)> {
+        let id_map = self.identifier_map.read().unwrap();
+        let node_id = id_map.get(identifier).copied()?;
+        drop(id_map);
+
+        let mut peers = self.peers.write().unwrap();
+        if let Some(peer) = peers.get_mut(&node_id) {
+            peer.is_connected = false;
+        }
+
+        Some((node_id, reason))
+    }
+
+    /// Register a peer from an incoming BLE connection
+    ///
+    /// Called when a remote device connects to us as a peripheral.
+    /// Creates a peer entry if one doesn't exist for this identifier.
+    pub fn on_incoming_connection(&self, identifier: &str, node_id: NodeId, now_ms: u64) -> bool {
+        // Don't track ourselves
+        if node_id == self.node_id {
+            return false;
+        }
+
+        let mut peers = self.peers.write().unwrap();
+        let mut id_map = self.identifier_map.write().unwrap();
+
+        // Check max peers limit
+        if peers.len() >= self.config.max_peers && !peers.contains_key(&node_id) {
+            return false;
+        }
+
+        let is_new = !peers.contains_key(&node_id);
+
+        let peer = peers.entry(node_id).or_insert_with(|| {
+            HivePeer::new(
+                node_id,
+                identifier.to_string(),
+                Some(self.config.mesh_id.clone()),
+                None,
+                -70, // Default RSSI for incoming connections
+            )
+        });
+
+        peer.is_connected = true;
+        peer.touch(now_ms);
+
+        // Update identifier if changed
+        if peer.identifier != identifier {
+            id_map.remove(&peer.identifier);
+            peer.identifier = identifier.to_string();
+        }
+        id_map.insert(identifier.to_string(), node_id);
+
+        is_new
+    }
+
+    /// Check if we should sync with a peer
+    ///
+    /// Returns true if enough time has passed since the last sync (cooldown).
+    pub fn should_sync_with(&self, node_id: NodeId, now_ms: u64) -> bool {
+        let history = self.sync_history.read().unwrap();
+        match history.get(&node_id) {
+            Some(&last_sync) => now_ms.saturating_sub(last_sync) >= self.config.sync_cooldown_ms,
+            None => true, // Never synced
+        }
+    }
+
+    /// Record that we synced with a peer
+    pub fn record_sync(&self, node_id: NodeId, now_ms: u64) {
+        let mut history = self.sync_history.write().unwrap();
+        history.insert(node_id, now_ms);
+    }
+
+    /// Clean up stale peers
+    ///
+    /// Removes peers that haven't been seen within the timeout period.
+    /// Returns list of removed NodeIds for generating PeerLost events.
+    pub fn cleanup_stale(&self, now_ms: u64) -> Vec<NodeId> {
+        let mut peers = self.peers.write().unwrap();
+        let mut id_map = self.identifier_map.write().unwrap();
+        let mut history = self.sync_history.write().unwrap();
+
+        let mut removed = Vec::new();
+
+        // Find stale peers
+        let stale: Vec<NodeId> = peers
+            .iter()
+            .filter(|(_, peer)| peer.is_stale(now_ms, self.config.peer_timeout_ms))
+            .map(|(&node_id, _)| node_id)
+            .collect();
+
+        // Remove them
+        for node_id in stale {
+            if let Some(peer) = peers.remove(&node_id) {
+                id_map.remove(&peer.identifier);
+                history.remove(&node_id);
+                removed.push(node_id);
+            }
+        }
+
+        removed
+    }
+
+    /// Get all known peers
+    pub fn get_peers(&self) -> Vec<HivePeer> {
+        let peers = self.peers.read().unwrap();
+        peers.values().cloned().collect()
+    }
+
+    /// Get connected peers only
+    pub fn get_connected_peers(&self) -> Vec<HivePeer> {
+        let peers = self.peers.read().unwrap();
+        peers.values().filter(|p| p.is_connected).cloned().collect()
+    }
+
+    /// Get a specific peer by NodeId
+    pub fn get_peer(&self, node_id: NodeId) -> Option<HivePeer> {
+        let peers = self.peers.read().unwrap();
+        peers.get(&node_id).cloned()
+    }
+
+    /// Get a peer by platform identifier
+    pub fn get_peer_by_identifier(&self, identifier: &str) -> Option<HivePeer> {
+        let id_map = self.identifier_map.read().unwrap();
+        let node_id = id_map.get(identifier).copied()?;
+        drop(id_map);
+
+        let peers = self.peers.read().unwrap();
+        peers.get(&node_id).cloned()
+    }
+
+    /// Get NodeId for a platform identifier
+    pub fn get_node_id(&self, identifier: &str) -> Option<NodeId> {
+        let id_map = self.identifier_map.read().unwrap();
+        id_map.get(identifier).copied()
+    }
+
+    /// Get peer count
+    pub fn peer_count(&self) -> usize {
+        self.peers.read().unwrap().len()
+    }
+
+    /// Get connected peer count
+    pub fn connected_count(&self) -> usize {
+        self.peers
+            .read()
+            .unwrap()
+            .values()
+            .filter(|p| p.is_connected)
+            .count()
+    }
+
+    /// Get peers that need sync (connected and past cooldown)
+    pub fn peers_needing_sync(&self, now_ms: u64) -> Vec<HivePeer> {
+        let peers = self.peers.read().unwrap();
+        let history = self.sync_history.read().unwrap();
+
+        peers
+            .values()
+            .filter(|peer| {
+                if !peer.is_connected {
+                    return false;
+                }
+                match history.get(&peer.node_id) {
+                    Some(&last_sync) => {
+                        now_ms.saturating_sub(last_sync) >= self.config.sync_cooldown_ms
+                    }
+                    None => true,
+                }
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Generate events for current mesh state
+    ///
+    /// Useful for notifying observers of the current state after initialization.
+    pub fn generate_state_event(&self) -> HiveEvent {
+        HiveEvent::MeshStateChanged {
+            peer_count: self.peer_count(),
+            connected_count: self.connected_count(),
+        }
+    }
+}
+
+/// Parse a NodeId from a HIVE device name
+///
+/// Expected format: "HIVE_MESH-XXXXXXXX" where XXXXXXXX is the hex node ID
+fn parse_node_id_from_name(name: Option<&str>) -> Option<NodeId> {
+    let name = name?;
+
+    // Find the last hyphen and parse hex after it
+    let hyphen_pos = name.rfind('-')?;
+    let hex_part = &name[hyphen_pos + 1..];
+
+    // Parse as hex (should be 8 characters)
+    if hex_part.len() != 8 {
+        return None;
+    }
+
+    u32::from_str_radix(hex_part, 16).ok().map(NodeId::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_node_id_from_name() {
+        assert_eq!(
+            parse_node_id_from_name(Some("HIVE_DEMO-12345678")),
+            Some(NodeId::new(0x12345678))
+        );
+        assert_eq!(
+            parse_node_id_from_name(Some("HIVE_ALPHA-AABBCCDD")),
+            Some(NodeId::new(0xAABBCCDD))
+        );
+        assert_eq!(parse_node_id_from_name(Some("Invalid")), None);
+        assert_eq!(parse_node_id_from_name(Some("HIVE_DEMO-123")), None); // Too short
+        assert_eq!(parse_node_id_from_name(None), None);
+    }
+
+    #[test]
+    fn test_peer_discovery() {
+        let config = PeerManagerConfig::with_mesh_id("DEMO");
+        let manager = PeerManager::new(NodeId::new(0x11111111), config);
+
+        // Discover a peer
+        let result = manager.on_discovered(
+            "device-uuid-1",
+            Some("HIVE_DEMO-22222222"),
+            -65,
+            Some("DEMO"),
+            1000,
+        );
+        assert!(result.is_some());
+        let (node_id, is_new) = result.unwrap();
+        assert_eq!(node_id.as_u32(), 0x22222222);
+        assert!(is_new);
+
+        // Same peer again - not new
+        let result = manager.on_discovered(
+            "device-uuid-1",
+            Some("HIVE_DEMO-22222222"),
+            -60,
+            Some("DEMO"),
+            2000,
+        );
+        assert!(result.is_some());
+        let (_, is_new) = result.unwrap();
+        assert!(!is_new);
+
+        // Check peer is tracked
+        assert_eq!(manager.peer_count(), 1);
+        let peer = manager.get_peer(NodeId::new(0x22222222)).unwrap();
+        assert_eq!(peer.rssi, -60); // Updated
+    }
+
+    #[test]
+    fn test_mesh_filtering() {
+        let config = PeerManagerConfig::with_mesh_id("ALPHA");
+        let manager = PeerManager::new(NodeId::new(0x11111111), config);
+
+        // Wrong mesh - ignored
+        let result = manager.on_discovered(
+            "device-uuid-1",
+            Some("HIVE_BETA-22222222"),
+            -65,
+            Some("BETA"),
+            1000,
+        );
+        assert!(result.is_none());
+        assert_eq!(manager.peer_count(), 0);
+
+        // Correct mesh - accepted
+        let result = manager.on_discovered(
+            "device-uuid-2",
+            Some("HIVE_ALPHA-33333333"),
+            -65,
+            Some("ALPHA"),
+            1000,
+        );
+        assert!(result.is_some());
+        assert_eq!(manager.peer_count(), 1);
+    }
+
+    #[test]
+    fn test_self_filtering() {
+        let config = PeerManagerConfig::with_mesh_id("DEMO");
+        let manager = PeerManager::new(NodeId::new(0x12345678), config);
+
+        // Discovering ourselves - ignored
+        let result = manager.on_discovered(
+            "my-device-uuid",
+            Some("HIVE_DEMO-12345678"),
+            -30,
+            Some("DEMO"),
+            1000,
+        );
+        assert!(result.is_none());
+        assert_eq!(manager.peer_count(), 0);
+    }
+
+    #[test]
+    fn test_connection_lifecycle() {
+        let config = PeerManagerConfig::with_mesh_id("DEMO");
+        let manager = PeerManager::new(NodeId::new(0x11111111), config);
+
+        // Discover
+        manager.on_discovered(
+            "device-uuid-1",
+            Some("HIVE_DEMO-22222222"),
+            -65,
+            Some("DEMO"),
+            1000,
+        );
+        assert_eq!(manager.connected_count(), 0);
+
+        // Connect
+        let node_id = manager.on_connected("device-uuid-1", 2000);
+        assert_eq!(node_id, Some(NodeId::new(0x22222222)));
+        assert_eq!(manager.connected_count(), 1);
+
+        // Disconnect
+        let result = manager.on_disconnected("device-uuid-1", DisconnectReason::RemoteRequest);
+        assert!(result.is_some());
+        assert_eq!(manager.connected_count(), 0);
+        assert_eq!(manager.peer_count(), 1); // Still tracked
+    }
+
+    #[test]
+    fn test_stale_cleanup() {
+        let config = PeerManagerConfig::with_mesh_id("DEMO").peer_timeout(10_000);
+        let manager = PeerManager::new(NodeId::new(0x11111111), config);
+
+        // Discover at t=1000
+        manager.on_discovered(
+            "device-uuid-1",
+            Some("HIVE_DEMO-22222222"),
+            -65,
+            Some("DEMO"),
+            1000,
+        );
+        assert_eq!(manager.peer_count(), 1);
+
+        // Not stale at t=5000
+        let removed = manager.cleanup_stale(5000);
+        assert!(removed.is_empty());
+        assert_eq!(manager.peer_count(), 1);
+
+        // Stale at t=20000 (10s timeout exceeded)
+        let removed = manager.cleanup_stale(20000);
+        assert_eq!(removed.len(), 1);
+        assert_eq!(removed[0].as_u32(), 0x22222222);
+        assert_eq!(manager.peer_count(), 0);
+    }
+
+    #[test]
+    fn test_sync_cooldown() {
+        let config = PeerManagerConfig::with_mesh_id("DEMO");
+        let manager = PeerManager::new(NodeId::new(0x11111111), config);
+        let peer_id = NodeId::new(0x22222222);
+
+        // Never synced - should sync
+        assert!(manager.should_sync_with(peer_id, 1000));
+
+        // Record sync
+        manager.record_sync(peer_id, 1000);
+
+        // Too soon - shouldn't sync (cooldown is 30s)
+        assert!(!manager.should_sync_with(peer_id, 5000));
+
+        // After cooldown - should sync
+        assert!(manager.should_sync_with(peer_id, 35000));
+    }
+
+    #[test]
+    fn test_max_peers_limit() {
+        let config = PeerManagerConfig::with_mesh_id("DEMO").max_peers(2);
+        let manager = PeerManager::new(NodeId::new(0x11111111), config);
+
+        // First two accepted
+        let result = manager.on_discovered(
+            "uuid-1",
+            Some("HIVE_DEMO-22222222"),
+            -65,
+            Some("DEMO"),
+            1000,
+        );
+        assert!(result.is_some());
+
+        let result = manager.on_discovered(
+            "uuid-2",
+            Some("HIVE_DEMO-33333333"),
+            -65,
+            Some("DEMO"),
+            1000,
+        );
+        assert!(result.is_some());
+
+        // Third rejected - at capacity
+        let result = manager.on_discovered(
+            "uuid-3",
+            Some("HIVE_DEMO-44444444"),
+            -65,
+            Some("DEMO"),
+            1000,
+        );
+        assert!(result.is_none());
+        assert_eq!(manager.peer_count(), 2);
+    }
+
+    #[test]
+    fn test_incoming_connection() {
+        let config = PeerManagerConfig::with_mesh_id("DEMO");
+        let manager = PeerManager::new(NodeId::new(0x11111111), config);
+
+        // Incoming connection from unknown peer
+        let is_new = manager.on_incoming_connection("central-uuid", NodeId::new(0x22222222), 1000);
+        assert!(is_new);
+        assert_eq!(manager.peer_count(), 1);
+        assert_eq!(manager.connected_count(), 1);
+
+        // Same peer reconnects - not new
+        let is_new = manager.on_incoming_connection("central-uuid", NodeId::new(0x22222222), 2000);
+        assert!(!is_new);
+    }
+}


### PR DESCRIPTION
## Summary

- Add unified peer management infrastructure (`HivePeer`, `PeerManager`) to eliminate duplicate tracking logic across iOS/Android/ESP32
- Add document sync with lightweight CRDTs (`HiveDocument`, `DocumentSync`) for embedded-friendly wire format
- Add observer pattern (`HiveEvent`, `HiveObserver`) for platform-agnostic callbacks
- Add `HiveMesh` facade composing all components as single entry point
- Add ADR-041 documenting the gateway translation architecture for multi-transport integration

This PR implements Phases 1-5 of Issue #482. Key architectural decisions:
- **Gateway Translation Model**: Full HIVE nodes translate between Automerge and hive-btle's lightweight format
- **Schema Ownership**: HIVE repo owns schema, hive-btle provides embedded-friendly projection
- **no_std Compatible**: Uses `spin` crate for RwLock, `BTreeMap` instead of `HashMap`

## Files Changed

### New Files (7)
| File | Purpose |
|------|---------|
| `hive-btle/src/peer.rs` | `HivePeer`, `PeerManagerConfig`, `SignalStrength` |
| `hive-btle/src/document.rs` | `HiveDocument` wire format encode/decode |
| `hive-btle/src/observer.rs` | `HiveEvent`, `HiveObserver` trait, `ObserverManager` |
| `hive-btle/src/peer_manager.rs` | `PeerManager` for unified peer tracking |
| `hive-btle/src/document_sync.rs` | `DocumentSync` for CRDT state management |
| `hive-btle/src/hive_mesh.rs` | `HiveMesh` facade composing all components |
| `docs/adr/041-multi-transport-embedded-integration.md` | Architecture decision record |

### Modified Files (4)
| File | Changes |
|------|---------|
| `hive-btle/src/lib.rs` | Export new modules, add `Ord` to `NodeId` |
| `hive-btle/Cargo.toml` | Add `spin` dependency |
| `hive-btle/README.md` | Add integration guidance section |
| `Cargo.lock` | Updated dependencies |

## Test Plan

- [x] All 269 existing tests pass
- [x] New unit tests for `HivePeer`, `HiveDocument`, `PeerManager`, `DocumentSync`, `HiveMesh`
- [x] Clippy passes with no warnings
- [ ] Integration testing with iOS app (Phase 7)
- [ ] Integration testing with Android app (Phase 7)

## Follow-up Work

- **Phase 6**: Platform bindings (UniFFI for iOS, JNI for Android)
- **Phase 7**: Simplify iOS/Android/ESP32 implementations to use `HiveMesh`

Closes #482 (Phases 1-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)