### PR TITLE
feat: Add CI workflows for benchmarks, simulation, and functional tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,21 +1,19 @@
 name: Android Build
 
-# Manual trigger only - not ready for CI yet
-# When ready, uncomment push/pull_request triggers
 on:
   workflow_dispatch:
-  # push:
-  #   branches: [ main, develop ]
-  #   paths:
-  #     - 'hive-ffi/**'
-  #     - 'hive-protocol/**'
-  #     - '.github/workflows/android.yml'
-  # pull_request:
-  #   branches: [ main, develop ]
-  #   paths:
-  #     - 'hive-ffi/**'
-  #     - 'hive-protocol/**'
-  #     - '.github/workflows/android.yml'
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'hive-ffi/**'
+      - 'hive-protocol/**'
+      - '.github/workflows/android.yml'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'hive-ffi/**'
+      - 'hive-protocol/**'
+      - '.github/workflows/android.yml'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,47 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'hive-protocol/**'
+      - '.github/workflows/benchmarks.yml'
+  schedule:
+    - cron: '0 6 * * 0'  # Sunday 06:00 UTC
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  benchmarks:
+    name: Run Benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler mold clang libdbus-1-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: benchmarks
+
+      - name: Run cap_benchmarks
+        run: cargo bench --bench cap_benchmarks -p hive-protocol
+
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: criterion-results
+          path: target/criterion/
+          retention-days: 90

