### PR TITLE
feat(hive-btle): Add on_peer_disconnected API and peer connection tests

### DIFF
--- a/hive-btle/CHANGELOG.md
+++ b/hive-btle/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to hive-btle will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- ESP32 platform support with NimBLE integration
+- macOS platform support with CoreBluetooth
+- iOS platform support with CoreBluetooth
+- EmergencyEvent CRDT with distributed ACK tracking
+- Peer connection tracking and management
+- GATT server and client implementations for all platforms
+- Cross-platform CRDT document synchronization
+- Swift test application for macOS/iOS testing
+
+### Changed
+- Centralized peer management and document sync
+- Improved peer connection tracking and display updates
+
+### Fixed
+- EMERGENCY/ACK sync between ESP32 and macOS/iOS devices
+
+## [0.1.0] - 2024-12-01
+
+### Added
+- Initial release
+- Linux platform support with BlueZ/bluer
+- Core BLE transport architecture
+- BleAdapter trait for platform abstraction
+- HIVE beacon format and discovery protocol
+- GATT service definition (0xF47A)
+- Power profile management (Aggressive, Balanced, LowPower, UltraLow)
+- Lightweight CRDT implementations (GCounter, LWWRegister, ORSet)
+- Hierarchical mesh topology support
+- Delta-based synchronization protocol
+- Coded PHY support for extended range (BLE 5.0+)
+
+### Platform Support
+- Linux (BlueZ 5.48+) - Complete
+- macOS (CoreBluetooth) - Complete
+- iOS (CoreBluetooth) - Complete
+- ESP32 (NimBLE) - Complete
+- Android - In Progress
+- Windows - Planned

