### PR TITLE
feat(hive-ble-test): Generate random node ID by default

### DIFF
--- a/hive-ble-test/src/main.rs
+++ b/hive-ble-test/src/main.rs
@@ -93,10 +93,8 @@ async fn main() -> Result<()> {
 
     // Parse or generate node ID
     let node_id_u32 = match &cli.node_id {
-        Some(id) => {
-            u32::from_str_radix(id.trim_start_matches("0x"), 16)
-                .context("Invalid node ID format (expected hex)")?
-        }
+        Some(id) => u32::from_str_radix(id.trim_start_matches("0x"), 16)
+            .context("Invalid node ID format (expected hex)")?,
         None => {
             // Generate random node ID
             let id = std::time::SystemTime::now()


### PR DESCRIPTION
## Summary

- Generate a unique random node ID when `--node-id` is not provided
- Uses timestamp XOR'd with process ID for uniqueness
- Each run gets a different ID (e.g., `4E04AC5E`)

## Before
```
Node ID: 00000000  (always the same)
```

## After
```
Generated random node ID: 4E04AC5E
Node ID: 4E04AC5E
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)