### PR TITLE
fix: Bind endpoint_id to avoid temporary borrow error in cross-build

### DIFF
--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -1115,7 +1115,8 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<HiveNode>, HiveError> {
 
                     // Derive a 32-bit BLE node ID from the Iroh endpoint's public key
                     // Use last 4 bytes of the 32-byte key for a unique-enough identifier
-                    let iroh_key_bytes = transport.endpoint_id().as_bytes();
+                    let iroh_endpoint_id = transport.endpoint_id();
+                    let iroh_key_bytes = iroh_endpoint_id.as_bytes();
                     let ble_node_id = hive_btle::NodeId::new(u32::from_be_bytes([
                         iroh_key_bytes[28],
                         iroh_key_bytes[29],


### PR DESCRIPTION
## Summary
- Follow-up to #647 — the cross-compiler (aarch64 via Docker) flagged `endpoint_id().as_bytes()` as a temporary value borrow error
- Fix: bind `endpoint_id()` result to a `let` before calling `as_bytes()`

## Test plan
- [ ] Trigger `functional-test.yml` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)