### PR TITLE
fix: Remove ChatCRDT from ATAK plugin, use CannedMessage exclusively

### DIFF
--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveBleManager.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveBleManager.kt
@@ -13,7 +13,6 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import com.revolveteam.hive.HiveBtle
-import com.revolveteam.hive.HiveChat
 import com.revolveteam.hive.HiveDocument
 import com.revolveteam.hive.HiveEventType
 import com.revolveteam.hive.HiveLocation
@@ -115,7 +114,6 @@ class HiveBleManager(
     private var peerEventCallback: ((HivePeer, HiveEventType) -> Unit)? = null
     private var documentSyncCallback: ((HiveDocument) -> Unit)? = null
     private var markerSyncCallback: ((HivePeer, HiveMarker) -> Unit)? = null
-    private var chatSyncCallback: ((HiveChat, HivePeer) -> Unit)? = null
     private var cannedMessageCallback: ((CannedMessageAckEventData) -> Unit)? = null
 
     // Storage for canned message documents (key = sourceNode:timestamp)
@@ -414,44 +412,11 @@ class HiveBleManager(
     }
 
     /**
-     * Set callback for chat sync events.
-     */
-    fun setChatSyncCallback(callback: ((HiveChat, HivePeer) -> Unit)?) {
-        chatSyncCallback = callback
-    }
-
-    /**
      * Set callback for canned message events.
      * Called when a canned message document is received and merged.
      */
     fun setCannedMessageCallback(callback: ((CannedMessageAckEventData) -> Unit)?) {
         cannedMessageCallback = callback
-    }
-
-    /**
-     * Send a chat message to all connected peers.
-     * @param sender Sender callsign (max 16 chars)
-     * @param message Message text (max 140 chars)
-     */
-    fun sendChat(sender: String, message: String) {
-        hiveBtle?.sendChat(sender, message)
-    }
-
-    /**
-     * Send a chat message to all connected peers.
-     * @param chat The chat message to send
-     */
-    fun sendChat(chat: HiveChat) {
-        hiveBtle?.sendChat(chat)
-    }
-
-    /**
-     * Get chat messages from the CRDT since a given timestamp.
-     * @param sinceTimestamp Only return messages newer than this timestamp (0 for all)
-     * @return List of HiveChat messages from the mesh CRDT
-     */
-    fun getChatMessagesSince(sinceTimestamp: Long): List<HiveChat> {
-        return hiveBtle?.getChatMessagesSince(sinceTimestamp) ?: emptyList()
     }
 
     // ========================================================================
@@ -628,13 +593,6 @@ class HiveBleManager(
             Log.i(TAG, "Marker synced from ${peer.displayName()}: ${marker.uid} " +
                     "type=${marker.type} at (${marker.lat}, ${marker.lon}) callsign=${marker.callsign}")
             markerSyncCallback?.invoke(peer, marker)
-        }
-    }
-
-    override fun onChatReceived(chat: HiveChat, fromPeer: HivePeer) {
-        mainHandler.post {
-            Log.d(TAG, "Chat received from ${fromPeer.displayName()}: ${chat.sender} says '${chat.message}'")
-            chatSyncCallback?.invoke(chat, fromPeer)
         }
     }
 

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveDropDownReceiver.kt
@@ -25,7 +25,6 @@ import com.revolveteam.atak.hive.model.HivePlatform
 import com.revolveteam.atak.hive.model.HiveRole
 import com.revolveteam.atak.hive.model.HiveTrack
 import com.revolveteam.atak.hive.model.CommsQuality
-import com.revolveteam.hive.HiveChat
 import com.revolveteam.hive.HiveMarker
 import com.revolveteam.hive.HivePeer as BlePeer
 import uniffi.hive_lite_android.CannedMessageType
