### PR TITLE
fix: Add missing MeshTransport import in hive-ffi

### DIFF
--- a/hive-ffi/src/lib.rs
+++ b/hive-ffi/src/lib.rs
@@ -73,7 +73,7 @@ use hive_protocol::sync::{BackendConfig, DataSyncBackend, TransportConfig};
 use hive_protocol::transport::btle::HiveBleTransport;
 #[cfg(feature = "sync")]
 use hive_protocol::transport::{
-    iroh::IrohMeshTransport, CollectionRouteTable, Transport, TransportCapabilities,
+    iroh::IrohMeshTransport, CollectionRouteTable, MeshTransport, Transport, TransportCapabilities,
     TransportInstance, TransportManager, TransportManagerConfig, TransportPolicy, TransportType,
 };
 #[cfg(feature = "sync")]


### PR DESCRIPTION
## Summary
- Add `MeshTransport` to the transport imports in hive-ffi
- The `start()` method on `HiveBleTransport` comes from this trait, which was only imported in the test module but needed at module scope
- Fixes the dual-transport functional test build failure

## Test plan
- [x] `cargo check -p hive-ffi --features sync,bluetooth` compiles clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)