### PR TITLE
chore: Add Android build artifacts to gitignore and embed git hash in hive-ffi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,13 @@ dist/
 build/
 .embuild/
 
+# Android build artifacts
+**/jniLibs/
+**/.gradle/
+*.apk
+*.aab
+local.properties
+
 # Shadow simulator
 shadow.data/
 

--- a/hive-ffi/build.rs
+++ b/hive-ffi/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+
+fn main() {
+    // Tell Cargo to rerun this if git HEAD changes
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs/heads/");
+
+    // Get git commit hash
+    let git_hash = Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|output| {
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        })
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_hash);
+}


### PR DESCRIPTION
## Summary
- Add jniLibs/, .gradle/, *.apk, *.aab, local.properties to gitignore
- Add build.rs to hive-ffi for embedding git commit hash in builds

This cleans up untracked build artifacts before exporting the hive-btle crate.

## Test plan
- [x] Verify working tree is clean after changes
- [x] Native builds still work (artifacts now gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)