### PR TITLE
fix: Derive BLE node ID from Iroh endpoint key

### DIFF
--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -1067,7 +1067,15 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<HiveNode>, HiveError> {
 
                 android_log("BLE transport requested - initializing AndroidAdapter stub");
 
-                let ble_config = BleConfig::default();
+                // Derive BLE node ID from Iroh endpoint key (same as Linux path)
+                let iroh_key_bytes = transport.endpoint_id().as_bytes();
+                let ble_node_id = hive_btle::NodeId::new(u32::from_be_bytes([
+                    iroh_key_bytes[28],
+                    iroh_key_bytes[29],
+                    iroh_key_bytes[30],
+                    iroh_key_bytes[31],
+                ]));
+                let ble_config = BleConfig::new(ble_node_id);
                 let adapter = AndroidAdapter::new_stub();
                 let btle = BluetoothLETransport::new(ble_config, adapter);
                 let ble_transport = Arc::new(HiveBleTransport::new(btle));
@@ -1105,8 +1113,18 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<HiveNode>, HiveError> {
                         _ => PowerProfile::Balanced,
                     };
 
-                    // Create BLE config with power profile and mesh ID
-                    let mut ble_config = BleConfig::default();
+                    // Derive a 32-bit BLE node ID from the Iroh endpoint's public key
+                    // Use last 4 bytes of the 32-byte key for a unique-enough identifier
+                    let iroh_key_bytes = transport.endpoint_id().as_bytes();
+                    let ble_node_id = hive_btle::NodeId::new(u32::from_be_bytes([
+                        iroh_key_bytes[28],
+                        iroh_key_bytes[29],
+                        iroh_key_bytes[30],
+                        iroh_key_bytes[31],
+                    ]));
+
+                    // Create BLE config with node ID, power profile, and mesh ID
+                    let mut ble_config = BleConfig::new(ble_node_id);
                     ble_config.power_profile = power_profile;
                     if let Some(ref mesh_id) = transport_config.ble_mesh_id {
                         ble_config.mesh.mesh_id = mesh_id.clone();


### PR DESCRIPTION
## Summary
- BleConfig was initialized with `NodeId::default()` (0x00000000), causing the Pi to advertise as `HIVE-00000000`
- Android's `connectGatt()` returned status 133 (GATT_ERROR) on every attempt — zero node ID in GATT service data likely caused BlueZ/Android connection issues
- Fix: derive a unique 32-bit BLE node ID from the last 4 bytes of the Iroh endpoint's 32-byte public key
- Applied to both Linux (BluerAdapter) and Android (AndroidAdapter) code paths

## Test plan
- [ ] Trigger `functional-test.yml` — verify Pi advertises as `HIVE-XXXXXXXX` (non-zero)
- [ ] Verify Android Phase 5 (BLE GATT Sync) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)