### PR TITLE
chore: Bump hive-mesh to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2895,9 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "hive-mesh"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f85d4700c4aefc98fac14b52be2ef8a46597f8974e065462bc707550be50aa"
+checksum = "009685787623e4cc62ec47e8419ea6bc61d00e823a2c1a018806bbea90ce33a2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2927,6 +2927,7 @@ dependencies = [
  "subtle",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "toml 0.8.23",
  "tracing",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ repository = "https://github.com/kitplummer/hive"
 
 [workspace.dependencies]
 # Mesh networking
-hive-mesh = "0.2.0"
+hive-mesh = "0.2.1"
 
 # BLE mesh transport (ADR-039)
 hive-btle = "0.1.3"


### PR DESCRIPTION
## Summary
- Bumps `hive-mesh` dependency from 0.2.0 to 0.2.1
- Picks up `TypedCollection<T>` convenience API, `json_convert` module, and `CompositeBrokerState` for broker document endpoints

## Test plan
- [x] `cargo check` passes across all workspace crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)