### PR TITLE
feat(atak-plugin): Add hive-btle BLE mesh integration for WearTAK sync

### DIFF
--- a/atak-plugin/app/build.gradle
+++ b/atak-plugin/app/build.gradle
@@ -210,6 +210,10 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: '*.jar')
 
+    // ATAK SDK - manually add main.jar for compilation (provided by ATAK at runtime)
+    // The atak-takdev-plugin should add this but may not work without remote TAK repo access
+    compileOnly files("/home/kit/Code/revolve/ATAK-CIV-5.6.0-SDK/main.jar")
+
     // Compose DISABLED - causes lifecycle conflicts with ATAK SDK
     // The plugin uses traditional Android Views instead
 
@@ -217,13 +221,22 @@ dependencies {
     implementation('net.java.dev.jna:jna:5.13.0@aar') {
         exclude group: 'org.jetbrains', module: 'annotations'
     }
+
+    // HIVE BLE mesh transport (for WearTAK sync)
+    implementation 'com.revolveteam:hive:0.0.5'
+
+    // CompileOnly dependencies - needed for compilation but provided by ATAK at runtime
+    // These are excluded from packaging to avoid conflicts with ATAK's bundled versions
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib:1.9.24'
+    compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
+    compileOnly 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
 }
 
 configurations.implementation {
-   // Exclude kotlin-stdlib (bundled in ATAK's main.jar)
-   exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
-   exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
-   exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
+   // NOTE: kotlin-stdlib is now allowed through (not excluded) to ensure
+   // it's available at compile time. R8/ProGuard should handle any duplicates
+   // with ATAK's bundled version at runtime.
+
    // Exclude kotlinx.coroutines - conflicts with ATAK's bundled version in main.jar
    exclude group: 'org.jetbrains.kotlinx', module: 'kotlinx-coroutines-core'
    exclude group: 'org.jetbrains.kotlinx', module: 'kotlinx-coroutines-core-jvm'

--- a/atak-plugin/app/build.gradle.kts
+++ b/atak-plugin/app/build.gradle.kts
@@ -157,6 +157,9 @@ dependencies {
     // The bindings and native .so files will be copied to this module
     // implementation(project(":hive-bindings"))
 
+    // HIVE BLE mesh transport (for WearTAK sync)
+    implementation("com.revolveteam:hive:0.0.5")
+
     // Testing
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/atak-plugin/app/src/main/AndroidManifest.xml
+++ b/atak-plugin/app/src/main/AndroidManifest.xml
@@ -3,6 +3,22 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="GoogleAppIndexingWarning">
 
+    <!-- BLE Permissions (Android 12+) -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        tools:targetApi="s" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+
+    <!-- BLE Permissions (Android 8-11 fallback) -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+
+    <!-- BLE feature (optional - plugin works without BLE) -->
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
+
     <application
         android:allowBackup="false"
         android:icon="@drawable/ic_launcher"

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveBleManager.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveBleManager.kt
@@ -1,0 +1,287 @@
+package com.revolveteam.atak.hive
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import com.revolveteam.hive.HiveBtle
+import com.revolveteam.hive.HiveDocument
+import com.revolveteam.hive.HiveEventType
+import com.revolveteam.hive.HiveMeshListener
+import com.revolveteam.hive.HivePeer
+
+/**
+ * Manages HIVE BLE mesh connectivity for the ATAK plugin.
+ *
+ * This provides BLE mesh transport to sync with WearTAK devices and other
+ * HIVE-enabled platforms without requiring network infrastructure.
+ *
+ * Features:
+ * - Automatic peer discovery via BLE scanning
+ * - Mesh document sync (health, status, events)
+ * - Emergency/ACK event propagation
+ * - Power-efficient operation (configurable duty cycle)
+ *
+ * Note: Uses simple callbacks instead of coroutines to avoid dependency
+ * conflicts with ATAK's bundled kotlinx.coroutines.
+ */
+class HiveBleManager(
+    private val context: Context,
+    val meshId: String = "WEARTAK"
+) : HiveMeshListener {
+
+    companion object {
+        private const val TAG = "HiveBleManager"
+
+        @Volatile
+        private var instance: HiveBleManager? = null
+
+        fun getInstance(): HiveBleManager? = instance
+    }
+
+    // BLE mesh instance
+    private var hiveBtle: HiveBtle? = null
+
+    // Main thread handler for callbacks
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    // State (using simple observables instead of StateFlow to avoid coroutines dependency)
+    @Volatile
+    private var _isRunning: Boolean = false
+    val isRunning: SimpleObservable<Boolean> = SimpleObservable(false)
+
+    @Volatile
+    private var _peers: List<HivePeer> = emptyList()
+    val peers: SimpleObservable<List<HivePeer>> = SimpleObservable(emptyList())
+
+    @Volatile
+    private var _connectedPeerCount: Int = 0
+    val connectedPeerCount: SimpleObservable<Int> = SimpleObservable(0)
+
+    // Callbacks for ATAK integration
+    private var peerEventCallback: ((HivePeer, HiveEventType) -> Unit)? = null
+    private var documentSyncCallback: ((HiveDocument) -> Unit)? = null
+
+    init {
+        instance = this
+    }
+
+    /**
+     * Check if BLE permissions are granted.
+     */
+    fun hasPermissions(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Android 12+
+            context.checkSelfPermission(Manifest.permission.BLUETOOTH_SCAN) == PackageManager.PERMISSION_GRANTED &&
+            context.checkSelfPermission(Manifest.permission.BLUETOOTH_CONNECT) == PackageManager.PERMISSION_GRANTED &&
+            context.checkSelfPermission(Manifest.permission.BLUETOOTH_ADVERTISE) == PackageManager.PERMISSION_GRANTED
+        } else {
+            // Android 8-11
+            context.checkSelfPermission(Manifest.permission.BLUETOOTH) == PackageManager.PERMISSION_GRANTED &&
+            context.checkSelfPermission(Manifest.permission.BLUETOOTH_ADMIN) == PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    /**
+     * Get required permissions for the current Android version.
+     */
+    fun getRequiredPermissions(): Array<String> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            arrayOf(
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT,
+                Manifest.permission.BLUETOOTH_ADVERTISE
+            )
+        } else {
+            arrayOf(
+                Manifest.permission.BLUETOOTH,
+                Manifest.permission.BLUETOOTH_ADMIN
+            )
+        }
+    }
+
+    /**
+     * Start the BLE mesh.
+     *
+     * @return true if started successfully
+     */
+    fun start(): Boolean {
+        if (_isRunning) {
+            Log.w(TAG, "BLE mesh already running")
+            return true
+        }
+
+        if (!hasPermissions()) {
+            Log.e(TAG, "BLE permissions not granted")
+            return false
+        }
+
+        return try {
+            Log.i(TAG, "Starting HIVE BLE mesh (meshId: $meshId)")
+
+            hiveBtle = HiveBtle(context, meshId = meshId).apply {
+                init()
+                startMesh(this@HiveBleManager)
+            }
+
+            _isRunning = true
+            isRunning.value = true
+            Log.i(TAG, "HIVE BLE mesh started - nodeId: ${hiveBtle?.nodeId}")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start BLE mesh: ${e.message}", e)
+            false
+        }
+    }
+
+    /**
+     * Stop the BLE mesh.
+     */
+    fun stop() {
+        if (!_isRunning) {
+            return
+        }
+
+        Log.i(TAG, "Stopping HIVE BLE mesh")
+
+        try {
+            hiveBtle?.stopMesh()
+        } catch (e: Exception) {
+            Log.w(TAG, "Error stopping mesh: ${e.message}")
+        }
+
+        hiveBtle = null
+        _isRunning = false
+        isRunning.value = false
+        _peers = emptyList()
+        peers.value = emptyList()
+        _connectedPeerCount = 0
+        connectedPeerCount.value = 0
+
+        Log.i(TAG, "HIVE BLE mesh stopped")
+    }
+
+    /**
+     * Clean up resources.
+     */
+    fun destroy() {
+        stop()
+        instance = null
+    }
+
+    /**
+     * Get the local node ID.
+     */
+    fun getNodeId(): Long? = hiveBtle?.nodeId
+
+    /**
+     * Send an event to all peers.
+     */
+    fun sendEvent(eventType: HiveEventType) {
+        hiveBtle?.sendEvent(eventType)
+    }
+
+    /**
+     * Send an emergency alert.
+     */
+    fun sendEmergency() {
+        sendEvent(HiveEventType.EMERGENCY)
+    }
+
+    /**
+     * Acknowledge an emergency from a peer.
+     */
+    fun acknowledgeEmergency() {
+        sendEvent(HiveEventType.ACK)
+    }
+
+    /**
+     * Set callback for peer events (emergency, ack, etc).
+     */
+    fun setPeerEventCallback(callback: ((HivePeer, HiveEventType) -> Unit)?) {
+        peerEventCallback = callback
+    }
+
+    /**
+     * Set callback for document sync events.
+     */
+    fun setDocumentSyncCallback(callback: ((HiveDocument) -> Unit)?) {
+        documentSyncCallback = callback
+    }
+
+    // ========================================================================
+    // HiveMeshListener implementation
+    // ========================================================================
+
+    override fun onMeshUpdated(peers: List<HivePeer>) {
+        mainHandler.post {
+            _peers = peers
+            this.peers.value = peers
+            _connectedPeerCount = peers.count { it.isConnected }
+            connectedPeerCount.value = _connectedPeerCount
+
+            Log.d(TAG, "Mesh updated: ${peers.size} peers ($_connectedPeerCount connected) " +
+                    "[mgr=${System.identityHashCode(this)}, obs=${System.identityHashCode(this.peers)}]")
+
+            // Log peer details for debugging
+            peers.forEach { peer ->
+                Log.v(TAG, "  - ${peer.displayName()} [${if (peer.isConnected) "connected" else "discovered"}] RSSI: ${peer.rssi}")
+            }
+        }
+    }
+
+    override fun onPeerEvent(peer: HivePeer, eventType: HiveEventType) {
+        mainHandler.post {
+            Log.i(TAG, "Peer event: ${peer.displayName()} -> $eventType")
+
+            when (eventType) {
+                HiveEventType.EMERGENCY -> {
+                    Log.w(TAG, "EMERGENCY received from ${peer.displayName()}")
+                }
+                HiveEventType.ACK -> {
+                    Log.i(TAG, "ACK received from ${peer.displayName()}")
+                }
+                else -> {}
+            }
+
+            peerEventCallback?.invoke(peer, eventType)
+        }
+    }
+
+    override fun onDocumentSynced(document: HiveDocument) {
+        mainHandler.post {
+            Log.d(TAG, "Document synced: nodeId=${document.nodeId}, version=${document.version}")
+            documentSyncCallback?.invoke(document)
+        }
+    }
+}
+
+/**
+ * Simple observable wrapper to replace StateFlow without coroutines dependency.
+ * Allows UI to observe value changes via callbacks.
+ */
+class SimpleObservable<T>(initialValue: T) {
+    private val listeners = mutableListOf<(T) -> Unit>()
+
+    @Volatile
+    var value: T = initialValue
+        set(newValue) {
+            if (field != newValue) {
+                field = newValue
+                listeners.forEach { it(newValue) }
+            }
+        }
+
+    fun observe(listener: (T) -> Unit) {
+        listeners.add(listener)
+        // Immediately notify with current value
+        listener(value)
+    }
+
+    fun removeObserver(listener: (T) -> Unit) {
+        listeners.remove(listener)
+    }
+}

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
@@ -20,6 +20,7 @@ import com.revolveteam.atak.hive.model.HivePlatform
 import com.revolveteam.atak.hive.model.HiveRole
 import com.revolveteam.atak.hive.model.HiveTrack
 import com.revolveteam.atak.hive.model.CommsQuality
+import com.revolveteam.hive.HivePeer as BlePeer
 
 /**
  * HIVE DropDown Receiver
@@ -51,6 +52,10 @@ class HiveDropDownReceiver(
     // User's role in the hierarchy (for PoC, using default role)
     private var userRole: HiveRole = HiveRole.defaultRole()
 
+    // Periodic refresh for BLE mesh updates
+    private var bleRefreshRunnable: Runnable? = null
+    private val BLE_REFRESH_INTERVAL = 2000L // 2 seconds
+
     init {
         // Register for peer events
         PeerEventManager.addListener(this)
@@ -59,6 +64,13 @@ class HiveDropDownReceiver(
         mapComponent.onCellSelectionChanged = { _, _ ->
             refreshContentOnMainThread()
         }
+
+        // Register for BLE mesh updates
+        HivePluginLifecycle.getInstance()?.getHiveBleManager()?.let { bleManager ->
+            bleManager.connectedPeerCount.observe { _ ->
+                refreshContentOnMainThread()
+            }
+        }
     }
 
     override fun disposeImpl() {
@@ -66,11 +78,27 @@ class HiveDropDownReceiver(
         Log.d(TAG, "HiveDropDownReceiver disposed")
     }
 
+    private var bleObserverRegistered = false
+
     override fun onReceive(context: Context, intent: Intent) {
         val action = intent.action ?: return
 
         if (action == SHOW_PLUGIN) {
             Log.d(TAG, "Showing HIVE plugin dropdown")
+
+            // Register BLE observer if not already done
+            if (!bleObserverRegistered) {
+                HivePluginLifecycle.getInstance()?.getHiveBleManager()?.let { bleManager ->
+                    bleManager.connectedPeerCount.observe { _ ->
+                        refreshContentOnMainThread()
+                    }
+                    bleManager.peers.observe { _ ->
+                        refreshContentOnMainThread()
+                    }
+                    bleObserverRegistered = true
+                    Log.d(TAG, "Registered BLE mesh observer")
+                }
+            }
 
             val view = createContentView()
             currentScrollView = view as ScrollView
@@ -204,6 +232,13 @@ class HiveDropDownReceiver(
         if (selectedCellId == null) {
             val pliSection = createPliBroadcastSection()
             container.addView(pliSection)
+            container.addView(createSpacer(24))
+        }
+
+        // BLE Mesh section (only in main view)
+        if (selectedCellId == null) {
+            val bleSection = createBleMeshSection()
+            container.addView(bleSection)
             container.addView(createSpacer(24))
         }
 
@@ -924,6 +959,201 @@ class HiveDropDownReceiver(
             setTextColor(statusColor)
         }
         card.addView(statusText)
+
+        section.addView(card)
+        return section
+    }
+
+    /**
+     * Create the BLE mesh section showing WearTAK peer connectivity
+     */
+    private fun createBleMeshSection(): View {
+        val section = LinearLayout(pluginContext).apply {
+            orientation = LinearLayout.VERTICAL
+        }
+
+        // Title
+        val title = TextView(pluginContext).apply {
+            text = "BLE Mesh (WearTAK)"
+            textSize = 16f
+            setTextColor(Color.WHITE)
+        }
+        section.addView(title)
+        section.addView(createSpacer(12))
+
+        // Card with status and peers
+        val card = LinearLayout(pluginContext).apply {
+            orientation = LinearLayout.VERTICAL
+            setBackgroundColor(Color.parseColor("#2d2d2d"))
+            setPadding(24, 16, 24, 16)
+        }
+
+        val bleManager = HivePluginLifecycle.getInstance()?.getHiveBleManager()
+        val isRunning = bleManager?.isRunning?.value ?: false
+        val blePeers = bleManager?.peers?.value ?: emptyList<BlePeer>()
+        val connectedCount = blePeers.count { it.isConnected }
+
+        Log.i(TAG, "BLE UI: bleManager=${System.identityHashCode(bleManager)}, isRunning=$isRunning, " +
+                "peers=${blePeers.size}, connected=$connectedCount, " +
+                "_peers=${bleManager?.let { System.identityHashCode(it.peers) }}")
+        blePeers.forEach { peer ->
+            Log.d(TAG, "  BLE peer: ${peer.displayName()} connected=${peer.isConnected}")
+        }
+
+        // Status row
+        val statusRow = LinearLayout(pluginContext).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+
+        val statusColor = if (isRunning) Color.parseColor("#4CAF50") else Color.parseColor("#F44336")
+        val statusIndicator = TextView(pluginContext).apply {
+            text = "●"
+            textSize = 14f
+            setTextColor(statusColor)
+        }
+        statusRow.addView(statusIndicator)
+        statusRow.addView(createHorizontalSpacer(8))
+
+        val statusText = TextView(pluginContext).apply {
+            text = if (isRunning) {
+                "Active • $connectedCount connected, ${blePeers.size} discovered"
+            } else {
+                "Inactive"
+            }
+            textSize = 12f
+            setTextColor(Color.WHITE)
+            layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+        }
+        statusRow.addView(statusText)
+        card.addView(statusRow)
+
+        // Mesh ID configuration row
+        card.addView(createSpacer(12))
+        val meshIdRow = LinearLayout(pluginContext).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+
+        val meshIdLabel = TextView(pluginContext).apply {
+            text = "Mesh ID: "
+            textSize = 12f
+            setTextColor(Color.WHITE)
+        }
+        meshIdRow.addView(meshIdLabel)
+
+        val currentMeshId = HivePluginLifecycle.getInstance()?.getCurrentMeshId() ?: HivePluginLifecycle.DEFAULT_MESH_ID
+        val meshIdInput = android.widget.EditText(pluginContext).apply {
+            setText(currentMeshId)
+            textSize = 12f
+            setTextColor(Color.WHITE)
+            setBackgroundColor(Color.parseColor("#3d3d3d"))
+            setPadding(16, 8, 16, 8)
+            layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            setSingleLine(true)
+        }
+        meshIdRow.addView(meshIdInput)
+        meshIdRow.addView(createHorizontalSpacer(8))
+
+        val applyButton = Button(pluginContext).apply {
+            text = "Apply"
+            textSize = 10f
+            setBackgroundColor(Color.parseColor("#2196F3"))
+            setTextColor(Color.WHITE)
+            setPadding(16, 8, 16, 8)
+
+            setOnClickListener {
+                val newMeshId = meshIdInput.text.toString().trim()
+                if (newMeshId.isNotEmpty()) {
+                    HivePluginLifecycle.getInstance()?.setMeshId(pluginContext, newMeshId)
+                    handler.postDelayed({ refreshContent() }, 200)
+                }
+            }
+        }
+        meshIdRow.addView(applyButton)
+        card.addView(meshIdRow)
+
+        // Toggle button
+        card.addView(createSpacer(12))
+        val toggleButton = Button(pluginContext).apply {
+            text = if (isRunning) "Stop BLE Mesh" else "Start BLE Mesh"
+            setBackgroundColor(if (isRunning) Color.parseColor("#F44336") else Color.parseColor("#4CAF50"))
+            setTextColor(Color.WHITE)
+            textSize = 12f
+            setPadding(32, 16, 32, 16)
+
+            setOnClickListener {
+                if (isRunning) {
+                    HivePluginLifecycle.getInstance()?.stopBleMesh()
+                } else {
+                    HivePluginLifecycle.getInstance()?.startBleMesh()
+                }
+                handler.postDelayed({ refreshContent() }, 100)
+            }
+        }
+        card.addView(toggleButton)
+
+        // Peer list (if running and has peers)
+        if (isRunning && blePeers.isNotEmpty()) {
+            card.addView(createSpacer(16))
+
+            val peersTitle = TextView(pluginContext).apply {
+                text = "Discovered Peers"
+                textSize = 12f
+                setTextColor(Color.parseColor("#888888"))
+            }
+            card.addView(peersTitle)
+            card.addView(createSpacer(8))
+
+            blePeers.forEach { peer ->
+                val peerRow = LinearLayout(pluginContext).apply {
+                    orientation = LinearLayout.HORIZONTAL
+                    gravity = Gravity.CENTER_VERTICAL
+                    setPadding(0, 4, 0, 4)
+                }
+
+                val connIndicator = TextView(pluginContext).apply {
+                    text = if (peer.isConnected) "●" else "○"
+                    textSize = 12f
+                    setTextColor(if (peer.isConnected) Color.parseColor("#4CAF50") else Color.GRAY)
+                }
+                peerRow.addView(connIndicator)
+                peerRow.addView(createHorizontalSpacer(8))
+
+                val peerName = TextView(pluginContext).apply {
+                    text = peer.displayName()
+                    textSize = 11f
+                    setTextColor(Color.WHITE)
+                    layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                }
+                peerRow.addView(peerName)
+
+                val rssiText = TextView(pluginContext).apply {
+                    text = "${peer.rssi} dBm"
+                    textSize = 10f
+                    val rssiColor = when {
+                        peer.rssi > -60 -> Color.parseColor("#4CAF50")  // Strong
+                        peer.rssi > -80 -> Color.parseColor("#FFC107")  // Medium
+                        else -> Color.parseColor("#F44336")             // Weak
+                    }
+                    setTextColor(rssiColor)
+                }
+                peerRow.addView(rssiText)
+
+                card.addView(peerRow)
+            }
+        }
+
+        // Permission warning if needed
+        if (bleManager != null && !bleManager.hasPermissions()) {
+            card.addView(createSpacer(12))
+            val permWarning = TextView(pluginContext).apply {
+                text = "⚠ BLE permissions required. Grant in Android Settings."
+                textSize = 11f
+                setTextColor(Color.parseColor("#FFC107"))
+            }
+            card.addView(permWarning)
+        }
 
         section.addView(card)
         return section

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
@@ -15,6 +15,7 @@ import com.revolveteam.atak.hive.model.HiveTrack
 import com.revolveteam.atak.hive.overlay.HiveCellOverlay
 import com.revolveteam.atak.hive.overlay.HivePlatformOverlay
 import com.revolveteam.atak.hive.overlay.HiveTrackOverlay
+import com.revolveteam.hive.HiveDocument
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -59,6 +60,9 @@ class HiveMapComponent : DropDownMapComponent() {
 
     private val _tracks = mutableListOf<HiveTrack>()
     val tracks: List<HiveTrack> get() = _tracks.toList()
+
+    // BLE peer tracks from hive-btle mesh (nodeId -> track)
+    private val _blePeerTracks = mutableMapOf<Long, HiveTrack>()
 
     private var _connectionStatus = ConnectionStatus.DISCONNECTED
     val connectionStatus: ConnectionStatus get() = _connectionStatus
@@ -117,6 +121,9 @@ class HiveMapComponent : DropDownMapComponent() {
         ddFilter.addAction(HiveDropDownReceiver.SHOW_PLUGIN)
         registerDropDownReceiver(dropDownReceiver, ddFilter)
 
+        // Register BLE document sync callback to display peer locations on map
+        registerBleDocumentCallback()
+
         // Update connection status based on HIVE node availability
         updateConnectionStatus()
 
@@ -138,6 +145,85 @@ class HiveMapComponent : DropDownMapComponent() {
         platformOverlay?.dispose()
         platformOverlay = null
         super.onDestroyImpl(context, view)
+    }
+
+    /**
+     * Register callback for BLE document sync to display peer locations.
+     */
+    private fun registerBleDocumentCallback() {
+        try {
+            val bleManager = HivePluginLifecycle.getInstance()?.getHiveBleManager()
+            if (bleManager != null) {
+                bleManager.setDocumentSyncCallback { document ->
+                    onBleDocumentSynced(document)
+                }
+                Log.i(TAG, "BLE document sync callback registered")
+            } else {
+                Log.w(TAG, "BLE manager not available for document callback")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error registering BLE document callback: ${e.message}", e)
+        }
+    }
+
+    /**
+     * Handle synced document from BLE mesh peer - create/update track marker.
+     */
+    private fun onBleDocumentSynced(document: HiveDocument) {
+        // Access peripheral data directly (more compatible with different AAR versions)
+        val peripheral = document.peripheral ?: return
+        val location = peripheral.location ?: return  // No location, nothing to display
+
+        val nodeId = document.nodeId
+        val callsign = peripheral.callsign.takeIf { it.isNotEmpty() }
+            ?: "BLE-${String.format("%08X", nodeId).takeLast(4)}"
+        val battery = peripheral.health.batteryPercent
+        val heartRate = peripheral.health.heartRate
+
+        Log.i(TAG, "BLE document synced: nodeId=${String.format("%08X", nodeId)}, " +
+                "callsign=$callsign, location=(${location.latitude}, ${location.longitude}), " +
+                "battery=$battery%, heartRate=$heartRate")
+
+        // Create/update track for this BLE peer
+        val track = HiveTrack(
+            id = "ble-${String.format("%08X", nodeId)}",
+            sourcePlatform = "hive-btle",
+            cellId = null,
+            formationId = null,
+            lat = location.latitude.toDouble(),
+            lon = location.longitude.toDouble(),
+            hae = location.altitude.toDouble().takeIf { it != 0.0 },
+            cep = null,
+            heading = null,
+            speed = null,
+            classification = "a-f-G-U-C",  // Friendly ground unit - combat
+            confidence = 1.0,
+            category = HiveTrack.Category.PERSON,
+            attributes = mapOf(
+                "callsign" to callsign,
+                "battery" to "$battery%",
+                "source" to "BLE Mesh"
+            ) + (heartRate?.let { mapOf("heartRate" to "$it bpm") } ?: emptyMap()),
+            createdAt = System.currentTimeMillis(),
+            lastUpdate = System.currentTimeMillis()
+        )
+
+        // Update the BLE peer track map and refresh overlay
+        refreshHandler.post {
+            _blePeerTracks[nodeId] = track
+            updateBlePeerOverlay()
+        }
+    }
+
+    /**
+     * Update the track overlay with BLE peer tracks.
+     */
+    private fun updateBlePeerOverlay() {
+        // Combine FFI tracks with BLE peer tracks
+        val allTracks = _tracks.toMutableList()
+        allTracks.addAll(_blePeerTracks.values)
+        trackOverlay?.updateTracks(allTracks)
+        Log.d(TAG, "Updated overlay with ${_tracks.size} FFI tracks + ${_blePeerTracks.size} BLE tracks")
     }
 
     /**
@@ -165,8 +251,10 @@ class HiveMapComponent : DropDownMapComponent() {
 
             try {
                 refreshData()
-                // Update map overlays
-                trackOverlay?.updateTracks(_tracks)
+                // Update map overlays - combine FFI tracks with BLE peer tracks
+                val allTracks = _tracks.toMutableList()
+                allTracks.addAll(_blePeerTracks.values)
+                trackOverlay?.updateTracks(allTracks)
                 // Update cell bounding circles based on platform positions
                 cellOverlay?.updateCellBounds(_cells, _platforms)
                 platformOverlay?.updatePlatforms(_platforms, _cells)

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HivePluginLifecycle.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HivePluginLifecycle.kt
@@ -25,6 +25,7 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
 ) {
     companion object {
         private const val TAG = "HivePluginLifecycle"
+        const val DEFAULT_MESH_ID = "WEARTAK"
 
         @Volatile
         private var instance: HivePluginLifecycle? = null
@@ -34,6 +35,9 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
 
     private var hiveFfiInitialized = false
     private var hiveNodeJni: HiveNodeJni? = null
+
+    // BLE mesh manager for WearTAK sync
+    private var hiveBleManager: HiveBleManager? = null
 
     init {
         instance = this
@@ -74,6 +78,32 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
         }
 
         Log.i(TAG, "HIVE Plugin initialized (FFI: $hiveFfiInitialized)")
+
+        // Initialize BLE mesh for WearTAK sync
+        initBleManager(pluginContext)
+    }
+
+    private fun initBleManager(context: Context) {
+        try {
+            // Get mesh ID from preferences, system properties, or use default
+            val prefs = context.getSharedPreferences("hive_prefs", Context.MODE_PRIVATE)
+            val meshId = prefs.getString("mesh_id", null)
+                ?: System.getProperty("hive.mesh_id")
+                ?: System.getenv("HIVE_MESH_ID")
+                ?: DEFAULT_MESH_ID
+
+            hiveBleManager = HiveBleManager(context, meshId)
+
+            if (hiveBleManager?.hasPermissions() == true) {
+                val started = hiveBleManager?.start() ?: false
+                Log.i(TAG, "HIVE BLE mesh started: $started")
+            } else {
+                Log.w(TAG, "BLE permissions not granted - mesh not started. " +
+                    "Required: ${hiveBleManager?.getRequiredPermissions()?.joinToString()}")
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to initialize BLE manager: ${e.message}", e)
+        }
     }
 
     private fun createHiveNodeJni(context: Context) {
@@ -142,10 +172,18 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
             return hiveNodeJni
         }
         // Try to recover from global singleton (survives APK replacement)
-        val recovered = HiveNodeJni.getInstance()
-        if (recovered != null) {
-            Log.i(TAG, "Recovered HIVE node from global singleton")
-            hiveNodeJni = recovered
+        // Wrapped in try-catch because native library may not be loaded
+        try {
+            val recovered = HiveNodeJni.getInstance()
+            if (recovered != null) {
+                Log.i(TAG, "Recovered HIVE node from global singleton")
+                hiveNodeJni = recovered
+            }
+        } catch (e: UnsatisfiedLinkError) {
+            // Native library not loaded - hive-ffi not available
+            Log.d(TAG, "HIVE FFI native library not available")
+        } catch (e: Exception) {
+            Log.w(TAG, "Error recovering HIVE node: ${e.message}")
         }
         return hiveNodeJni
     }
@@ -155,4 +193,47 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
     fun getNodeId(): String? = getHiveNodeJni()?.nodeId()
 
     fun getConnectedPeers(): String = getHiveNodeJni()?.connectedPeers() ?: "[]"
+
+    // ========================================================================
+    // BLE Mesh Accessors
+    // ========================================================================
+
+    fun getHiveBleManager(): HiveBleManager? = hiveBleManager
+
+    fun isBleAvailable(): Boolean = hiveBleManager?.isRunning?.value == true
+
+    fun getBlePeerCount(): Int = hiveBleManager?.connectedPeerCount?.value ?: 0
+
+    fun startBleMesh(): Boolean {
+        return hiveBleManager?.start() ?: false
+    }
+
+    fun stopBleMesh() {
+        hiveBleManager?.stop()
+    }
+
+    fun getCurrentMeshId(): String {
+        return hiveBleManager?.meshId ?: DEFAULT_MESH_ID
+    }
+
+    fun setMeshId(context: Context, meshId: String) {
+        // Save to preferences
+        val prefs = context.getSharedPreferences("hive_prefs", Context.MODE_PRIVATE)
+        prefs.edit().putString("mesh_id", meshId).apply()
+
+        // Fully destroy old BLE mesh before creating new one
+        Log.i(TAG, "Changing mesh ID from ${hiveBleManager?.meshId} to: $meshId")
+        hiveBleManager?.destroy()  // Use destroy() not stop() to fully clean up
+        hiveBleManager = null
+
+        // Small delay to ensure BLE stack cleans up
+        Thread.sleep(500)
+
+        // Create and start new mesh with new ID
+        hiveBleManager = HiveBleManager(context, meshId)
+        if (hiveBleManager?.hasPermissions() == true) {
+            val started = hiveBleManager?.start() ?: false
+            Log.i(TAG, "New BLE mesh started: $started with meshId: $meshId")
+        }
+    }
 }

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/overlay/HiveTrackOverlay.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/overlay/HiveTrackOverlay.kt
@@ -104,7 +104,9 @@ class HiveTrackOverlay(private val mapView: MapView) {
 
             val marker = Marker(point, uid)
             marker.type = track.toCotType()
-            marker.title = "Track ${track.id.takeLast(6)}"
+            // Use callsign from attributes, fallback to track ID
+            val callsign = track.attributes["callsign"] ?: track.id.takeLast(8)
+            marker.title = callsign
 
             // Set marker style based on classification
             applyMarkerStyle(marker, track)
@@ -137,8 +139,9 @@ class HiveTrackOverlay(private val mapView: MapView) {
             val point = GeoPoint(track.lat, track.lon, track.hae ?: 0.0)
             marker.point = point
 
-            // Update title with confidence
-            marker.title = "Track ${track.id.takeLast(6)} (${(track.confidence * 100).toInt()}%)"
+            // Update title with callsign
+            val callsign = track.attributes["callsign"] ?: track.id.takeLast(8)
+            marker.title = callsign
 
             // Update style if classification changed
             applyMarkerStyle(marker, track)

--- a/atak-plugin/build.gradle
+++ b/atak-plugin/build.gradle
@@ -18,6 +18,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()  // For hive-btle AAR
         google()
         mavenCentral()
     }


### PR DESCRIPTION
## Summary
- Integrates hive-btle v0.0.5 AAR for direct BLE mesh communication with WearTAK devices
- Adds HiveBleManager for BLE mesh lifecycle and peer connectivity
- Displays WearTAK watch locations on ATAK map with callsigns (green friendly icons)
- Works offline - no WiFi/network required, pure Bluetooth Low Energy P2P sync

## Changes
- **HiveBleManager.kt** (new): Manages BLE mesh, implements HiveMeshListener
- **HiveMapComponent.kt**: BLE document sync callback → track markers
- **HiveDropDownReceiver.kt**: BLE mesh status UI section
- **HivePluginLifecycle.kt**: Initialize BLE manager on startup
- **HiveTrackOverlay.kt**: Display callsigns instead of track IDs
- **AndroidManifest.xml**: BLE permissions (BLUETOOTH_SCAN, CONNECT, ADVERTISE)
- **build.gradle**: Add com.revolveteam:hive:0.0.5 dependency

## Test plan
- [x] Build ATAK plugin with hive-btle 0.0.5
- [x] Deploy to Android tablet
- [x] Verify BLE mesh connects to WearTAK watches
- [x] Confirm location sync (lat/lon appearing in logs)
- [x] Verify map markers show callsigns (WEAROS-XXXX)
- [x] Test offline (WiFi disabled) - pure BLE mesh works
- [x] Restart ATAK - markers persist and reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)