### PR TITLE
feat(viewer+sim): Spatial animation engine (hq-7vf.7+8)

### DIFF
--- a/hive-sim/port-ops/bridge/src/port_agent_bridge/bridge_api.py
+++ b/hive-sim/port-ops/bridge/src/port_agent_bridge/bridge_api.py
@@ -854,6 +854,21 @@ class BridgeAPI:
             f"total_moves={moves + 1}"
         )
 
+        spatial_event = {
+            "event_type": "spatial_update",
+            "source": self.node_id,
+            "priority": "ROUTINE",
+            "details": {
+                "operation": "crane_discharge",
+                "crane_id": self.node_id,
+                "container_id": container_id,
+                "container_index": queue.fields.get("completed_count", 1) - 1,
+                "weight_tons": weight,
+                "destination_block": dest,
+            },
+        }
+        print(json.dumps(spatial_event), flush=True)
+
         remaining_count = queue.fields["total_containers"] - queue.fields.get("completed_count", 0)
         return (
             f"Container {container_id} move completed. "
@@ -1116,6 +1131,19 @@ class BridgeAPI:
             "aggregation_policy": "AGGREGATE_AT_PARENT",
             "priority": "NORMAL",
         })
+
+        spatial_event = {
+            "event_type": "spatial_update",
+            "source": self.node_id,
+            "priority": "ROUTINE",
+            "details": {
+                "operation": "tractor_transport",
+                "tractor_id": self.node_id,
+                "container_id": container_id,
+                "destination_block": destination,
+            },
+        }
+        print(json.dumps(spatial_event), flush=True)
 
         logger.info(
             f"METRICS: container_transported node={self.node_id} "

--- a/hive-viewer-ui/src/protocol/state.ts
+++ b/hive-viewer-ui/src/protocol/state.ts
@@ -10,6 +10,7 @@ import type {
   LifecycleState,
 } from './types';
 import { inferRole } from './types';
+import { useAnimationStore } from '../spatial/animationState';
 import { ViewerConnection, defaultWsUrl, type ConnectionStatus } from './connection';
 import type { ReplayMeta } from './replay';
 import { extractMeta } from './replay';
@@ -356,6 +357,22 @@ export const useViewerStore = create<ViewerStore>((set, get) => ({
       }
 
       case 'hive_event': {
+        // Dispatch spatial animation triggers
+        if (event.event_type === 'spatial_update') {
+          const d = event.details as Record<string, unknown> | undefined;
+          if (d?.operation === 'crane_discharge') {
+            useAnimationStore.getState().triggerCraneDischarge(
+              d.crane_id as string, d.container_id as string,
+              d.container_index as number, d.destination_block as string,
+            );
+          } else if (d?.operation === 'tractor_transport') {
+            useAnimationStore.getState().triggerTractorTransport(
+              d.tractor_id as string, d.container_id as string,
+              d.destination_block as string,
+            );
+          }
+        }
+
         set((state) => {
           const details = (event.details ?? {}) as Record<string, unknown>;
           const source = event.source;

--- a/hive-viewer-ui/src/spatial/animationState.ts
+++ b/hive-viewer-ui/src/spatial/animationState.ts
@@ -1,0 +1,196 @@
+/** Zustand store for fire-and-forget spatial animations.
+ *
+ * Animations are triggered by spatial_update events and run independently
+ * via useFrame tick, persisting beyond single-frame OODA cycles.
+ */
+
+import { create } from 'zustand';
+
+// ── Crane animation phases ──────────────────────────────────────────────────
+
+export type CranePhase =
+  | 'idle'
+  | 'boom_to_ship'
+  | 'trolley_extend'
+  | 'spreader_lower'
+  | 'grip'
+  | 'spreader_hoist'
+  | 'boom_to_shore'
+  | 'spreader_lower_truck'
+  | 'release'
+  | 'spreader_return';
+
+const CRANE_PHASE_DURATIONS: Record<CranePhase, number> = {
+  idle: Infinity,
+  boom_to_ship: 0.6,
+  trolley_extend: 0.6,
+  spreader_lower: 0.5,
+  grip: 0.3,
+  spreader_hoist: 0.5,
+  boom_to_shore: 0.8,
+  spreader_lower_truck: 0.5,
+  release: 0.3,
+  spreader_return: 0.4,
+};
+
+const CRANE_PHASE_ORDER: CranePhase[] = [
+  'boom_to_ship',
+  'trolley_extend',
+  'spreader_lower',
+  'grip',
+  'spreader_hoist',
+  'boom_to_shore',
+  'spreader_lower_truck',
+  'release',
+  'spreader_return',
+  'idle',
+];
+
+export interface CraneAnimation {
+  phase: CranePhase;
+  phaseProgress: number; // 0-1
+  containerId: string;
+  containerIndex: number;
+  destinationBlock: string;
+}
+
+// ── Tractor animation phases ────────────────────────────────────────────────
+
+export type TractorPhase = 'idle' | 'drive_to_yard' | 'unload' | 'drive_to_berth';
+
+const TRACTOR_PHASE_DURATIONS: Record<TractorPhase, number> = {
+  idle: Infinity,
+  drive_to_yard: 2.0,
+  unload: 0.5,
+  drive_to_berth: 2.0,
+};
+
+const TRACTOR_PHASE_ORDER: TractorPhase[] = [
+  'drive_to_yard',
+  'unload',
+  'drive_to_berth',
+  'idle',
+];
+
+export interface TractorAnimation {
+  phase: TractorPhase;
+  phaseProgress: number; // 0-1
+  containerId: string;
+  destinationBlock: string;
+}
+
+// ── Store ───────────────────────────────────────────────────────────────────
+
+export interface AnimationStore {
+  cranes: Record<string, CraneAnimation>;
+  tractors: Record<string, TractorAnimation>;
+  triggerCraneDischarge: (
+    craneId: string,
+    containerId: string,
+    containerIndex: number,
+    destBlock: string,
+  ) => void;
+  triggerTractorTransport: (
+    tractorId: string,
+    containerId: string,
+    destBlock: string,
+  ) => void;
+  tick: (delta: number) => void;
+}
+
+function advanceCranePhase(anim: CraneAnimation, delta: number): CraneAnimation {
+  if (anim.phase === 'idle') return anim;
+
+  const duration = CRANE_PHASE_DURATIONS[anim.phase];
+  const newProgress = anim.phaseProgress + delta / duration;
+
+  if (newProgress >= 1) {
+    const idx = CRANE_PHASE_ORDER.indexOf(anim.phase);
+    const nextPhase = CRANE_PHASE_ORDER[idx + 1] ?? 'idle';
+    return { ...anim, phase: nextPhase, phaseProgress: 0 };
+  }
+
+  return { ...anim, phaseProgress: newProgress };
+}
+
+function advanceTractorPhase(anim: TractorAnimation, delta: number): TractorAnimation {
+  if (anim.phase === 'idle') return anim;
+
+  const duration = TRACTOR_PHASE_DURATIONS[anim.phase];
+  const newProgress = anim.phaseProgress + delta / duration;
+
+  if (newProgress >= 1) {
+    const idx = TRACTOR_PHASE_ORDER.indexOf(anim.phase);
+    const nextPhase = TRACTOR_PHASE_ORDER[idx + 1] ?? 'idle';
+    return { ...anim, phase: nextPhase, phaseProgress: 0 };
+  }
+
+  return { ...anim, phaseProgress: newProgress };
+}
+
+export const useAnimationStore = create<AnimationStore>((set, get) => ({
+  cranes: {},
+  tractors: {},
+
+  triggerCraneDischarge: (craneId, containerId, containerIndex, destBlock) => {
+    set((state) => ({
+      cranes: {
+        ...state.cranes,
+        [craneId]: {
+          phase: 'boom_to_ship' as CranePhase,
+          phaseProgress: 0,
+          containerId,
+          containerIndex,
+          destinationBlock: destBlock,
+        },
+      },
+    }));
+  },
+
+  triggerTractorTransport: (tractorId, containerId, destBlock) => {
+    set((state) => ({
+      tractors: {
+        ...state.tractors,
+        [tractorId]: {
+          phase: 'drive_to_yard' as TractorPhase,
+          phaseProgress: 0,
+          containerId,
+          destinationBlock: destBlock,
+        },
+      },
+    }));
+  },
+
+  tick: (delta: number) => {
+    const { cranes, tractors } = get();
+    let craneDirty = false;
+    let tractorDirty = false;
+    const nextCranes: Record<string, CraneAnimation> = {};
+    const nextTractors: Record<string, TractorAnimation> = {};
+
+    for (const [id, anim] of Object.entries(cranes)) {
+      if (anim.phase === 'idle') {
+        nextCranes[id] = anim;
+      } else {
+        nextCranes[id] = advanceCranePhase(anim, delta);
+        craneDirty = true;
+      }
+    }
+
+    for (const [id, anim] of Object.entries(tractors)) {
+      if (anim.phase === 'idle') {
+        nextTractors[id] = anim;
+      } else {
+        nextTractors[id] = advanceTractorPhase(anim, delta);
+        tractorDirty = true;
+      }
+    }
+
+    if (craneDirty || tractorDirty) {
+      set({
+        ...(craneDirty ? { cranes: nextCranes } : {}),
+        ...(tractorDirty ? { tractors: nextTractors } : {}),
+      });
+    }
+  },
+}));

--- a/hive-viewer-ui/src/spatial/constants.ts
+++ b/hive-viewer-ui/src/spatial/constants.ts
@@ -72,6 +72,17 @@ export const YARD = {
   labels: ['YB-A', 'YB-B', 'YB-C', 'YB-D', 'YB-E', 'YB-F'],
 };
 
+export const CRANE_ANIM = {
+  BOOM_SHIP_ANGLE: 0.15,       // radians toward ship (+Z)
+  BOOM_SHORE_ANGLE: -0.1,      // radians toward shore (-Z)
+  TROLLEY_RETRACTED_Z: 1.5,
+  TROLLEY_EXTENDED_Z: 4.5,     // over container in hold
+  SPREADER_REST_Y: 4.2,
+  SPREADER_GRAB_Y: 1.0,        // container height on vessel
+  SPREADER_TRUCK_Y: 1.5,       // truck bed height
+  CONTAINER_SIZE: [0.6, 0.35, 0.6] as const,
+};
+
 export const COLORS = {
   water: '#0a1628',
   berth: '#2a2a2a',

--- a/hive-viewer-ui/src/spatial/useAnimationTick.ts
+++ b/hive-viewer-ui/src/spatial/useAnimationTick.ts
@@ -1,0 +1,10 @@
+/** Drives animation state machines every frame via useFrame. */
+
+import { useFrame } from '@react-three/fiber';
+import { useAnimationStore } from './animationState';
+
+export function useAnimationTick() {
+  useFrame((_, delta) => {
+    useAnimationStore.getState().tick(delta);
+  });
+}

--- a/hive-viewer-ui/src/views/SpatialView/BerthScene.tsx
+++ b/hive-viewer-ui/src/views/SpatialView/BerthScene.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from 'react';
 import { OrbitControls, OrthographicCamera } from '@react-three/drei';
 import type { SpatialDerivedState } from '../../spatial/types';
 import { CAMERA, COLORS } from '../../spatial/constants';
+import { useAnimationStore } from '../../spatial/animationState';
+import { useAnimationTick } from '../../spatial/useAnimationTick';
 import VesselHull from './VesselHull';
 import HoldGrid from './HoldGrid';
 import ContainerQueue from './ContainerQueue';
@@ -17,6 +20,23 @@ interface Props {
 
 export default function BerthScene({ state }: Props) {
   const anyContention = Object.values(state.cranes).some((c) => c.isContending);
+
+  // Drive animation state machines every frame
+  useAnimationTick();
+
+  const craneAnims = useAnimationStore((s) => s.cranes);
+  const tractorAnims = useAnimationStore((s) => s.tractors);
+
+  // Collect container indices currently being animated by cranes
+  const animatingContainerIndices = useMemo(() => {
+    const indices = new Set<number>();
+    for (const anim of Object.values(craneAnims)) {
+      if (anim.phase !== 'idle') {
+        indices.add(anim.containerIndex);
+      }
+    }
+    return indices;
+  }, [craneAnims]);
 
   return (
     <>
@@ -59,11 +79,16 @@ export default function BerthScene({ state }: Props) {
       {/* Scene elements */}
       <VesselHull />
       <HoldGrid />
-      <ContainerQueue state={state} />
+      <ContainerQueue state={state} animatingIndices={animatingContainerIndices} />
 
       {/* Cranes */}
       {Object.entries(state.cranes).map(([nodeId, crane]) => (
-        <CraneGantry key={nodeId} nodeId={nodeId} crane={crane} />
+        <CraneGantry
+          key={nodeId}
+          nodeId={nodeId}
+          crane={crane}
+          animation={craneAnims[nodeId] ?? null}
+        />
       ))}
 
       {/* Operators */}
@@ -73,7 +98,12 @@ export default function BerthScene({ state }: Props) {
 
       {/* Tractors */}
       {Object.entries(state.tractors).map(([nodeId, tractor]) => (
-        <TractorUnit key={nodeId} nodeId={nodeId} tractor={tractor} />
+        <TractorUnit
+          key={nodeId}
+          nodeId={nodeId}
+          tractor={tractor}
+          animation={tractorAnims[nodeId] ?? null}
+        />
       ))}
 
       {/* Sensors */}

--- a/hive-viewer-ui/src/views/SpatialView/ContainerQueue.tsx
+++ b/hive-viewer-ui/src/views/SpatialView/ContainerQueue.tsx
@@ -6,6 +6,7 @@ import { CONTAINER_GRID, COLORS } from '../../spatial/constants';
 
 interface Props {
   state: SpatialDerivedState;
+  animatingIndices?: Set<number>;
 }
 
 function ContainerBox({
@@ -78,10 +79,13 @@ function ContainerBox({
   );
 }
 
-export default function ContainerQueue({ state }: Props) {
+export default function ContainerQueue({ state, animatingIndices }: Props) {
   return (
     <group>
       {state.containers.map((c) => {
+        // Hide containers that are currently attached to a crane spreader
+        if (animatingIndices?.has(c.index)) return null;
+
         const col = c.index % CONTAINER_GRID.cols;
         const row = Math.floor(c.index / CONTAINER_GRID.cols);
         return (

--- a/hive-viewer-ui/src/views/SpatialView/CraneGantry.tsx
+++ b/hive-viewer-ui/src/views/SpatialView/CraneGantry.tsx
@@ -3,15 +3,29 @@ import { useFrame } from '@react-three/fiber';
 import { Text } from '@react-three/drei';
 import type { Group, Mesh, MeshStandardMaterial } from 'three';
 import type { CraneVisualState } from '../../spatial/types';
-import { CRANE_POSITIONS, COLORS } from '../../spatial/constants';
+import type { CraneAnimation, CranePhase } from '../../spatial/animationState';
+import { useAnimationStore } from '../../spatial/animationState';
+import { CRANE_POSITIONS, CRANE_ANIM, COLORS } from '../../spatial/constants';
+
+function easeInOut(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
 
 interface Props {
   nodeId: string;
   crane: CraneVisualState;
+  animation: CraneAnimation | null;
 }
 
-export default function CraneGantry({ nodeId, crane }: Props) {
+export default function CraneGantry({ nodeId, crane, animation: _animation }: Props) {
+  const boomRef = useRef<Group>(null);
+  const trolleyRef = useRef<Group>(null);
   const spreaderRef = useRef<Group>(null);
+  const containerRef = useRef<Mesh>(null);
   const ringRef = useRef<Group>(null);
   const phaseRef = useRef(0);
   const pos = CRANE_POSITIONS[nodeId];
@@ -27,16 +41,87 @@ export default function CraneGantry({ nodeId, crane }: Props) {
   useFrame((_, delta) => {
     phaseRef.current += delta * 3;
 
-    // Spreader oscillation when active
-    if (spreaderRef.current) {
-      if (crane.isActive) {
-        spreaderRef.current.position.y = 3.5 + Math.sin(phaseRef.current) * 0.4;
-      } else {
-        spreaderRef.current.position.y = 4.2;
+    // Read animation state imperatively (avoids React re-renders)
+    const anim = useAnimationStore.getState().cranes[nodeId];
+    const phase: CranePhase = anim?.phase ?? 'idle';
+    const t = anim ? easeInOut(anim.phaseProgress) : 0;
+
+    // --- Boom rotation ---
+    if (boomRef.current) {
+      let targetAngle = 0;
+      if (phase === 'boom_to_ship') {
+        targetAngle = lerp(0, CRANE_ANIM.BOOM_SHIP_ANGLE, t);
+      } else if (
+        phase === 'trolley_extend' || phase === 'spreader_lower' ||
+        phase === 'grip' || phase === 'spreader_hoist'
+      ) {
+        targetAngle = CRANE_ANIM.BOOM_SHIP_ANGLE;
+      } else if (phase === 'boom_to_shore') {
+        targetAngle = lerp(CRANE_ANIM.BOOM_SHIP_ANGLE, CRANE_ANIM.BOOM_SHORE_ANGLE, t);
+      } else if (
+        phase === 'spreader_lower_truck' || phase === 'release' || phase === 'spreader_return'
+      ) {
+        targetAngle = CRANE_ANIM.BOOM_SHORE_ANGLE;
       }
+      boomRef.current.rotation.y = targetAngle;
     }
 
-    // Contention ring expansion
+    // --- Trolley position along boom ---
+    if (trolleyRef.current) {
+      let targetZ = CRANE_ANIM.TROLLEY_RETRACTED_Z;
+      if (phase === 'trolley_extend') {
+        targetZ = lerp(CRANE_ANIM.TROLLEY_RETRACTED_Z, CRANE_ANIM.TROLLEY_EXTENDED_Z, t);
+      } else if (
+        phase === 'spreader_lower' || phase === 'grip' || phase === 'spreader_hoist'
+      ) {
+        targetZ = CRANE_ANIM.TROLLEY_EXTENDED_Z;
+      } else if (
+        phase === 'boom_to_shore' || phase === 'spreader_lower_truck' ||
+        phase === 'release' || phase === 'spreader_return'
+      ) {
+        targetZ = CRANE_ANIM.TROLLEY_RETRACTED_Z;
+      }
+      trolleyRef.current.position.z = targetZ;
+    }
+
+    // --- Spreader vertical (local Y relative to boom at Y=5) ---
+    if (spreaderRef.current) {
+      const BOOM_Y = 5;
+      const restLocal = CRANE_ANIM.SPREADER_REST_Y - BOOM_Y;   // -0.8
+      const grabLocal = CRANE_ANIM.SPREADER_GRAB_Y - BOOM_Y;   // -4.0
+      const truckLocal = CRANE_ANIM.SPREADER_TRUCK_Y - BOOM_Y; // -3.5
+
+      let targetY = restLocal;
+      if (phase === 'spreader_lower') {
+        targetY = lerp(restLocal, grabLocal, t);
+      } else if (phase === 'grip') {
+        targetY = grabLocal;
+      } else if (phase === 'spreader_hoist') {
+        targetY = lerp(grabLocal, restLocal, t);
+      } else if (phase === 'boom_to_shore' || phase === 'boom_to_ship') {
+        targetY = restLocal;
+      } else if (phase === 'spreader_lower_truck') {
+        targetY = lerp(restLocal, truckLocal, t);
+      } else if (phase === 'release') {
+        targetY = truckLocal;
+      } else if (phase === 'spreader_return') {
+        targetY = lerp(truckLocal, restLocal, t);
+      } else if (phase === 'idle' && crane.isActive) {
+        // Fallback: gentle oscillation when active but no spatial animation
+        targetY = (3.5 - BOOM_Y) + Math.sin(phaseRef.current) * 0.4;
+      }
+      spreaderRef.current.position.y = targetY;
+    }
+
+    // --- Container visibility on spreader ---
+    if (containerRef.current) {
+      const gripped =
+        phase === 'grip' || phase === 'spreader_hoist' ||
+        phase === 'boom_to_shore' || phase === 'spreader_lower_truck';
+      containerRef.current.visible = gripped;
+    }
+
+    // --- Contention ring ---
     if (ringRef.current) {
       if (crane.isContending) {
         ringRef.current.visible = true;
@@ -54,7 +139,7 @@ export default function CraneGantry({ nodeId, crane }: Props) {
 
   return (
     <group position={[pos.x, 0, pos.z]}>
-      {/* Tower legs */}
+      {/* Tower legs (static) */}
       <mesh position={[-0.4, 2.5, 0]}>
         <boxGeometry args={[0.2, 5, 0.2]} />
         <meshStandardMaterial color={statusColor} />
@@ -64,29 +149,41 @@ export default function CraneGantry({ nodeId, crane }: Props) {
         <meshStandardMaterial color={statusColor} />
       </mesh>
 
-      {/* Cross beam */}
+      {/* Cross beam (static) */}
       <mesh position={[0, 5, 0]}>
         <boxGeometry args={[1.2, 0.2, 0.2]} />
         <meshStandardMaterial color={statusColor} />
       </mesh>
 
-      {/* Boom (extends toward vessel) */}
-      <mesh position={[0, 5, 2.5]}>
-        <boxGeometry args={[0.15, 0.15, 5]} />
-        <meshStandardMaterial color={statusColor} />
-      </mesh>
+      {/* Boom (rotates around Y) */}
+      <group ref={boomRef} position={[0, 5, 0]}>
+        {/* Boom bar */}
+        <mesh position={[0, 0, 2.5]}>
+          <boxGeometry args={[0.15, 0.15, 5]} />
+          <meshStandardMaterial color={statusColor} />
+        </mesh>
 
-      {/* Spreader (animated) */}
-      <group ref={spreaderRef} position={[0, 4.2, 1.5]}>
-        <mesh>
-          <boxGeometry args={[0.8, 0.1, 0.4]} />
-          <meshStandardMaterial color="#ffffff" />
-        </mesh>
-        {/* Cable */}
-        <mesh position={[0, 0.5, 0]}>
-          <cylinderGeometry args={[0.02, 0.02, 1]} />
-          <meshStandardMaterial color="#888888" />
-        </mesh>
+        {/* Trolley (slides along boom Z) */}
+        <group ref={trolleyRef} position={[0, 0, CRANE_ANIM.TROLLEY_RETRACTED_Z]}>
+          {/* Spreader (moves vertically) */}
+          <group ref={spreaderRef} position={[0, CRANE_ANIM.SPREADER_REST_Y - 5, 0]}>
+            {/* Spreader frame */}
+            <mesh>
+              <boxGeometry args={[0.8, 0.1, 0.4]} />
+              <meshStandardMaterial color="#ffffff" />
+            </mesh>
+            {/* Cable */}
+            <mesh position={[0, 0.5, 0]}>
+              <cylinderGeometry args={[0.02, 0.02, 1]} />
+              <meshStandardMaterial color="#888888" />
+            </mesh>
+            {/* Container (visible only when gripped) */}
+            <mesh ref={containerRef} position={[0, -0.25, 0]} visible={false}>
+              <boxGeometry args={CRANE_ANIM.CONTAINER_SIZE} />
+              <meshStandardMaterial color={COLORS.containerInProgress} />
+            </mesh>
+          </group>
+        </group>
       </group>
 
       {/* Contention ring */}
@@ -114,4 +211,3 @@ export default function CraneGantry({ nodeId, crane }: Props) {
     </group>
   );
 }
-

--- a/hive-viewer-ui/src/views/SpatialView/TractorUnit.tsx
+++ b/hive-viewer-ui/src/views/SpatialView/TractorUnit.tsx
@@ -1,17 +1,38 @@
 import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Text } from '@react-three/drei';
-import type { Mesh } from 'three';
+import type { Group, Mesh } from 'three';
 import type { TractorVisualState } from '../../spatial/types';
-import { TRACTOR_POSITIONS, COLORS } from '../../spatial/constants';
+import type { TractorAnimation, TractorPhase } from '../../spatial/animationState';
+import { useAnimationStore } from '../../spatial/animationState';
+import { TRACTOR_POSITIONS, YARD, COLORS } from '../../spatial/constants';
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function easeInOut(t: number): number {
+  return t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+}
+
+/** Compute yard block center position from block name (e.g. "YB-A" → first block). */
+function getYardBlockPosition(blockName: string): { x: number; z: number } {
+  const idx = YARD.labels.indexOf(blockName);
+  const i = idx >= 0 ? idx : 0;
+  const x = YARD.startX + i * (YARD.blockWidth + YARD.gap) + YARD.blockWidth / 2;
+  return { x, z: YARD.z };
+}
 
 interface Props {
   nodeId: string;
   tractor: TractorVisualState;
+  animation: TractorAnimation | null;
 }
 
-export default function TractorUnit({ nodeId, tractor }: Props) {
+export default function TractorUnit({ nodeId, tractor, animation: _animation }: Props) {
+  const groupRef = useRef<Group>(null);
   const bodyRef = useRef<Mesh>(null);
+  const cargoRef = useRef<Mesh>(null);
   const phaseRef = useRef(0);
   const pos = TRACTOR_POSITIONS[nodeId];
   if (!pos) return null;
@@ -24,9 +45,46 @@ export default function TractorUnit({ nodeId, tractor }: Props) {
 
   useFrame((_, delta) => {
     phaseRef.current += delta * 2;
+
+    // Read animation state imperatively
+    const anim = useAnimationStore.getState().tractors[nodeId];
+    const phase: TractorPhase = anim?.phase ?? 'idle';
+    const t = anim ? easeInOut(anim.phaseProgress) : 0;
+
+    // Position interpolation
+    if (groupRef.current) {
+      const home = { x: 0, z: 0 }; // group is already positioned at pos.x, pos.z
+      if (phase === 'drive_to_yard') {
+        const yard = getYardBlockPosition(anim!.destinationBlock);
+        const targetX = yard.x - pos.x;
+        const targetZ = yard.z - pos.z;
+        groupRef.current.position.x = lerp(home.x, targetX, t);
+        groupRef.current.position.z = lerp(home.z, targetZ, t);
+      } else if (phase === 'unload') {
+        const yard = getYardBlockPosition(anim!.destinationBlock);
+        groupRef.current.position.x = yard.x - pos.x;
+        groupRef.current.position.z = yard.z - pos.z;
+      } else if (phase === 'drive_to_berth') {
+        const yard = getYardBlockPosition(anim!.destinationBlock);
+        const fromX = yard.x - pos.x;
+        const fromZ = yard.z - pos.z;
+        groupRef.current.position.x = lerp(fromX, home.x, t);
+        groupRef.current.position.z = lerp(fromZ, home.z, t);
+      } else {
+        // idle: smoothly return to home
+        groupRef.current.position.x += (home.x - groupRef.current.position.x) * delta * 3;
+        groupRef.current.position.z += (home.z - groupRef.current.position.z) * delta * 3;
+      }
+    }
+
     // Gentle bob when moving
-    if (bodyRef.current && tractor.isMoving) {
+    if (bodyRef.current && (tractor.isMoving || phase !== 'idle')) {
       bodyRef.current.position.y = 0.3 + Math.sin(phaseRef.current) * 0.05;
+    }
+
+    // Cargo visibility
+    if (cargoRef.current) {
+      cargoRef.current.visible = phase === 'drive_to_yard' || phase === 'unload';
     }
   });
 
@@ -35,34 +93,42 @@ export default function TractorUnit({ nodeId, tractor }: Props) {
 
   return (
     <group position={[pos.x, 0, pos.z]}>
-      {/* Tractor body — rectangular */}
-      <mesh ref={bodyRef} position={[0, 0.3, 0]}>
-        <boxGeometry args={[0.9, 0.35, 0.5]} />
-        <meshStandardMaterial color={color} />
-      </mesh>
+      <group ref={groupRef}>
+        {/* Tractor body */}
+        <mesh ref={bodyRef} position={[0, 0.3, 0]}>
+          <boxGeometry args={[0.9, 0.35, 0.5]} />
+          <meshStandardMaterial color={color} />
+        </mesh>
 
-      {/* Cab */}
-      <mesh position={[0.25, 0.55, 0]}>
-        <boxGeometry args={[0.3, 0.2, 0.45]} />
-        <meshStandardMaterial color="#333333" />
-      </mesh>
+        {/* Cab */}
+        <mesh position={[0.25, 0.55, 0]}>
+          <boxGeometry args={[0.3, 0.2, 0.45]} />
+          <meshStandardMaterial color="#333333" />
+        </mesh>
 
-      {/* Battery bar (below body) */}
-      <mesh position={[-0.4 + batteryWidth / 2, 0.08, 0]}>
-        <boxGeometry args={[batteryWidth, 0.06, 0.3]} />
-        <meshStandardMaterial color={batteryColor} />
-      </mesh>
+        {/* Container cargo (visible during transport) */}
+        <mesh ref={cargoRef} position={[-0.15, 0.65, 0]} visible={false}>
+          <boxGeometry args={[0.6, 0.3, 0.45]} />
+          <meshStandardMaterial color={COLORS.containerInProgress} />
+        </mesh>
 
-      {/* Label */}
-      <Text
-        position={[0, 0.9, 0]}
-        fontSize={0.25}
-        color={COLORS.text}
-        anchorX="center"
-        anchorY="middle"
-      >
-        {`${nodeId} [${tractor.tripsCompleted}]`}
-      </Text>
+        {/* Battery bar */}
+        <mesh position={[-0.4 + batteryWidth / 2, 0.08, 0]}>
+          <boxGeometry args={[batteryWidth, 0.06, 0.3]} />
+          <meshStandardMaterial color={batteryColor} />
+        </mesh>
+
+        {/* Label */}
+        <Text
+          position={[0, 0.9, 0]}
+          fontSize={0.25}
+          color={COLORS.text}
+          anchorX="center"
+          anchorY="middle"
+        >
+          {`${nodeId} [${tractor.tripsCompleted}]`}
+        </Text>
+      </group>
     </group>
   );
 }


### PR DESCRIPTION
## Summary
- Sim emits `spatial_update` events from bridge on crane discharge and tractor transport (stdout → relay → WebSocket)
- Zustand animation store with fire-and-forget state machines: crane 10-phase (~4.5s), tractor 4-phase (~4.5s)
- Crane geometry restructured into hierarchical animated groups (boom → trolley → spreader) with easeInOut interpolation
- Tractors lerp between berth positions and yard blocks, showing cargo mesh during transport
- Containers hide from ship grid while attached to crane spreader

## Tracks
- hq-7vf.7: Spatial world model in sim
- hq-7vf.8: Spatial animation engine in viewer

## Files changed (9)
- `bridge_api.py` — +28 lines (spatial_update event emission)
- `animationState.ts` — NEW, 196 lines (Zustand animation store)
- `useAnimationTick.ts` — NEW, 10 lines (useFrame tick hook)
- `state.ts` — +17 lines (event → animation trigger wiring)
- `constants.ts` — +11 lines (CRANE_ANIM keyframe constants)
- `BerthScene.tsx` — +36/-14 (animation store integration)
- `CraneGantry.tsx` — +150/-45 (hierarchical animated crane)
- `TractorUnit.tsx` — +130/-39 (position-animated tractor)
- `ContainerQueue.tsx` — +6/-4 (animating index filter)

## QA
- [x] `tsc --noEmit` — clean
- [x] `vite build` — clean (616 modules, 2.6s)
- [ ] Inspector visual QA with live sim

🤖 Generated with [Claude Code](https://claude.com/claude-code)