### PR TITLE
feat(atak-plugin): Add platform detail view and squad leader summary

### DIFF
--- a/hive-btle/Makefile
+++ b/hive-btle/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build-android build-android-demo deploy-android clean check-android
+.PHONY: help build-android build-android-demo deploy-android clean check-android check-rust check
 
 # ============================================
 # HIVE BLE Android Build & Deploy
@@ -18,7 +18,9 @@ help:
 	@echo "  build-android-demo - Build the Android demo APK"
 	@echo "  deploy-android     - Deploy demo APK to connected device"
 	@echo "  android            - Build everything and deploy to device"
+	@echo "  check-rust         - Check Rust library compiles for Android"
 	@echo "  check-android      - Check for Kotlin compilation errors"
+	@echo "  check              - Check both Rust and Kotlin"
 	@echo "  clean              - Clean build artifacts"
 	@echo ""
 	@echo "Configuration (override with make VAR=value):"
@@ -49,10 +51,19 @@ deploy-android:
 android: build-android-demo deploy-android
 	@echo "✓ Build and deploy complete"
 
+# Check Rust library for Android (requires Android target)
+check-rust:
+	@echo "Checking hive-btle Rust library for Android..."
+	CXXFLAGS="-include cstdint" cargo ndk -t arm64-v8a check -p hive-btle --features android
+
 # Check for Kotlin compilation errors
 check-android:
 	@echo "Checking Android demo for compilation errors..."
 	JAVA_HOME=$(JAVA_HOME) ../examples/android-hive-demo/gradlew -p ../examples/android-hive-demo compileDebugKotlin 2>&1 | grep -E "e:|error:|Error:" || true
+
+# Check both Rust and Kotlin
+check: check-rust check-android
+	@echo "✓ All checks complete"
 
 # Clean build artifacts
 clean:

--- a/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
+++ b/hive-btle/android/src/main/java/com/hive/btle/HiveBtle.kt
@@ -139,7 +139,7 @@ class HiveBtle(
          * Derive a short mesh ID from an app ID string.
          *
          * The mesh ID is used in BLE device names and should be short (4-8 chars).
-         * This function takes a potentially long app_id (e.g., "default-atak-formation")
+         * This function takes a potentially long app_id (e.g., "my-app-formation-alpha")
          * and derives a short mesh ID from it.
          *
          * Strategy:


### PR DESCRIPTION
## Summary
- Add platform detail view with comprehensive platform information (position, motion, status, mission, capabilities)
- Add squad leader summary view showing aggregated squad status and health
- Implement hierarchy role awareness with `HiveRole` model
- Add hive-btle Android build Makefile with dual architecture support
- Remove ATAK references from hive-btle (prep for standalone repo)

Closes #375

## Changes

### ATAK Plugin
- **HiveDropDownReceiver.kt**: Added `buildPlatformDetailView()` for detailed platform info, `createSquadLeaderSummary()` for leader aggregation view, click handlers on platform cards
- **HivePlatform.kt**: Extended model with motion fields (course, verticalSpeed, positionAccuracy), status fields (batteryPercent, commsQuality, sensorStatus), and mission fields (currentTask, missionId)
- **HiveRole.kt**: New model for hierarchy role representation (SQUAD/PLATOON/COMPANY/BATTALION with leader flag)

### hive-btle
- **Makefile**: Added build targets for Android (arm64-v8a, armeabi-v7a), check-rust, check-android, and deploy
- **HiveBtle.kt**: Removed ATAK reference from example comment

## Test plan
- [ ] Build ATAK plugin and install on device
- [ ] Verify platforms appear in list with "Tap for details" hint
- [ ] Tap platform card to verify detail view opens with all sections
- [ ] Verify back button returns to main view
- [ ] Verify squad summary shows for users with leader role
- [ ] Run `make check` in hive-btle to verify Rust/Kotlin compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)