### PR TITLE
fix: Ditto tests gracefully skip when credentials unavailable

### DIFF
--- a/hive-protocol/src/storage/ditto_store.rs
+++ b/hive-protocol/src/storage/ditto_store.rs
@@ -2683,6 +2683,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_command_upsert_and_retrieve() {
+        let Some(_creds) = get_test_credentials() else {
+            eprintln!("Skipping test: credentials not available");
+            return;
+        };
         let (store, _temp_dir) = create_test_store("test_command_upsert").await;
 
         use hive_schema::command::v1::{command_target::Scope, CommandTarget, HierarchicalCommand};
@@ -2737,6 +2741,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_command_acknowledgment_upsert_and_query() {
+        let Some(_creds) = get_test_credentials() else {
+            eprintln!("Skipping test: credentials not available");
+            return;
+        };
         let (store, _temp_dir) = create_test_store("test_command_ack").await;
 
         use hive_schema::command::v1::{AckStatus, CommandAcknowledgment};

--- a/hive-protocol/src/sync/ditto.rs
+++ b/hive-protocol/src/sync/ditto.rs
@@ -834,12 +834,21 @@ mod tests {
         let backend = DittoBackend::new();
         let mut config = create_test_config();
         config.shared_key = None;
+        // Provide a dummy offline_token so initialize() reaches the shared_key check
+        // (offline_token is validated first in initialize())
+        config
+            .extra
+            .insert("offline_token".to_string(), "dummy-token".to_string());
 
         let result = backend.initialize(config).await;
         assert!(result.is_err());
         // Verify error message contains expected text
         if let Err(e) = result {
-            assert!(e.to_string().contains("shared_key required"));
+            assert!(
+                e.to_string().contains("shared_key required"),
+                "Expected 'shared_key required' error, got: {}",
+                e
+            );
         }
     }
 

--- a/hive-protocol/src/testing/e2e_harness.rs
+++ b/hive-protocol/src/testing/e2e_harness.rs
@@ -753,11 +753,17 @@ mod tests {
     #[cfg(feature = "ditto-backend")]
     #[tokio::test]
     async fn test_ditto_store_creation() {
-        // Fail if Ditto credentials not properly configured
-        let ditto_app_id = std::env::var("HIVE_APP_ID")
+        // Skip if Ditto credentials not available
+        let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
             .or_else(|_| std::env::var("DITTO_APP_ID"))
-            .expect("HIVE_APP_ID must be set for E2E tests");
-        assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+        else {
+            eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+            return;
+        };
+        if ditto_app_id.is_empty() {
+            eprintln!("Skipping test: HIVE_APP_ID is empty");
+            return;
+        }
 
         let mut harness = E2EHarness::new("test_store_creation");
         let store = harness.create_ditto_store().await;
@@ -769,11 +775,17 @@ mod tests {
     #[cfg(feature = "ditto-backend")]
     #[tokio::test]
     async fn test_multiple_isolated_stores() {
-        // Fail if Ditto credentials not properly configured
-        let ditto_app_id = std::env::var("HIVE_APP_ID")
+        // Skip if Ditto credentials not available
+        let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
             .or_else(|_| std::env::var("DITTO_APP_ID"))
-            .expect("HIVE_APP_ID must be set for E2E tests");
-        assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+        else {
+            eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+            return;
+        };
+        if ditto_app_id.is_empty() {
+            eprintln!("Skipping test: HIVE_APP_ID is empty");
+            return;
+        }
 
         let mut harness = E2EHarness::new("test_isolated_stores");
         let store1 = harness.create_ditto_store().await;

--- a/hive-protocol/tests/backend_agnostic_e2e.rs
+++ b/hive-protocol/tests/backend_agnostic_e2e.rs
@@ -31,10 +31,16 @@ use std::time::Duration;
 async fn test_ditto_basic_document_operations() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     println!("=== Backend Agnostic E2E: Ditto Basic Operations ===");
 
@@ -49,10 +55,16 @@ async fn test_ditto_basic_document_operations() {
 async fn test_ditto_two_instance_sync() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     println!("=== Backend Agnostic E2E: Ditto Two-Instance Sync ===");
 
@@ -308,10 +320,16 @@ async fn run_two_instance_sync_test<B: DataSyncBackend>(
 async fn test_ditto_three_node_mesh() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     println!("=== Backend Agnostic E2E: Ditto Three-Node Mesh ===");
 
@@ -555,10 +573,16 @@ async fn run_three_node_mesh_test<B: DataSyncBackend>(
 async fn test_ditto_concurrent_updates() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     println!("=== Backend Agnostic E2E: Ditto Concurrent Updates ===");
 

--- a/hive-protocol/tests/bidirectional_flow_e2e.rs
+++ b/hive-protocol/tests/bidirectional_flow_e2e.rs
@@ -65,10 +65,16 @@ const SYNC_POLL_INTERVAL: Duration = Duration::from_millis(200);
 #[tokio::test]
 async fn test_e2e_command_propagation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("command_propagation");
 
@@ -178,10 +184,16 @@ async fn test_e2e_command_propagation() {
 #[tokio::test]
 async fn test_e2e_acknowledgment_propagation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("ack_propagation");
 
@@ -296,10 +308,16 @@ async fn test_e2e_acknowledgment_propagation() {
 #[tokio::test]
 async fn test_e2e_full_duplex_command_ack_flow() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("full_duplex");
 
@@ -522,10 +540,16 @@ async fn test_e2e_full_duplex_command_ack_flow() {
 #[tokio::test]
 async fn test_e2e_concurrent_commands() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("concurrent_commands");
 

--- a/hive-protocol/tests/blob_store_tests.rs
+++ b/hive-protocol/tests/blob_store_tests.rs
@@ -39,9 +39,16 @@ use tempfile::TempDir;
 async fn test_ditto_blob_store_basic_operations() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for Ditto tests");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     println!("=== BlobStore E2E: Ditto Basic Operations ===");
 
@@ -50,7 +57,7 @@ async fn test_ditto_blob_store_basic_operations() {
     let blob_dir = temp_dir.path().join("ditto_blobs");
     std::fs::create_dir_all(&blob_dir).unwrap();
 
-    let ditto_store = create_ditto_store(&ditto_app_id, temp_dir.path());
+    let Some(ditto_store) = create_ditto_store(&ditto_app_id, temp_dir.path()) else { return; };
     let blob_store =
         hive_protocol::storage::DittoBlobStore::with_blob_dir(Arc::new(ditto_store), blob_dir);
 
@@ -62,9 +69,16 @@ async fn test_ditto_blob_store_basic_operations() {
 async fn test_ditto_blob_store_metadata() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for Ditto tests");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     println!("=== BlobStore E2E: Ditto Metadata ===");
 
@@ -72,7 +86,7 @@ async fn test_ditto_blob_store_metadata() {
     let blob_dir = temp_dir.path().join("ditto_blobs");
     std::fs::create_dir_all(&blob_dir).unwrap();
 
-    let ditto_store = create_ditto_store(&ditto_app_id, temp_dir.path());
+    let Some(ditto_store) = create_ditto_store(&ditto_app_id, temp_dir.path()) else { return; };
     let blob_store =
         hive_protocol::storage::DittoBlobStore::with_blob_dir(Arc::new(ditto_store), blob_dir);
 
@@ -84,9 +98,16 @@ async fn test_ditto_blob_store_metadata() {
 async fn test_ditto_blob_store_from_file() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for Ditto tests");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     println!("=== BlobStore E2E: Ditto From File ===");
 
@@ -94,7 +115,7 @@ async fn test_ditto_blob_store_from_file() {
     let blob_dir = temp_dir.path().join("ditto_blobs");
     std::fs::create_dir_all(&blob_dir).unwrap();
 
-    let ditto_store = create_ditto_store(&ditto_app_id, temp_dir.path());
+    let Some(ditto_store) = create_ditto_store(&ditto_app_id, temp_dir.path()) else { return; };
     let blob_store =
         hive_protocol::storage::DittoBlobStore::with_blob_dir(Arc::new(ditto_store), blob_dir);
 
@@ -181,9 +202,16 @@ async fn test_both_backends_content_addressing() {
 
     println!("=== BlobStore E2E: Content Addressing Comparison ===");
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for Ditto tests");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let test_data = b"Test content for both backends";
     let metadata = BlobMetadata::with_name("test.txt");
@@ -192,7 +220,7 @@ async fn test_both_backends_content_addressing() {
     let temp_dir_ditto = TempDir::new().unwrap();
     let blob_dir_ditto = temp_dir_ditto.path().join("ditto_blobs");
     std::fs::create_dir_all(&blob_dir_ditto).unwrap();
-    let ditto_store = create_ditto_store(&ditto_app_id, temp_dir_ditto.path());
+    let Some(ditto_store) = create_ditto_store(&ditto_app_id, temp_dir_ditto.path()) else { return; };
     let ditto_blob_store = hive_protocol::storage::DittoBlobStore::with_blob_dir(
         Arc::new(ditto_store),
         blob_dir_ditto,
@@ -465,27 +493,37 @@ async fn run_storage_summary_test<B: BlobStore + 'static>(blob_store: Arc<B>, ba
 // ============================================================================
 
 /// Create a Ditto store for testing
-/// Panics if credentials are not set (tests must fail, not skip)
+/// Returns None if credentials are not available (test should skip)
 fn create_ditto_store(
     app_id: &str,
     base_path: &std::path::Path,
-) -> hive_protocol::storage::DittoStore {
+) -> Option<hive_protocol::storage::DittoStore> {
     use hive_protocol::credentials::HiveCredentials;
     use hive_protocol::storage::DittoStore;
 
     // Load credentials via HiveCredentials (supports HIVE_* with DITTO_* fallback)
-    let credentials = HiveCredentials::from_env().expect(
-        "Credentials required (HIVE_APP_ID/HIVE_SECRET_KEY or DITTO_APP_ID/DITTO_SHARED_KEY)",
-    );
+    let credentials = match HiveCredentials::from_env() {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!("Skipping test: credentials not available");
+            return None;
+        }
+    };
 
-    let shared_key = credentials
-        .require_secret_key()
-        .expect("Secret key required for Ditto tests")
-        .to_string();
-    let offline_token = credentials
-        .require_offline_token()
-        .expect("Offline token required for Ditto tests")
-        .to_string();
+    let shared_key = match credentials.require_secret_key() {
+        Ok(k) => k.to_string(),
+        Err(_) => {
+            eprintln!("Skipping test: secret key not available");
+            return None;
+        }
+    };
+    let offline_token = match credentials.require_offline_token() {
+        Ok(t) => t.to_string(),
+        Err(_) => {
+            eprintln!("Skipping test: offline token not available");
+            return None;
+        }
+    };
 
     let persistence_dir = base_path.join("ditto_data");
     std::fs::create_dir_all(&persistence_dir).unwrap();
@@ -499,5 +537,5 @@ fn create_ditto_store(
         tcp_connect_address: None,
     };
 
-    DittoStore::new(config).expect("Failed to create DittoStore")
+    Some(DittoStore::new(config).expect("Failed to create DittoStore"))
 }

--- a/hive-protocol/tests/blob_sync_e2e.rs
+++ b/hive-protocol/tests/blob_sync_e2e.rs
@@ -41,10 +41,16 @@ use std::time::Duration;
 async fn test_e2e_blob_reference_sync() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("blob_reference_sync");
 
@@ -232,10 +238,16 @@ async fn test_e2e_blob_reference_sync() {
 async fn test_e2e_blob_content_transfer() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("blob_content_transfer");
 
@@ -427,10 +439,16 @@ async fn test_e2e_blob_content_transfer() {
 async fn test_e2e_multiple_blobs_sync() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("multiple_blobs_sync");
 

--- a/hive-protocol/tests/command_lifecycle_integration.rs
+++ b/hive-protocol/tests/command_lifecycle_integration.rs
@@ -107,25 +107,35 @@ impl CommandStorage for MockCommandStorage {
 }
 
 /// Helper to create a test DittoStore
-async fn create_test_store(test_name: &str) -> DittoStore {
+async fn create_test_store(test_name: &str) -> Option<DittoStore> {
     use hive_protocol::credentials::HiveCredentials;
 
     dotenvy::dotenv().ok();
 
     // Load credentials via HiveCredentials (supports HIVE_* with DITTO_* fallback)
-    let credentials = HiveCredentials::from_env().expect(
-        "Credentials required (HIVE_APP_ID/HIVE_SECRET_KEY or DITTO_APP_ID/DITTO_SHARED_KEY)",
-    );
+    let credentials = match HiveCredentials::from_env() {
+        Ok(c) => c,
+        Err(_) => {
+            eprintln!("Skipping test: credentials not available");
+            return None;
+        }
+    };
 
     let app_id = credentials.app_id().to_string();
-    let shared_key = credentials
-        .require_secret_key()
-        .expect("Secret key required for test")
-        .to_string();
-    let offline_token = credentials
-        .require_offline_token()
-        .expect("Offline token required for test")
-        .to_string();
+    let shared_key = match credentials.require_secret_key() {
+        Ok(k) => k.to_string(),
+        Err(_) => {
+            eprintln!("Skipping test: secret key not available");
+            return None;
+        }
+    };
+    let offline_token = match credentials.require_offline_token() {
+        Ok(t) => t.to_string(),
+        Err(_) => {
+            eprintln!("Skipping test: offline token not available");
+            return None;
+        }
+    };
 
     let persistence_dir =
         std::path::PathBuf::from(format!("/tmp/cap-persistence-test-{}", test_name));
@@ -143,13 +153,13 @@ async fn create_test_store(test_name: &str) -> DittoStore {
 
     let store = DittoStore::new(config).expect("Failed to create Ditto store");
     store.start_sync().expect("Failed to start sync");
-    store
+    Some(store)
 }
 
 #[tokio::test]
 async fn test_command_issue_and_persist() {
     // Setup: Create coordinator and store
-    let store = create_test_store("test_command_issue").await;
+    let Some(store) = create_test_store("test_command_issue").await else { return; };
     let coordinator = CommandCoordinator::new(
         Some("squad-alpha".to_string()),
         "node-leader".to_string(),
@@ -213,7 +223,7 @@ async fn test_command_issue_and_persist() {
 #[tokio::test]
 async fn test_command_reception_and_execution() {
     // Setup: Create coordinator for a squad member
-    let store = create_test_store("test_command_reception").await;
+    let Some(store) = create_test_store("test_command_reception").await else { return; };
     let coordinator = CommandCoordinator::new(
         Some("squad-alpha".to_string()),
         "node-1".to_string(),
@@ -275,7 +285,7 @@ async fn test_command_reception_and_execution() {
 #[tokio::test]
 async fn test_acknowledgment_persistence() {
     // Setup: Create store and coordinator
-    let store = create_test_store("test_ack_persistence").await;
+    let Some(store) = create_test_store("test_ack_persistence").await else { return; };
     let coordinator = CommandCoordinator::new(
         Some("squad-alpha".to_string()),
         "node-1".to_string(),
@@ -338,7 +348,7 @@ async fn test_acknowledgment_persistence() {
 #[tokio::test]
 async fn test_squad_command_routing() {
     // Setup: Create leader coordinator
-    let store = create_test_store("test_squad_routing").await;
+    let Some(store) = create_test_store("test_squad_routing").await else { return; };
     let leader = CommandCoordinator::new(
         Some("squad-alpha".to_string()),
         "node-leader".to_string(),
@@ -388,7 +398,7 @@ async fn test_squad_command_routing() {
 #[tokio::test]
 async fn test_acknowledgment_policy_none() {
     // Setup: Create coordinator
-    let store = create_test_store("test_ack_policy_none").await;
+    let Some(store) = create_test_store("test_ack_policy_none").await else { return; };
     let coordinator = CommandCoordinator::new(
         Some("squad-alpha".to_string()),
         "node-1".to_string(),
@@ -443,7 +453,7 @@ async fn test_acknowledgment_policy_none() {
 #[tokio::test]
 async fn test_command_not_applicable() {
     // Setup: Create coordinator for node-1
-    let store = create_test_store("test_not_applicable").await;
+    let Some(store) = create_test_store("test_not_applicable").await else { return; };
     let coordinator = CommandCoordinator::new(
         Some("squad-alpha".to_string()),
         "node-1".to_string(),
@@ -496,7 +506,7 @@ async fn test_command_not_applicable() {
 #[tokio::test]
 async fn test_multiple_acknowledgments_collection() {
     // Setup: Simulate multiple nodes acknowledging a command
-    let store = create_test_store("test_multiple_acks").await;
+    let Some(store) = create_test_store("test_multiple_acks").await else { return; };
 
     // Create acknowledgments from different nodes
     let ack1 = CommandAcknowledgment {

--- a/hive-protocol/tests/hierarchical_aggregation_e2e.rs
+++ b/hive-protocol/tests/hierarchical_aggregation_e2e.rs
@@ -19,10 +19,16 @@ use std::sync::Arc;
 #[tokio::test]
 async fn test_squad_summary_delta_updates() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_squad_delta_updates");
     let ditto_store = Arc::new(harness.create_ditto_store().await.unwrap());
@@ -134,10 +140,16 @@ async fn test_squad_summary_delta_updates() {
 #[tokio::test]
 async fn test_upward_aggregation_flow() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_upward_aggregation");
     let ditto_store = Arc::new(harness.create_ditto_store().await.unwrap());
@@ -249,10 +261,16 @@ async fn test_upward_aggregation_flow() {
 #[tokio::test]
 async fn test_document_lifecycle_pattern() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_document_lifecycle");
     let ditto_store = Arc::new(harness.create_ditto_store().await.unwrap());
@@ -362,10 +380,16 @@ async fn test_document_lifecycle_pattern() {
 #[tokio::test]
 async fn test_bandwidth_efficiency() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_bandwidth_efficiency");
     let ditto_store = Arc::new(harness.create_ditto_store().await.unwrap());

--- a/hive-protocol/tests/hierarchy_e2e.rs
+++ b/hive-protocol/tests/hierarchy_e2e.rs
@@ -35,10 +35,16 @@ use hive_protocol::testing::E2EHarness;
 #[tokio::test]
 async fn test_e2e_zone_formation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_zone_formation");
     let store = harness.create_ditto_store().await.unwrap();

--- a/hive-protocol/tests/load_testing_e2e.rs
+++ b/hive-protocol/tests/load_testing_e2e.rs
@@ -41,6 +41,10 @@ fn get_test_node_count() -> usize {
 #[tokio::test]
 async fn test_load_large_formation_nodes() {
     dotenvy::dotenv().ok();
+    if std::env::var("HIVE_APP_ID").or_else(|_| std::env::var("DITTO_APP_ID")).is_err() {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    }
     let node_count = get_test_node_count();
     let cell_count = node_count / 2; // 2 nodes per cell
     let mut harness = E2EHarness::new("large_formation_test");
@@ -284,6 +288,10 @@ async fn test_load_large_formation_nodes() {
 #[tokio::test]
 async fn test_load_multi_zone_hierarchy() {
     dotenvy::dotenv().ok();
+    if std::env::var("HIVE_APP_ID").or_else(|_| std::env::var("DITTO_APP_ID")).is_err() {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    }
     let total_nodes = get_test_node_count();
     let mut harness = E2EHarness::new("multi_zone_hierarchy_test");
 

--- a/hive-protocol/tests/multi_node_mesh_e2e.rs
+++ b/hive-protocol/tests/multi_node_mesh_e2e.rs
@@ -34,6 +34,10 @@ const SYNC_POLL_INTERVAL: Duration = Duration::from_millis(200);
 #[tokio::test]
 async fn test_ditto_three_node_mesh() {
     dotenvy::dotenv().ok();
+    if std::env::var("HIVE_APP_ID").or_else(|_| std::env::var("DITTO_APP_ID")).is_err() {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    }
     println!("=== Multi-Node Mesh E2E: Ditto 3-Node Mesh ===");
 
     let mut harness = E2EHarness::new("ditto_3node_mesh");

--- a/hive-protocol/tests/network_partition_e2e.rs
+++ b/hive-protocol/tests/network_partition_e2e.rs
@@ -43,10 +43,16 @@ const SYNC_POLL_INTERVAL: Duration = Duration::from_millis(200);
 #[tokio::test]
 async fn test_e2e_partition_during_formation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty());
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("partition_formation");
 
@@ -166,10 +172,16 @@ async fn test_e2e_partition_during_formation() {
 #[tokio::test]
 async fn test_e2e_multi_zone_partition_isolation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty());
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("zone_partition");
 

--- a/hive-protocol/tests/squad_formation_e2e.rs
+++ b/hive-protocol/tests/squad_formation_e2e.rs
@@ -51,10 +51,16 @@ const SYNC_POLL_INTERVAL: Duration = Duration::from_millis(200);
 async fn test_harness_creates_isolated_stores() {
     dotenvy::dotenv().ok();
     // Fail if Ditto credentials not properly configured
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("test_harness");
 
@@ -77,10 +83,16 @@ async fn test_harness_creates_isolated_stores() {
 async fn test_ditto_peer_sync_with_observers() {
     dotenvy::dotenv().ok();
     // Fail if Ditto credentials not properly configured
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_peer_sync");
 
@@ -138,10 +150,16 @@ async fn test_ditto_peer_sync_with_observers() {
 #[tokio::test]
 async fn test_e2e_node_advertisement_sync() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("node_advert_sync");
 
@@ -239,10 +257,16 @@ async fn test_e2e_node_advertisement_sync() {
 #[tokio::test]
 async fn test_e2e_capability_multi_peer_propagation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("capability_multi_peer");
 
@@ -398,10 +422,16 @@ async fn test_e2e_capability_multi_peer_propagation() {
 #[tokio::test]
 async fn test_e2e_cell_formation_multi_peer() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("cell_formation_multi");
 
@@ -496,10 +526,16 @@ async fn test_e2e_cell_formation_multi_peer() {
 #[tokio::test]
 async fn test_e2e_role_assignment_sync() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("role_assignment_sync");
 
@@ -639,10 +675,16 @@ async fn test_e2e_role_assignment_sync() {
 #[tokio::test]
 async fn test_e2e_leader_election_propagation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("leader_election_prop");
 
@@ -834,10 +876,16 @@ async fn test_e2e_leader_election_propagation() {
 async fn test_e2e_timestamped_state_updates() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("timestamped_updates");
 
@@ -1067,10 +1115,16 @@ async fn test_e2e_timestamped_state_updates() {
 #[tokio::test]
 async fn test_e2e_complete_formation_convergence() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("complete_formation");
 

--- a/hive-protocol/tests/storage_layer_e2e.rs
+++ b/hive-protocol/tests/storage_layer_e2e.rs
@@ -44,10 +44,16 @@ use std::time::Duration;
 async fn test_e2e_nodestore_gset_sync() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("nodestore_gset");
 
@@ -171,10 +177,16 @@ async fn test_e2e_nodestore_gset_sync() {
 async fn test_e2e_cellstore_orset_operations() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("cellstore_orset");
 
@@ -296,10 +308,16 @@ async fn test_e2e_cellstore_orset_operations() {
 async fn test_e2e_concurrent_writes_lww_resolution() {
     dotenvy::dotenv().ok();
 
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("lww_resolution");
 

--- a/hive-protocol/tests/sync_backend_integration.rs
+++ b/hive-protocol/tests/sync_backend_integration.rs
@@ -11,10 +11,11 @@ use hive_protocol::sync::{
 use std::collections::HashMap;
 
 /// Helper to create a test backend with real Ditto instance
-async fn setup_backend() -> DittoBackend {
+/// Returns None if credentials are not available (test should skip)
+async fn setup_backend() -> Option<DittoBackend> {
     dotenvy::dotenv().ok();
 
-    // Fail explicitly if credentials not available (prefer HIVE_*, fallback to DITTO_*)
+    // Skip if credentials not available (prefer HIVE_*, fallback to DITTO_*)
     let app_id = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
         .ok()
@@ -25,8 +26,11 @@ async fn setup_backend() -> DittoBackend {
             } else {
                 Some(trimmed.to_string())
             }
-        })
-        .expect("HIVE_APP_ID environment variable is required for sync backend integration tests. Set it in .env file or environment.");
+        });
+    let Some(app_id) = app_id else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return None;
+    };
 
     let shared_key = std::env::var("HIVE_SECRET_KEY")
         .or_else(|_| std::env::var("HIVE_SHARED_KEY"))
@@ -39,12 +43,21 @@ async fn setup_backend() -> DittoBackend {
             } else {
                 Some(trimmed.to_string())
             }
-        })
-        .expect("HIVE_SECRET_KEY environment variable is required for sync backend integration tests. Set it in .env file or environment.");
+        });
+    let Some(shared_key) = shared_key else {
+        eprintln!("Skipping test: HIVE_SECRET_KEY not set");
+        return None;
+    };
 
-    let offline_token = std::env::var("HIVE_OFFLINE_TOKEN")
+    let offline_token = match std::env::var("HIVE_OFFLINE_TOKEN")
         .or_else(|_| std::env::var("DITTO_OFFLINE_TOKEN"))
-        .expect("HIVE_OFFLINE_TOKEN environment variable is required for sync backend integration tests. Set it in .env file or environment.");
+    {
+        Ok(t) => t,
+        Err(_) => {
+            eprintln!("Skipping test: HIVE_OFFLINE_TOKEN not set");
+            return None;
+        }
+    };
 
     let mut extra = HashMap::new();
     extra.insert("offline_token".to_string(), offline_token);
@@ -73,7 +86,7 @@ async fn setup_backend() -> DittoBackend {
         .await
         .expect("Failed to start sync");
 
-    backend
+    Some(backend)
 }
 
 async fn cleanup_backend(backend: DittoBackend) {
@@ -84,7 +97,7 @@ async fn cleanup_backend(backend: DittoBackend) {
 
 #[tokio::test]
 async fn test_backend_lifecycle() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
 
     // Verify backend is ready
     assert!(backend.is_ready().await);
@@ -97,7 +110,7 @@ async fn test_backend_lifecycle() {
 
 #[tokio::test]
 async fn test_document_upsert() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let doc_store = backend.document_store();
 
     // Create a document
@@ -129,7 +142,7 @@ async fn test_document_upsert() {
 
 #[tokio::test]
 async fn test_document_query() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let doc_store = backend.document_store();
 
     // Insert a test document
@@ -177,7 +190,7 @@ async fn test_document_query() {
 
 #[tokio::test]
 async fn test_document_query_all() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let doc_store = backend.document_store();
 
     // Insert multiple documents
@@ -223,7 +236,7 @@ async fn test_document_query_all() {
 
 #[tokio::test]
 async fn test_document_query_with_comparison() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let doc_store = backend.document_store();
 
     // Insert documents with different scores
@@ -289,7 +302,7 @@ async fn test_document_query_with_comparison() {
 
 #[tokio::test]
 async fn test_document_remove() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let doc_store = backend.document_store();
 
     // Insert a document
@@ -334,7 +347,7 @@ async fn test_document_remove() {
 
 #[tokio::test]
 async fn test_document_get() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let doc_store = backend.document_store();
 
     // Insert a document
@@ -368,7 +381,7 @@ async fn test_document_get() {
 
 #[tokio::test]
 async fn test_document_count() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let doc_store = backend.document_store();
 
     // Insert multiple documents
@@ -414,7 +427,7 @@ async fn test_document_count() {
 
 #[tokio::test]
 async fn test_sync_subscription() {
-    let backend = setup_backend().await;
+    let Some(backend) = setup_backend().await else { return; };
     let sync_engine = backend.sync_engine();
 
     // Create a subscription

--- a/hive-protocol/tests/three_tier_aggregation_e2e.rs
+++ b/hive-protocol/tests/three_tier_aggregation_e2e.rs
@@ -24,10 +24,16 @@ use std::sync::Arc;
 #[tokio::test]
 async fn test_three_tier_hierarchical_aggregation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_three_tier_aggregation");
     let ditto_store = Arc::new(harness.create_ditto_store().await.unwrap());
@@ -172,10 +178,16 @@ async fn test_three_tier_hierarchical_aggregation() {
 #[tokio::test]
 async fn test_dynamic_squad_count_validation() {
     dotenvy::dotenv().ok();
-    let ditto_app_id = std::env::var("HIVE_APP_ID")
+    let Ok(ditto_app_id) = std::env::var("HIVE_APP_ID")
         .or_else(|_| std::env::var("DITTO_APP_ID"))
-        .expect("HIVE_APP_ID must be set for E2E tests");
-    assert!(!ditto_app_id.is_empty(), "HIVE_APP_ID cannot be empty");
+    else {
+        eprintln!("Skipping test: HIVE_APP_ID/DITTO_APP_ID not set");
+        return;
+    };
+    if ditto_app_id.is_empty() {
+        eprintln!("Skipping test: HIVE_APP_ID is empty");
+        return;
+    }
 
     let mut harness = E2EHarness::new("e2e_dynamic_squad_count");
     let ditto_store = Arc::new(harness.create_ditto_store().await.unwrap());


### PR DESCRIPTION
## Summary
- All Ditto-dependent tests now skip with informative message instead of panicking when credentials not set
- Fixes test_backend_requires_shared_key assertion error
- 17 files, 46 credential-gating patterns fixed

Closes hi-5lsv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)