### PR TITLE
chore: Update hive-btle to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2724,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "hive-btle"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86160a1bdb202a39e32a6d01b1c5caf7d7ba57fd4b9cccb311dddc5b2fe64fa7"
+checksum = "bd14f41c85cc68ec37ab843571829ef581eec4f66a6ff092a53a0f6eaaefe625"
 dependencies = [
  "android_logger",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ repository = "https://github.com/kitplummer/hive"
 
 [workspace.dependencies]
 # BLE mesh transport (ADR-039)
-hive-btle = "0.1.1"
+hive-btle = "0.1.2"
 
 # CRDT synchronization
 dittolive-ditto = "=4.11.5"


### PR DESCRIPTION
## Summary

- Update hive-btle workspace dependency from 0.1.1 to 0.1.2
- Picks up AndroidAdapter lifecycle fix and UniFFI cfg-gate fix

## Test plan

- [x] `cargo build -p hive-ffi --features "sync,bluetooth"` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)