--- a/hive-btle/CONTRIBUTING.md
+++ b/hive-btle/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to hive-btle
+
+Thank you for your interest in contributing to hive-btle! This document provides guidelines and information for contributors.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/hive-btle.git`
+3. Create a feature branch: `git checkout -b feature/your-feature-name`
+4. Make your changes
+5. Run tests: `cargo test`
+6. Commit with a descriptive message
+7. Push to your fork and submit a Pull Request
+
+## Development Setup
+
+### Prerequisites
+
+- Rust 1.75 or later
+- Platform-specific dependencies:
+  - **Linux**: BlueZ 5.48+, D-Bus development libraries
+  - **macOS**: Xcode Command Line Tools
+  - **ESP32**: ESP-IDF toolchain
+
+### Building
+
+```bash
+# Build for your platform
+cargo build --features linux    # Linux
+cargo build --features macos    # macOS
+cargo build --features ios      # iOS (cross-compile)
+
+# Build for ESP32
+cargo +esp build --target xtensa-esp32-espidf --features esp32
+```
+
+### Testing
+
+```bash
+# Run unit tests (no hardware required)
+cargo test
+
+# Run with platform features
+cargo test --features linux
+
+# Run specific test module
+cargo test sync::
+```
+
+## Code Guidelines
+
+### Style
+
+- Follow Rust standard style (use `cargo fmt`)
+- Run `cargo clippy` and address warnings
+- Write doc comments for public APIs
+- Keep functions focused and reasonably sized
+
+### Safety
+
+- Minimize `unsafe` code; document safety invariants when required
+- Avoid panics in library code; return `Result` types
+- Be careful with BLE security - never store credentials in code
+
+### Testing
+
+- Write unit tests for new functionality
+- Integration tests go in `tests/`
+- Test on real hardware when possible (BLE simulators have limitations)
+
+## Priority Areas
+
+We welcome contributions in these areas:
+
+1. **Android Implementation** (#410) - JNI bindings to Android Bluetooth API
+2. **Security Integration** (#413) - BLE pairing + application-layer encryption
+3. **Windows Implementation** (#412) - WinRT Bluetooth APIs
+4. **Hardware Testing** - Real-world validation on various devices
+5. **Documentation** - Examples, tutorials, API documentation
+
+## Pull Request Process
+
+1. Ensure your code compiles without warnings
+2. Add tests for new functionality
+3. Update documentation as needed
+4. Keep PRs focused on a single change
+5. Reference any related issues in the PR description
+
+## Reporting Issues
+
+When reporting bugs, please include:
+
+- Platform and OS version
+- Bluetooth hardware details
+- Rust version (`rustc --version`)
+- Steps to reproduce
+- Expected vs actual behavior
+- Relevant log output
+
+## Code of Conduct
+
+Be respectful and constructive in all interactions. We're building software for critical tactical applications - quality and reliability matter more than speed.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/hive-btle/Cargo.toml
+++ b/hive-btle/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["(r)evolve - Revolve Team LLC"]
 license = "Apache-2.0"
 description = "Bluetooth Low Energy mesh transport for HIVE Protocol"
-repository = "https://github.com/revolveteam/hive"
+repository = "https://github.com/r-evolve/hive-btle"
 keywords = ["bluetooth", "ble", "mesh", "hive", "tactical"]
 categories = ["network-programming", "embedded"]
 

--- a/hive-btle/LICENSE
+++ b/hive-btle/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024-2025 (r)evolve - Revolve Team LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/hive-btle/README.md
+++ b/hive-btle/README.md
@@ -37,11 +37,11 @@ Traditional BLE mesh implementations (like those in commercial sync SDKs) often 
 | Platform | Status | Notes |
 |----------|--------|-------|
 | Linux (BlueZ) | ✅ Complete | BlueZ 5.48+ required |
+| macOS | ✅ Complete | CoreBluetooth, tested with ESP32 devices |
+| iOS | ✅ Complete | CoreBluetooth (shared with macOS) |
+| ESP32 | ✅ Complete | ESP-IDF NimBLE integration |
 | Android | 🔄 In Progress | JNI bindings to Android Bluetooth API |
-| iOS | 🔄 In Progress | CoreBluetooth bindings |
-| macOS | 🔄 Planned | CoreBluetooth (shared with iOS) |
 | Windows | 📋 Planned | WinRT Bluetooth APIs |
-| ESP32 | 📋 Planned | ESP-IDF NimBLE |
 
 ## Installation
 
@@ -250,24 +250,24 @@ cargo test sync::
 
 ## Related Documentation
 
-- [ADR-039: HIVE-BTLE Mesh Transport](../docs/adr/039-hive-btle-mesh-transport.md) - Full architecture design
-- [ADR-041: Multi-Transport Integration](../docs/adr/041-multi-transport-embedded-integration.md) - HIVE integration architecture
-- [ADR-035: HIVE-Lite Embedded Nodes](../docs/adr/035-hive-lite-embedded-nodes.md) - Embedded node design
+- [ADR-039: HIVE-BTLE Mesh Transport](https://github.com/revolveteam/hive/blob/main/docs/adr/039-hive-btle-mesh-transport.md) - Full architecture design
+- [ADR-041: Multi-Transport Integration](https://github.com/revolveteam/hive/blob/main/docs/adr/041-multi-transport-embedded-integration.md) - HIVE integration architecture
+- [ADR-035: HIVE-Lite Embedded Nodes](https://github.com/revolveteam/hive/blob/main/docs/adr/035-hive-lite-embedded-nodes.md) - Embedded node design
 
 ## Contributing
 
 Contributions are welcome! Priority areas:
 
 1. **Android Implementation** (#410) - JNI bindings to Android Bluetooth API
-2. **iOS Implementation** (#411) - CoreBluetooth bindings
-3. **Security Integration** (#413) - BLE pairing + application-layer encryption
+2. **Security Integration** (#413) - BLE pairing + application-layer encryption
+3. **Windows Implementation** (#412) - WinRT Bluetooth APIs
 4. **Hardware Testing** - Real-world validation on various devices
 
-Please see [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelines.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-Licensed under the Apache License, Version 2.0. See [LICENSE](../LICENSE) for details.
+Licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for details.
 
 ## Acknowledgments
 

--- a/hive-btle/src/hive_mesh.rs
+++ b/hive-btle/src/hive_mesh.rs
@@ -366,6 +366,19 @@ impl HiveMesh {
         Some(node_id)
     }
 
+    /// Called when a BLE connection is lost, using NodeId directly
+    ///
+    /// Alternative to on_ble_disconnected() when only NodeId is known (e.g., ESP32).
+    pub fn on_peer_disconnected(&self, node_id: NodeId, reason: DisconnectReason) {
+        if self
+            .peer_manager
+            .on_disconnected_by_node_id(node_id, reason)
+        {
+            self.notify(HiveEvent::PeerDisconnected { node_id, reason });
+            self.notify_mesh_state_changed();
+        }
+    }
+
     /// Called when a remote device connects to us (incoming connection)
     ///
     /// Use this when we're acting as a peripheral and a central connects to us.

--- a/hive-btle/src/peer_manager.rs
+++ b/hive-btle/src/peer_manager.rs
@@ -205,6 +205,20 @@ impl PeerManager {
         Some((node_id, reason))
     }
 
+    /// Handle a peer disconnection by NodeId
+    ///
+    /// Alternative to on_disconnected() when only NodeId is known (e.g., ESP32).
+    /// Returns true if the peer was found and marked disconnected.
+    pub fn on_disconnected_by_node_id(&self, node_id: NodeId, _reason: DisconnectReason) -> bool {
+        let mut peers = self.peers.write().unwrap();
+        if let Some(peer) = peers.get_mut(&node_id) {
+            peer.is_connected = false;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Register a peer from an incoming BLE connection
     ///
     /// Called when a remote device connects to us as a peripheral.

--- a/hive-btle/tests/peer_connection_test.rs
+++ b/hive-btle/tests/peer_connection_test.rs
@@ -1,0 +1,228 @@
+//! Test peer connection state tracking and emergency/ACK flow
+//!
+//! Verifies that hive-btle properly tracks peer connection state
+//! and handles emergency/ACK propagation.
+
+use hive_btle::hive_mesh::{HiveMesh, HiveMeshConfig};
+use hive_btle::NodeId;
+
+/// Test that receiving data from a peer marks them as connected
+#[test]
+fn test_peer_marked_connected_on_data_receive() {
+    let node_a = NodeId::new(0xAAAAAAAA);
+    let node_b = NodeId::new(0xBBBBBBBB);
+
+    let config_a = HiveMeshConfig::new(node_a, "ALPHA", "TEST");
+    let config_b = HiveMeshConfig::new(node_b, "BRAVO", "TEST");
+
+    let mesh_a = HiveMesh::new(config_a);
+    let mesh_b = HiveMesh::new(config_b);
+
+    // Initially, mesh_a has no peers
+    assert_eq!(
+        mesh_a.get_peers().len(),
+        0,
+        "Mesh A should start with no peers"
+    );
+
+    // Build document from mesh_b
+    let doc_b = mesh_b.build_document();
+    println!("Doc from B: {} bytes", doc_b.len());
+
+    // Mesh A receives data from "peer-b" identifier
+    let result = mesh_a.on_ble_data("peer-b", &doc_b, 1000);
+    assert!(
+        result.is_some(),
+        "on_ble_data should return Some for valid peer data"
+    );
+
+    // Now mesh_a should have peer_b registered
+    let peers = mesh_a.get_peers();
+    assert_eq!(
+        peers.len(),
+        1,
+        "Mesh A should have 1 peer after receiving data"
+    );
+
+    // The peer should be marked as connected
+    let peer_b = &peers[0];
+    assert_eq!(peer_b.node_id, node_b);
+    assert!(
+        peer_b.is_connected,
+        "Peer B should be marked as CONNECTED after receiving data"
+    );
+
+    println!(
+        "PASS: Peer {} is_connected={}",
+        peer_b.node_id.as_u32(),
+        peer_b.is_connected
+    );
+}
+
+/// Test full emergency/ACK flow between two nodes
+#[test]
+fn test_emergency_ack_flow() {
+    let node_a = NodeId::new(0xAAAAAAAA);
+    let node_b = NodeId::new(0xBBBBBBBB);
+
+    let config_a = HiveMeshConfig::new(node_a, "ALPHA", "TEST");
+    let config_b = HiveMeshConfig::new(node_b, "BRAVO", "TEST");
+
+    let mesh_a = HiveMesh::new(config_a);
+    let mesh_b = HiveMesh::new(config_b);
+
+    // Step 1: Exchange initial documents to register peers
+    let doc_a = mesh_a.build_document();
+    let doc_b = mesh_b.build_document();
+
+    let result_a = mesh_a.on_ble_data("peer-b", &doc_b, 1000);
+    let result_b = mesh_b.on_ble_data("peer-a", &doc_a, 1000);
+
+    assert!(result_a.is_some(), "A should process B's document");
+    assert!(result_b.is_some(), "B should process A's document");
+
+    // Verify peers are registered
+    assert_eq!(mesh_a.get_peers().len(), 1, "A should have 1 peer");
+    assert_eq!(mesh_b.get_peers().len(), 1, "B should have 1 peer");
+
+    println!("Step 1 PASS: Both nodes see each other as peers");
+
+    // Step 2: Node A sends EMERGENCY
+    let emergency_doc = mesh_a.start_emergency_with_known_peers(2000);
+    println!("Emergency doc from A: {} bytes", emergency_doc.len());
+
+    // Verify A has active emergency
+    assert!(
+        mesh_a.has_active_emergency(),
+        "A should have active emergency after start_emergency"
+    );
+
+    let status_a = mesh_a.get_emergency_status();
+    assert!(status_a.is_some(), "A should have emergency status");
+    let (source, ts, acked, pending) = status_a.unwrap();
+    println!(
+        "A's emergency: source={:08X} ts={} acked={} pending={}",
+        source, ts, acked, pending
+    );
+    assert_eq!(source, node_a.as_u32(), "Emergency source should be A");
+
+    println!("Step 2 PASS: A created emergency");
+
+    // Step 3: Node B receives emergency document
+    let result_b = mesh_b.on_ble_data("peer-a", &emergency_doc, 2100);
+    assert!(
+        result_b.is_some(),
+        "B should process A's emergency document"
+    );
+
+    let result = result_b.unwrap();
+    println!(
+        "B received: emergency={} ack={} counter_changed={} emergency_changed={}",
+        result.is_emergency, result.is_ack, result.counter_changed, result.emergency_changed
+    );
+
+    // B should now have the emergency
+    assert!(
+        mesh_b.has_active_emergency(),
+        "B should have active emergency after receiving"
+    );
+
+    let status_b = mesh_b.get_emergency_status();
+    assert!(status_b.is_some(), "B should have emergency status");
+    let (source_b, ts_b, acked_b, pending_b) = status_b.unwrap();
+    println!(
+        "B's emergency: source={:08X} ts={} acked={} pending={}",
+        source_b, ts_b, acked_b, pending_b
+    );
+    assert_eq!(
+        source_b,
+        node_a.as_u32(),
+        "B's emergency source should be A"
+    );
+
+    println!("Step 3 PASS: B received emergency");
+
+    // Step 4: Node B sends ACK
+    let ack_doc = mesh_b.ack_emergency(2200);
+    assert!(ack_doc.is_some(), "B should be able to ACK the emergency");
+    let ack_doc = ack_doc.unwrap();
+    println!("ACK doc from B: {} bytes", ack_doc.len());
+
+    // Verify B has acked (in its own state)
+    assert!(
+        mesh_b.has_peer_acked(node_b.as_u32()),
+        "B should show itself as acked"
+    );
+
+    println!("Step 4 PASS: B created ACK");
+
+    // Step 5: Node A receives ACK
+    let result_a = mesh_a.on_ble_data("peer-b", &ack_doc, 2300);
+    assert!(result_a.is_some(), "A should process B's ACK document");
+
+    let result = result_a.unwrap();
+    println!(
+        "A received: emergency={} ack={} counter_changed={} emergency_changed={}",
+        result.is_emergency, result.is_ack, result.counter_changed, result.emergency_changed
+    );
+
+    // A should now see B as acked
+    let a_sees_b_acked = mesh_a.has_peer_acked(node_b.as_u32());
+    println!("A sees B acked: {}", a_sees_b_acked);
+    assert!(a_sees_b_acked, "A should see B as having ACKed");
+
+    println!("Step 5 PASS: A received B's ACK");
+
+    // Final verification
+    let status_a = mesh_a.get_emergency_status().unwrap();
+    println!(
+        "Final A status: acked={} pending={}",
+        status_a.2, status_a.3
+    );
+
+    println!("\n=== FULL EMERGENCY/ACK FLOW TEST PASSED ===");
+}
+
+/// Test that multiple peers are properly tracked
+#[test]
+fn test_multiple_peer_registration() {
+    let node_a = NodeId::new(0xAAAAAAAA);
+    let node_b = NodeId::new(0xBBBBBBBB);
+    let node_c = NodeId::new(0xCCCCCCCC);
+
+    let config_a = HiveMeshConfig::new(node_a, "ALPHA", "TEST");
+    let config_b = HiveMeshConfig::new(node_b, "BRAVO", "TEST");
+    let config_c = HiveMeshConfig::new(node_c, "CHARLIE", "TEST");
+
+    let mesh_a = HiveMesh::new(config_a);
+    let mesh_b = HiveMesh::new(config_b);
+    let mesh_c = HiveMesh::new(config_c);
+
+    // Build documents
+    let _doc_a = mesh_a.build_document();
+    let doc_b = mesh_b.build_document();
+    let doc_c = mesh_c.build_document();
+
+    // A receives from B and C
+    mesh_a.on_ble_data("peer-b", &doc_b, 1000);
+    mesh_a.on_ble_data("peer-c", &doc_c, 1100);
+
+    // A should have 2 peers, both connected
+    let peers_a = mesh_a.get_peers();
+    assert_eq!(peers_a.len(), 2, "A should have 2 peers");
+
+    for peer in &peers_a {
+        println!(
+            "Peer {:08X}: is_connected={}",
+            peer.node_id.as_u32(),
+            peer.is_connected
+        );
+        assert!(peer.is_connected, "All peers should be connected");
+    }
+
+    // Verify connected peer count
+    let connected = mesh_a.get_connected_peers();
+    assert_eq!(connected.len(), 2, "A should have 2 connected peers");
+
+    println!("PASS: Multiple peers registered correctly");
+}


### PR DESCRIPTION
## Summary

- Adds NodeId-based disconnect handling for ESP32 and platforms where only NodeId is known at disconnect time
- Adds comprehensive peer connection and emergency/ACK flow tests
- Adds OSS project files (LICENSE, CHANGELOG, CONTRIBUTING)

### API Additions

```rust
// High-level disconnect handler - use when BLE connection drops
impl HiveMesh {
    pub fn on_peer_disconnected(&self, node_id: NodeId, reason: DisconnectReason);
}

// Low-level peer state update
impl PeerManager {
    pub fn on_disconnected_by_node_id(&self, node_id: NodeId, reason: DisconnectReason) -> bool;
}
```

This complements the existing `on_ble_disconnected(conn_handle)` API for cases where the platform only provides the NodeId (e.g., ESP32 BLE stack callbacks).

### New Tests

| Test | Description |
|------|-------------|
| `test_peer_marked_connected_on_data_receive` | Verifies peers are marked connected when data is received |
| `test_emergency_ack_flow` | Full emergency/ACK round-trip between two nodes |
| `test_multiple_peer_registration` | Multiple peers tracked correctly |

### OSS Files

- `LICENSE` - Apache-2.0
- `CHANGELOG.md` - Version history
- `CONTRIBUTING.md` - Contribution guidelines

## Test plan

- [x] All 3 new peer connection tests pass
- [x] Full hive-btle test suite passes
- [x] Pre-commit hooks pass (fmt + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)