@@ -92,11 +91,6 @@ class HiveDropDownReceiver(
 
         // Register for marker received events
         mapComponent.onMarkerReceived = { _, _ ->
-            refreshContentOnMainThread()
-        }
-
-        // Register for chat received events
-        mapComponent.onChatReceived = { _, _ ->
             refreshContentOnMainThread()
         }
 
@@ -393,7 +387,6 @@ class HiveDropDownReceiver(
 
         // Canned Messages section (only in cell detail view)
         if (selectedCellId != null) {
-            val chatMessages = mapComponent.chatMessages
             val chatTitle = TextView(pluginContext).apply {
                 text = "Quick Messages"
                 textSize = 16f
@@ -404,32 +397,6 @@ class HiveDropDownReceiver(
 
             // Canned message buttons organized by category
             container.addView(createCannedMessageSection())
-            container.addView(createSpacer(16))
-
-            // Recent messages section
-            val recentTitle = TextView(pluginContext).apply {
-                text = "Recent (${chatMessages.size})"
-                textSize = 14f
-                setTextColor(Color.parseColor("#888888"))
-            }
-            container.addView(recentTitle)
-            container.addView(createSpacer(8))
-
-            // Chat messages (most recent at top)
-            if (chatMessages.isEmpty()) {
-                val noChat = TextView(pluginContext).apply {
-                    text = "No messages yet"
-                    textSize = 14f
-                    setTextColor(Color.GRAY)
-                }
-                container.addView(noChat)
-            } else {
-                // Show most recent first (reversed)
-                chatMessages.reversed().take(10).forEach { cachedChat ->
-                    container.addView(createChatMessageCard(cachedChat))
-                    container.addView(createSpacer(4))
-                }
-            }
 
             container.addView(createSpacer(24))
         }
@@ -597,7 +564,7 @@ class HiveDropDownReceiver(
 
         // Tap hint
         val tapHint = TextView(pluginContext).apply {
-            text = "Tap for chat + details →"
+            text = "Tap for messages + details →"
             textSize = 10f
             setTextColor(Color.parseColor("#666666"))
             gravity = Gravity.END
@@ -765,72 +732,6 @@ class HiveDropDownReceiver(
             cotType.startsWith("b-m-r") -> "Route"
             else -> cotType.take(10)
         }
-    }
-
-    private fun createChatMessageCard(cachedChat: HiveMapComponent.CachedChat): View {
-        val chat = cachedChat.chat
-        val isSelf = cachedChat.isSelf
-
-        val card = LinearLayout(pluginContext).apply {
-            orientation = LinearLayout.VERTICAL
-            setBackgroundColor(if (isSelf) Color.parseColor("#1a3d1a") else Color.parseColor("#2d2d2d"))
-            setPadding(16, 12, 16, 12)
-        }
-
-        // Header row: sender + time
-        val headerRow = LinearLayout(pluginContext).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER_VERTICAL
-        }
-
-        val senderText = TextView(pluginContext).apply {
-            text = chat.sender
-            textSize = 12f
-            setTextColor(if (isSelf) Color.parseColor("#8BC34A") else Color.parseColor("#64B5F6"))
-            layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
-        }
-        headerRow.addView(senderText)
-
-        val ageSec = (System.currentTimeMillis() - chat.timestamp) / 1000
-        val timeText = TextView(pluginContext).apply {
-            text = when {
-                ageSec < 60 -> "${ageSec}s"
-                ageSec < 3600 -> "${ageSec / 60}m"
-                else -> "${ageSec / 3600}h"
-            }
-            textSize = 10f
-            setTextColor(Color.parseColor("#666666"))
-        }
-        headerRow.addView(timeText)
-        card.addView(headerRow)
-
-        // Message text
-        val msgTextView = TextView(pluginContext).apply {
-            text = chat.message
-            textSize = 14f
-            setTextColor(Color.WHITE)
-        }
-        card.addView(msgTextView)
-
-        // ACK status row (for sent messages)
-        if (isSelf && cachedChat.acks.isNotEmpty()) {
-            val ackRow = LinearLayout(pluginContext).apply {
-                orientation = LinearLayout.HORIZONTAL
-                gravity = Gravity.END or Gravity.CENTER_VERTICAL
-                setPadding(0, 4, 0, 0)
-            }
-
-            val ackNames = cachedChat.acks.joinToString(", ") { it.sender }
-            val ackText = TextView(pluginContext).apply {
-                text = "ACK: $ackNames"
-                textSize = 10f
-                setTextColor(Color.parseColor("#4CAF50"))  // Green for ACKs
-            }
-            ackRow.addView(ackText)
-            card.addView(ackRow)
-        }
-
-        return card
     }
 
     /**

--- a/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
+++ b/atak-plugin/app/src/main/java/com/revolveteam/atak/hive/HiveMapComponent.kt
@@ -19,7 +19,6 @@ import com.revolveteam.atak.hive.model.HiveTrack
 import com.revolveteam.atak.hive.overlay.HiveCellOverlay
 import com.revolveteam.atak.hive.overlay.HivePlatformOverlay
 import com.revolveteam.atak.hive.overlay.HiveTrackOverlay
-import com.revolveteam.hive.HiveChat
 import com.revolveteam.hive.HiveDocument
 import com.revolveteam.hive.HiveEventType
 import com.revolveteam.hive.HiveMarker
@@ -197,74 +196,6 @@ class HiveMapComponent : DropDownMapComponent() {
     /** Callback for when a marker is received (for UI/map display) */
     var onMarkerReceived: ((marker: HiveMarker, sourcePeer: HivePeer) -> Unit)? = null
 
-    /**
-     * ACK info for tracking who acknowledged a message.
-     */
-    data class ChatAck(
-        val sender: String,         // Callsign of the acker
-        val timestamp: Long         // When the ACK was sent
-    )
-
-    /**
-     * Chat message with ACK associations for UI display.
-     */
-    data class CachedChat(
-        val chat: HiveChat,
-        val isSelf: Boolean,        // True if sent by this device
-        val acks: List<ChatAck> = emptyList()
-    ) {
-        /** Get the message ID string for correlation (format: "XXXXXXXX:timestamp") */
-        fun messageId(): String = chat.messageIdString()
-    }
-
-    /**
-     * Get chat messages from the mesh CRDT with ACK associations.
-     * Returns messages sorted by timestamp, with ACKs associated to their parent messages.
-     */
-    val chatMessages: List<CachedChat>
-        get() {
-            val bleManager = HivePluginLifecycle.getInstance()?.getHiveBleManager() ?: return emptyList()
-            val myNodeId = bleManager.getNodeId() ?: 0L
-
-            // Get all messages from CRDT
-            val allMessages = bleManager.getChatMessagesSince(0)
-
-            // Separate regular messages from ACK replies
-            val regularMessages = mutableListOf<HiveChat>()
-            val ackMessages = mutableListOf<HiveChat>()
-
-            for (msg in allMessages) {
-                val isAckReply = msg.isReply() && msg.message.equals("ACK", ignoreCase = true)
-                if (isAckReply) {
-                    ackMessages.add(msg)
-                } else {
-                    regularMessages.add(msg)
-                }
-            }
-
-            // Build ACK associations
-            val acksByMessageId = ackMessages.groupBy { it.replyToIdString() }
-
-            // Build CachedChat list with ACKs
-            return regularMessages
-                .sortedBy { it.timestamp }
-                .map { msg ->
-                    val messageId = msg.messageIdString()
-                    val acks = acksByMessageId[messageId]?.map { ack ->
-                        ChatAck(sender = ack.sender, timestamp = ack.timestamp)
-                    } ?: emptyList()
-
-                    CachedChat(
-                        chat = msg,
-                        isSelf = msg.originNode == myNodeId,
-                        acks = acks
-                    )
-                }
-        }
-
-    /** Callback for when a chat message is received (for UI refresh) */
-    var onChatReceived: ((chat: HiveChat, fromPeer: HivePeer) -> Unit)? = null
-
     private var _connectionStatus = ConnectionStatus.DISCONNECTED
     val connectionStatus: ConnectionStatus get() = _connectionStatus
 
@@ -330,9 +261,6 @@ class HiveMapComponent : DropDownMapComponent() {
 
         // Register BLE marker callback for mesh-synced map markers
         registerBleMarkerCallback()
-
-        // Register BLE chat callback for mesh chat messages
-        registerBleChatCallback()
 
         // Register observer for BLE peer connectivity changes to update cell composition immediately
         registerBlePeerConnectivityObserver()
@@ -505,25 +433,6 @@ class HiveMapComponent : DropDownMapComponent() {
     }
 
     /**
-     * Register callback for BLE chat messages.
-     */
-    private fun registerBleChatCallback() {
-        try {
-            val bleManager = HivePluginLifecycle.getInstance()?.getHiveBleManager()
-            if (bleManager != null) {
-                bleManager.setChatSyncCallback { chat, fromPeer ->
-                    onBleChatReceived(chat, fromPeer)
-                }
-                Log.i(TAG, "BLE chat callback registered")
-            } else {
-                Log.w(TAG, "BLE manager not available for chat callback")
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error registering BLE chat callback: ${e.message}", e)
-        }
-    }
-
-    /**
      * Register observer for BLE peer connectivity changes.
      * This triggers immediate cell composition updates when peers connect/disconnect,
      * ensuring cell capabilities reflect current operational state.
@@ -550,61 +459,6 @@ class HiveMapComponent : DropDownMapComponent() {
         } catch (e: Exception) {
             Log.e(TAG, "Error registering BLE connectivity observer: ${e.message}", e)
         }
-    }
-
-    /**
-     * Handle chat message received from BLE mesh peer.
-     * The CRDT handles storage and deduplication - we just notify the UI.
-     */
-    private fun onBleChatReceived(chat: HiveChat, fromPeer: HivePeer) {
-        refreshHandler.post {
-            Log.i(TAG, "Chat from ${fromPeer.displayName()}: '${chat.sender}' says '${chat.message}'")
-
-            // Notify UI to refresh (CRDT handles storage)
-            onChatReceived?.invoke(chat, fromPeer)
-        }
-    }
-
-    /**
-     * Send a chat message to all connected BLE mesh peers.
-     * The CRDT handles storage - message will appear in chatMessages after sync.
-     * @param message Message text (max 140 chars)
-     */
-    fun sendChat(message: String) {
-        val bleManager = HivePluginLifecycle.getInstance()?.getHiveBleManager()
-        if (bleManager == null) {
-            Log.w(TAG, "Cannot send chat - BLE manager not available")
-            return
-        }
-
-        val nodeId = bleManager.getNodeId()
-        if (nodeId == null || nodeId == 0L) {
-            Log.e(TAG, "Cannot send chat - mesh not initialized")
-            return
-        }
-
-        if (!bleManager.isRunning.value) {
-            Log.e(TAG, "Cannot send chat - mesh not running")
-            return
-        }
-
-        // Get callsign from self marker
-        val selfCallsign = mapView.selfMarker?.getMetaString("callsign", null)
-            ?: mapView.selfMarker?.title
-            ?: "ATAK"
-
-        // Create and send chat - CRDT handles storage and sync
-        val chat = HiveChat(
-            sender = selfCallsign,
-            message = message,
-            timestamp = System.currentTimeMillis(),
-            originNode = nodeId,
-            isBroadcast = true,
-            requiresAck = false
-        )
-
-        bleManager.sendChat(chat)
-        Log.i(TAG, "Sent chat: '$selfCallsign' says '$message'")
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove all ChatCRDT usage from the ATAK plugin — CannedMessage was already fully implemented (UI buttons, delta sync polling, ACK tracking, display cards)
- Companion hive-btle patch removes stale UniFFI chat bindings that were blocking the APK build: https://app.radicle.xyz/nodes/rosa.radicle.xyz/rad:z458mp9Um3AYNQQFMdHaNEUtmiohq/patches/5c8633e6a3885e1dadf81162674660a5a15d95d7

### Files changed

| File | Change |
|------|--------|
| `HiveDropDownReceiver.kt` | Remove chat import, callback, "Recent" chat section, `createChatMessageCard()`, update tap hint |
| `HiveMapComponent.kt` | Remove `ChatAck`, `CachedChat`, `chatMessages`, `sendChat()`, chat callback/registration |
| `HiveBleManager.kt` | Remove chat callback, `setChatSyncCallback()`, `sendChat()` overloads, `getChatMessagesSince()`, `onChatReceived()` |

Closes #583

## Test plan

- [x] APK builds successfully (`./gradlew assembleDebug`)
- [ ] Verify CannedMessage buttons and "Recent Messages" display work in cell detail view
- [ ] Verify no regressions in emergency/ACK handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)