--- a/.github/workflows/functional-test.yml
+++ b/.github/workflows/functional-test.yml
@@ -1,0 +1,24 @@
+name: Functional Test (BLE Lab)
+
+on:
+  workflow_dispatch:
+  release:
+    types: [ created ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  dual-transport-test:
+    name: Dual Transport (BLE + QUIC)
+    runs-on: [self-hosted, ble-lab]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run dual-transport test
+        env:
+          BLE_TEST_PI: ${{ vars.BLE_TEST_PI || 'rpi-ci' }}
+          BLE_TEST_PI_USER: ${{ vars.BLE_TEST_PI_USER || 'kit' }}
+          BLE_TEST_PI_IP: ${{ vars.BLE_TEST_PI_IP || '192.168.228.13' }}
+        run: make dual-transport-test BLE_TEST_PI=$BLE_TEST_PI BLE_TEST_PI_USER=$BLE_TEST_PI_USER BLE_TEST_PI_IP=$BLE_TEST_PI_IP

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -1,0 +1,34 @@
+name: Simulation Smoke Test
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'hive-sim/**'
+      - 'hive-protocol/**'
+      - '.github/workflows/simulation.yml'
+  schedule:
+    - cron: '0 6 * * 0'  # Sunday 06:00 UTC
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  simulation:
+    name: 24-Node Smoke Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install ContainerLab
+        run: |
+          curl -sL https://get.containerlab.dev | sudo bash
+
+      - name: Build Docker image
+        run: docker build -f hive-sim/Dockerfile -t hive-sim-node:latest .
+
+      - name: Run validation
+        working-directory: hive-sim
+        run: ./simple-validate.sh

--- a/hive-sim/simple-validate.sh
+++ b/hive-sim/simple-validate.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# simple-validate.sh - Quick validation smoke test for hive-sim
+#
+# Deploys the am24n topology (24 nodes, 26 containers, Automerge backend),
+# waits for convergence, checks for errors, and tears down.
+#
+# Exit 0 on PASS, 1 on FAIL.
+
+set -euo pipefail
+
+TOPOLOGY="topologies/am24n.yaml"
+TOPO_NAME="am24n"
+EXPECTED_CONTAINERS=26
+WAIT_SECONDS=30
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$SCRIPT_DIR"
+
+# Colors (disabled if not a terminal)
+if [ -t 1 ]; then
+    GREEN='\033[0;32m'
+    RED='\033[0;31m'
+    YELLOW='\033[1;33m'
+    NC='\033[0m'
+else
+    GREEN='' RED='' YELLOW='' NC=''
+fi
+
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+info() { echo -e "${YELLOW}[INFO]${NC} $1"; }
+
+FAILED=0
+
+cleanup() {
+    info "Destroying topology..."
+    sudo containerlab destroy -t "$TOPOLOGY" --cleanup 2>/dev/null || true
+}
+
+# Always clean up on exit
+trap cleanup EXIT
+
+# --- Deploy ---
+info "Deploying $TOPOLOGY ($EXPECTED_CONTAINERS containers expected)..."
+if ! sudo containerlab deploy -t "$TOPOLOGY" --reconfigure; then
+    fail "ContainerLab deploy failed"
+    exit 1
+fi
+
+# --- Wait for convergence ---
+info "Waiting ${WAIT_SECONDS}s for nodes to converge..."
+sleep "$WAIT_SECONDS"
+
+# --- Check 1: All containers running ---
+RUNNING=$(docker ps --filter "name=clab-${TOPO_NAME}" --filter "status=running" -q | wc -l)
+if [ "$RUNNING" -ge "$EXPECTED_CONTAINERS" ]; then
+    pass "All containers running ($RUNNING/$EXPECTED_CONTAINERS)"
+else
+    fail "Only $RUNNING/$EXPECTED_CONTAINERS containers running"
+    FAILED=1
+fi
+
+# --- Check 2: No panics or fatal errors ---
+PANIC_COUNT=0
+for container in $(docker ps --filter "name=clab-${TOPO_NAME}" --format '{{.Names}}'); do
+    PANICS=$(docker logs "$container" 2>&1 | grep -ciE "panic|fatal|segfault|SIGSEGV" || true)
+    if [ "$PANICS" -gt 0 ]; then
+        fail "Container $container has $PANICS panic/fatal messages"
+        docker logs "$container" 2>&1 | grep -iE "panic|fatal|segfault|SIGSEGV" | head -3
+        PANIC_COUNT=$((PANIC_COUNT + PANICS))
+    fi
+done
+if [ "$PANIC_COUNT" -eq 0 ]; then
+    pass "No panics or fatal errors in any container"
+else
+    FAILED=1
+fi
+
+# --- Check 3: Sync activity detected ---
+SYNC_NODES=0
+for container in $(docker ps --filter "name=clab-${TOPO_NAME}" --format '{{.Names}}'); do
+    HAS_SYNC=$(docker logs "$container" 2>&1 | grep -ciE "sync|merge|replicate|AggregationCompleted|DocumentReceived" || true)
+    if [ "$HAS_SYNC" -gt 0 ]; then
+        SYNC_NODES=$((SYNC_NODES + 1))
+    fi
+done
+if [ "$SYNC_NODES" -gt 0 ]; then
+    pass "Sync activity detected on $SYNC_NODES/$RUNNING nodes"
+else
+    fail "No sync activity detected on any node"
+    FAILED=1
+fi
+
+# --- Summary ---
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+    pass "Validation PASSED"
+    exit 0
+else
+    fail "Validation FAILED"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- **Android build**: Enable push/PR triggers (was manual-only), path-scoped to `hive-ffi/**` and `hive-protocol/**`
- **Benchmarks**: New workflow runs `cap_benchmarks` on push to main, weekly, and manual dispatch; uploads Criterion artifacts
- **Simulation smoke test**: New workflow installs ContainerLab, builds Docker image, runs `simple-validate.sh` against am24n (24-node) topology
- **Functional test**: New workflow for `[self-hosted, ble-lab]` runner, triggered on release or manual dispatch, runs `make dual-transport-test`
- **simple-validate.sh**: Creates the missing script referenced by `make validate` — deploys am24n, checks all 26 containers running, no panics, sync activity detected

## Test plan
- [ ] Verify android.yml triggers on PRs touching `hive-ffi/` or `hive-protocol/`
- [ ] Manually trigger benchmarks.yml via `workflow_dispatch` — verify cap_benchmarks runs and Criterion artifacts upload
- [ ] Manually trigger simulation.yml — verify Docker build + ContainerLab 24-node test
- [ ] Verify functional-test.yml YAML is valid (won't run without `ble-lab` runner registered)
- [ ] Run `cd hive-sim && ./simple-validate.sh` locally if Docker + ContainerLab available

🤖 Generated with [Claude Code](https://claude.com/claude-code)