### PR TITLE
fix: Align license to Apache-2.0 and clean up stale metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ exclude = ["hive-lite", "examples/m5stack-core2-hive"]
 version = "0.1.0"
 edition = "2021"
 authors = ["Kit Plummer <kit@revolveteam.com>"]
-license = "MIT"
+license = "Apache-2.0"
 repository = "https://github.com/kitplummer/hive"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ docs/
 
 ## License
 
-MIT OR Apache-2.0
+Apache-2.0
 
 ## Contributing
 

--- a/hive-persistence/Cargo.toml
+++ b/hive-persistence/Cargo.toml
@@ -3,9 +3,9 @@ name = "hive-persistence"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-authors = ["Kit Plummer <kitplummer@gmail.com>"]
-description = "Storage abstraction layer for CAP Protocol data persistence"
-repository = "https://github.com/kitplummer/cap"
+authors.workspace = true
+description = "Storage abstraction layer for HIVE Protocol data persistence"
+repository.workspace = true
 
 [dependencies]
 # CAP dependencies

--- a/hive-transport/Cargo.toml
+++ b/hive-transport/Cargo.toml
@@ -3,9 +3,9 @@ name = "hive-transport"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-authors = ["Kit Plummer <kitplummer@gmail.com>"]
-description = "HTTP/REST API transport layer for CAP Protocol external integration"
-repository = "https://github.com/kitplummer/cap"
+authors.workspace = true
+description = "HTTP/REST API transport layer for HIVE Protocol external integration"
+repository.workspace = true
 
 [dependencies]
 # CAP dependencies


### PR DESCRIPTION
## Summary

- Workspace license field: `"MIT"` → `"Apache-2.0"` (matches actual LICENSE file)
- README license section: `MIT OR Apache-2.0` → `Apache-2.0`
- hive-persistence: fix stale `cap` repo URL, `CAP Protocol` description, old email
- hive-transport: fix stale `cap` repo URL, `CAP Protocol` description, old email

All three repos (hive, hive-mesh, hive-btle) now consistently declare Apache-2.0.

## Test plan

- [ ] CI passes (metadata-only change, no code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)