### PR TITLE
feat: Android BLE bootstrap — Kotlin → JNI → HiveBleTransport (M4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1900,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,6 +2728,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86160a1bdb202a39e32a6d01b1c5caf7d7ba57fd4b9cccb311dddc5b2fe64fa7"
 dependencies = [
+ "android_logger",
  "async-trait",
  "bitflags 2.10.0",
  "blake3",

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveJni.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveJni.kt
@@ -185,6 +185,37 @@ object HiveJni {
     @JvmStatic
     external fun publishPlatformJni(handle: Long, platformJson: String): Boolean
 
+    // ========================================================================
+    // BLE Transport JNI Methods (ADR-047 Android Bootstrap)
+    // ========================================================================
+
+    /**
+     * Signal BLE transport started/stopped.
+     * Makes is_available() return true/false for PACE routing.
+     * @param handle Node handle from createNodeJni
+     * @param started true to start, false to stop
+     */
+    @JvmStatic
+    external fun bleSetStartedJni(handle: Long, started: Boolean)
+
+    /**
+     * Add a reachable BLE peer.
+     * Makes can_reach(peer) return true for PACE routing.
+     * @param handle Node handle from createNodeJni
+     * @param peerId Peer ID as 8-char hex string (e.g. "0A1B2C3D")
+     */
+    @JvmStatic
+    external fun bleAddPeerJni(handle: Long, peerId: String)
+
+    /**
+     * Remove a reachable BLE peer.
+     * Makes can_reach(peer) return false for PACE routing.
+     * @param handle Node handle from createNodeJni
+     * @param peerId Peer ID as 8-char hex string (e.g. "0A1B2C3D")
+     */
+    @JvmStatic
+    external fun bleRemovePeerJni(handle: Long, peerId: String)
+
     /**
      * Test if JNI bindings are working.
      * @return true if JNI is functional
@@ -379,6 +410,28 @@ class HiveNodeJni private constructor(private val handle: Long) : AutoCloseable 
      * @return true if published successfully
      */
     fun publishPlatform(platformJson: String): Boolean = HiveJni.publishPlatformJni(handle, platformJson)
+
+    // ========================================================================
+    // BLE Transport Methods (ADR-047 Android Bootstrap)
+    // ========================================================================
+
+    /**
+     * Signal BLE transport started/stopped to Rust TransportManager.
+     * @param started true when BLE stack is ready, false on shutdown
+     */
+    fun bleSetStarted(started: Boolean) = HiveJni.bleSetStartedJni(handle, started)
+
+    /**
+     * Add a reachable BLE peer for PACE routing.
+     * @param peerId Peer ID as 8-char hex string (e.g. "0A1B2C3D")
+     */
+    fun bleAddPeer(peerId: String) = HiveJni.bleAddPeerJni(handle, peerId)
+
+    /**
+     * Remove a reachable BLE peer from PACE routing.
+     * @param peerId Peer ID as 8-char hex string (e.g. "0A1B2C3D")
+     */
+    fun bleRemovePeer(peerId: String) = HiveJni.bleRemovePeerJni(handle, peerId)
 
     /**
      * Free the native node resources.

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HivePluginLifecycle.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HivePluginLifecycle.kt
@@ -137,6 +137,24 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
             if (hiveBleManager?.hasPermissions() == true) {
                 val started = hiveBleManager?.start() ?: false
                 Log.i(TAG, "HIVE BLE mesh started (fallback): $started [unified BLE requested: $unifiedBleEnabled]")
+
+                // Bridge BLE peer discovery to Rust TransportManager (ADR-047)
+                // This makes PACE routing aware of BLE-reachable peers
+                hiveBleManager?.setPeerEventCallback { peer, _ ->
+                    try {
+                        val nodeId = peer.nodeId
+                        if (nodeId != null) {
+                            val peerId = String.format("%08X", nodeId)
+                            if (peer.isConnected) {
+                                hiveNodeJni?.bleAddPeer(peerId)
+                            } else {
+                                hiveNodeJni?.bleRemovePeer(peerId)
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Error bridging BLE peer event to Rust: ${e.message}")
+                    }
+                }
             } else {
                 Log.w(TAG, "BLE permissions not granted - mesh not started. " +
                     "Required: ${hiveBleManager?.getRequiredPermissions()?.joinToString()}")
@@ -207,6 +225,16 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
                 val nodeId = hiveNodeJni?.nodeId() ?: "unknown"
                 Log.i(TAG, "HIVE node created - ID: ${nodeId.take(16)}... (unified transport, BLE: $enableBle)")
 
+                // Signal BLE transport as started if BLE is enabled (ADR-047)
+                if (enableBle) {
+                    try {
+                        hiveNodeJni?.bleSetStarted(true)
+                        Log.i(TAG, "BLE transport signaled as started for PACE routing")
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Failed to signal BLE started (may not be compiled with bluetooth feature): ${e.message}")
+                    }
+                }
+
                 // Start sync
                 val syncStarted = hiveNodeJni?.startSync() ?: false
                 Log.i(TAG, "HIVE sync started: $syncStarted, peer count: ${hiveNodeJni?.peerCount() ?: 0}")
@@ -264,6 +292,10 @@ class HivePluginLifecycle(serviceController: IServiceController) : AbstractPlugi
 
     fun stopBleMesh() {
         hiveBleManager?.stop()
+        // Signal BLE transport stopped to Rust TransportManager (ADR-047)
+        try {
+            hiveNodeJni?.bleSetStarted(false)
+        } catch (_: Exception) { }
     }
 
     fun getCurrentMeshId(): String {

--- a/docs/PROJECT-BLE-INTEGRATION.md
+++ b/docs/PROJECT-BLE-INTEGRATION.md
@@ -140,7 +140,7 @@ the transport layer into `hive-mesh`. Much of the original M4 work is now comple
 | ~~`route_message()` supports per-collection transport~~ | DONE | `route_collection()` + `RouteDecision::TransportInstance` |
 | ~~PACE as transport config option~~ | DONE | `CollectionTransportRoute::Pace` with optional policy override |
 | ~~Create FFI bootstrap for dual-active transport~~ | DONE | `hive-ffi`: construct `TransportManager` with both Iroh + BLE |
-| Android bootstrap: Kotlin -> JNI -> HiveBleTransport | TODO | Instantiate `AndroidBleDelegate`, pass through JNI |
+| Android bootstrap: Kotlin -> JNI -> HiveBleTransport | DONE | AndroidAdapter stub, 3 JNI methods, Kotlin wiring |
 | ~~Integration test: dual-active (Iroh + BLE concurrent)~~ | DONE | `dual_active_transport_e2e.rs` (mock) + `dual_active_simultaneous.rs` (real Iroh) |
 | ~~CannedMessage round-trip over BLE~~ | DONE | `canned_message_sync.rs` — 3 tests with encrypted BLE round-trip |
 
@@ -151,7 +151,7 @@ the transport layer into `hive-mesh`. Much of the original M4 work is now comple
 - [x] Per-collection transport routing (explicit or autopace)
 - [x] Both Iroh and BLE active simultaneously
 - [x] FFI bootstrap creates dual-active TransportManager
-- [ ] Android bootstrap wires Kotlin delegate through JNI
+- [x] Android bootstrap wires Kotlin delegate through JNI
 
 ---
 
@@ -216,6 +216,7 @@ Final cleanup and documentation.
 | 2026-02-13 | ADR-049 transport extraction merged | `HiveBleTransport` now in `hive-mesh/src/transport/btle.rs` |
 | 2026-02-13 | M4 re-evaluated against hive-mesh | Most transport wiring already done by ADR-049 |
 | 2026-02-14 | Per-collection transport routing | `CollectionRouteTable`, `route_collection()`, PACE config option |
+| 2026-02-14 | Android bootstrap: Kotlin -> JNI -> HiveBleTransport | AndroidAdapter Ok(()), 3 JNI methods, Kotlin peer bridge |
 
 ---
 

--- a/hive-ffi/Cargo.toml
+++ b/hive-ffi/Cargo.toml
@@ -68,5 +68,8 @@ hive-btle = { workspace = true, features = ["macos"], optional = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 hive-btle = { workspace = true, features = ["windows"], optional = true }
 
+[target.'cfg(target_os = "android")'.dependencies]
+hive-btle = { workspace = true, features = ["android"], optional = true }
+
 [build-dependencies]
 uniffi = { version = "0.28", features = ["build"] }

--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -47,6 +47,14 @@ static PEER_EVENT_MANAGER_CLASS: LazyLock<Mutex<Option<GlobalRef>>> =
 #[cfg(feature = "sync")]
 static GLOBAL_NODE_HANDLE: LazyLock<Mutex<i64>> = LazyLock::new(|| Mutex::new(0));
 
+// Global BLE transport reference for Android JNI access
+// Kotlin signals BLE state (started/stopped, peer discovery) into this transport
+// which makes TransportManager aware of BLE availability for PACE routing.
+#[cfg(all(feature = "bluetooth", target_os = "android"))]
+static ANDROID_BLE_TRANSPORT: LazyLock<
+    Mutex<Option<Arc<HiveBleTransport<hive_btle::platform::android::AndroidAdapter>>>>,
+> = LazyLock::new(|| Mutex::new(None));
+
 use hive_protocol::cot::{
     CotEncoder, Position as CotPosition, TrackUpdate, Velocity as CotVelocity,
 };
@@ -1014,9 +1022,33 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<HiveNode>, HiveError> {
     if let Some(ref transport_config) = config.transport {
         if transport_config.enable_ble {
             #[cfg(target_os = "android")]
-            android_log(
-                "BLE transport requested - Android adapter initialization deferred to JNI callback",
-            );
+            {
+                use hive_btle::platform::android::AndroidAdapter;
+                use hive_btle::{BleConfig, BluetoothLETransport};
+
+                android_log("BLE transport requested - initializing AndroidAdapter stub");
+
+                let ble_config = BleConfig::default();
+                let adapter = AndroidAdapter::new_stub();
+                let btle = BluetoothLETransport::new(ble_config, adapter);
+                let ble_transport = Arc::new(HiveBleTransport::new(btle));
+                let ble_as_transport: Arc<dyn Transport> = ble_transport.clone();
+                transport_manager.register(ble_as_transport.clone());
+
+                // Register as PACE instance for collection routing
+                let ble_instance = TransportInstance::new(
+                    "ble-primary",
+                    TransportType::BluetoothLE,
+                    TransportCapabilities::bluetooth_le(),
+                )
+                .with_description("Primary BLE transport (Android)");
+                transport_manager.register_instance(ble_instance, ble_as_transport);
+
+                // Store in global for JNI access
+                *ANDROID_BLE_TRANSPORT.lock().unwrap() = Some(ble_transport);
+
+                android_log("BLE transport registered as PACE instance 'ble-primary'");
+            }
 
             #[cfg(not(target_os = "android"))]
             {
@@ -2231,11 +2263,143 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_freeNodeJni(
         // Give the background task a moment to exit
         std::thread::sleep(std::time::Duration::from_millis(100));
 
+        // Clear Android BLE transport global to prevent dangling refs
+        #[cfg(all(feature = "bluetooth", target_os = "android"))]
+        {
+            *ANDROID_BLE_TRANSPORT.lock().unwrap() = None;
+            android_log("freeNodeJni: Cleared ANDROID_BLE_TRANSPORT");
+        }
+
         // Drop the node - this should release the database
         drop(node);
 
         #[cfg(target_os = "android")]
         android_log("freeNodeJni: Node dropped");
+    }
+}
+
+// =============================================================================
+// BLE Transport JNI Methods (Android)
+// =============================================================================
+
+/// JNI: Signal BLE transport started/stopped
+///
+/// Called by Kotlin when the Android BLE stack is ready or shutting down.
+/// This makes `is_available()` return true/false for PACE routing.
+///
+/// Kotlin signature: external fun bleSetStartedJni(handle: Long, started: Boolean)
+#[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+#[no_mangle]
+pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_bleSetStartedJni(
+    _env: JNIEnv,
+    _class: JClass,
+    handle: i64,
+    started: jboolean,
+) {
+    if handle == 0 {
+        android_log("bleSetStartedJni: Invalid handle (0)");
+        return;
+    }
+
+    let node = unsafe { Arc::from_raw(handle as *const HiveNode) };
+
+    use hive_protocol::transport::MeshTransport;
+
+    let guard = ANDROID_BLE_TRANSPORT.lock().unwrap();
+    if let Some(ref ble_transport) = *guard {
+        if started != 0 {
+            match node.runtime.block_on(ble_transport.start()) {
+                Ok(()) => android_log("bleSetStartedJni: BLE transport started"),
+                Err(e) => android_log(&format!("bleSetStartedJni: start failed: {}", e)),
+            }
+        } else {
+            match node.runtime.block_on(ble_transport.stop()) {
+                Ok(()) => android_log("bleSetStartedJni: BLE transport stopped"),
+                Err(e) => android_log(&format!("bleSetStartedJni: stop failed: {}", e)),
+            }
+        }
+    } else {
+        android_log("bleSetStartedJni: No BLE transport registered");
+    }
+    drop(guard);
+
+    // Don't drop the Arc - we're just borrowing
+    std::mem::forget(node);
+}
+
+/// JNI: Add a reachable BLE peer
+///
+/// Called by Kotlin when a BLE peer is discovered/connected.
+/// This makes `can_reach(peer)` return true for PACE routing.
+///
+/// Kotlin signature: external fun bleAddPeerJni(handle: Long, peerId: String)
+#[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+#[no_mangle]
+pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_bleAddPeerJni(
+    mut env: JNIEnv,
+    _class: JClass,
+    handle: i64,
+    peer_id: JString,
+) {
+    if handle == 0 {
+        android_log("bleAddPeerJni: Invalid handle (0)");
+        return;
+    }
+
+    let peer_id_str: String = match env.get_string(&peer_id) {
+        Ok(s) => s.into(),
+        Err(_) => {
+            android_log("bleAddPeerJni: Failed to get peer_id string");
+            return;
+        }
+    };
+
+    android_log(&format!("bleAddPeerJni: Adding peer {}", peer_id_str));
+
+    let guard = ANDROID_BLE_TRANSPORT.lock().unwrap();
+    if let Some(ref ble_transport) = *guard {
+        use hive_protocol::transport::NodeId;
+        ble_transport.add_reachable_peer(NodeId::new(peer_id_str));
+    } else {
+        android_log("bleAddPeerJni: No BLE transport registered");
+    }
+}
+
+/// JNI: Remove a reachable BLE peer
+///
+/// Called by Kotlin when a BLE peer is disconnected/lost.
+/// This makes `can_reach(peer)` return false for PACE routing.
+///
+/// Kotlin signature: external fun bleRemovePeerJni(handle: Long, peerId: String)
+#[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+#[no_mangle]
+pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_bleRemovePeerJni(
+    mut env: JNIEnv,
+    _class: JClass,
+    handle: i64,
+    peer_id: JString,
+) {
+    if handle == 0 {
+        android_log("bleRemovePeerJni: Invalid handle (0)");
+        return;
+    }
+
+    let peer_id_str: String = match env.get_string(&peer_id) {
+        Ok(s) => s.into(),
+        Err(_) => {
+            android_log("bleRemovePeerJni: Failed to get peer_id string");
+            return;
+        }
+    };
+
+    android_log(&format!("bleRemovePeerJni: Removing peer {}", peer_id_str));
+
+    let guard = ANDROID_BLE_TRANSPORT.lock().unwrap();
+    if let Some(ref ble_transport) = *guard {
+        use hive_protocol::transport::NodeId;
+        ble_transport.remove_reachable_peer(&NodeId::new(peer_id_str));
+    } else {
+        android_log("bleRemovePeerJni: No BLE transport registered");
     }
 }
 
@@ -2625,6 +2789,24 @@ pub extern "system" fn Java_com_revolveteam_atak_hive_HiveJni_nativeInit(
             sig: "(JLjava/lang/String;)Z".into(),
             fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_publishPlatformJni as *mut c_void,
         },
+        #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+        NativeMethod {
+            name: "bleSetStartedJni".into(),
+            sig: "(JZ)V".into(),
+            fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_bleSetStartedJni as *mut c_void,
+        },
+        #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+        NativeMethod {
+            name: "bleAddPeerJni".into(),
+            sig: "(JLjava/lang/String;)V".into(),
+            fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_bleAddPeerJni as *mut c_void,
+        },
+        #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+        NativeMethod {
+            name: "bleRemovePeerJni".into(),
+            sig: "(JLjava/lang/String;)V".into(),
+            fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_bleRemovePeerJni as *mut c_void,
+        },
     ];
 
     // Register native methods - the class is passed in from Kotlin so it's valid
@@ -2805,6 +2987,24 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
                     sig: "(JLjava/lang/String;)Z".into(),
                     fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_publishPlatformJni
                         as *mut c_void,
+                },
+                #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+                NativeMethod {
+                    name: "bleSetStartedJni".into(),
+                    sig: "(JZ)V".into(),
+                    fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_bleSetStartedJni as *mut c_void,
+                },
+                #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+                NativeMethod {
+                    name: "bleAddPeerJni".into(),
+                    sig: "(JLjava/lang/String;)V".into(),
+                    fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_bleAddPeerJni as *mut c_void,
+                },
+                #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]
+                NativeMethod {
+                    name: "bleRemovePeerJni".into(),
+                    sig: "(JLjava/lang/String;)V".into(),
+                    fn_ptr: Java_com_revolveteam_atak_hive_HiveJni_bleRemovePeerJni as *mut c_void,
                 },
             ];
 


### PR DESCRIPTION
## Summary

- Register `HiveBleTransport<AndroidAdapter>` with `TransportManager` on Android when `create_node(enableBle=true)` is called
- Add 3 JNI methods (`bleSetStarted`, `bleAddPeer`, `bleRemovePeer`) so Kotlin can signal BLE state into Rust for PACE routing
- Bridge `HiveBleManager` peer discovery events to `TransportManager` via the new JNI methods
- Fix `AndroidAdapter` lifecycle methods (`init`/`start`/`stop` → `Ok(())`, `is_powered` → `true`) in hive-btle (separate Radicle patch)

## Test plan

- [x] `cargo build -p hive-ffi --features "sync,bluetooth"` compiles on host (non-Android paths unaffected)
- [x] `cargo test -p hive-mesh --test dual_active_transport_e2e` — 6/6 passing, no regressions
- [ ] Deploy APK to Android tablet — verify BLE shows as available transport, peer discovery bridges to Rust

🤖 Generated with [Claude Code](https://claude.com/claude-code)