### PR TITLE
chore: Bump hive-btle dependency to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2608,6 +2608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2652,10 +2661,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version",
  "serde",
  "spin 0.9.8",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -2755,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "hive-btle"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd14f41c85cc68ec37ab843571829ef581eec4f66a6ff092a53a0f6eaaefe625"
+checksum = "25071cb38b1ddcd3e86fee8fa369b789ac0b7e1b82803a1b6894c08233a30639"
 dependencies = [
  "android_logger",
  "async-trait",
@@ -2768,6 +2787,7 @@ dependencies = [
  "chacha20poly1305",
  "ed25519-dalek 2.2.0",
  "hashbrown 0.15.5",
+ "hive-lite",
  "hkdf",
  "log",
  "objc2",
@@ -2862,6 +2882,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "hive-lite"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74743f7629ed140c2428c0a79a577d4e45c47b9b56d59299f69125f137d4ccb5"
+dependencies = [
+ "heapless 0.8.0",
 ]
 
 [[package]]
@@ -5121,7 +5150,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
- "heapless",
+ "heapless 0.7.17",
  "postcard-derive",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ repository = "https://github.com/kitplummer/hive"
 hive-mesh = "0.2.0"
 
 # BLE mesh transport (ADR-039)
-hive-btle = "0.1.2"
+hive-btle = "0.1.3"
 
 # CRDT synchronization
 dittolive-ditto = "=4.11.5"


### PR DESCRIPTION
## Summary
- Updates `hive-btle` workspace dependency from 0.1.2 to 0.1.3
- Picks up BLE GATT reliability fixes and reconnect delay determinism from the latest crates.io release

## Test plan
- [x] `cargo check` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)