### PR TITLE
chore: Bump hive-mesh to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/kitplummer/hive"
 
 [workspace.dependencies]
 # Mesh networking
-hive-mesh = "0.2.1"
+hive-mesh = "0.2.2"
 
 # BLE mesh transport (ADR-039)
 hive-btle = "0.1.3"

--- a/hive-protocol/Cargo.toml
+++ b/hive-protocol/Cargo.toml
@@ -73,7 +73,7 @@ ditto-backend = ["dittolive-ditto"]
 # Automerge/Iroh backend - pure Rust, works on Android
 automerge-backend = ["automerge", "iroh", "iroh-blobs", "redb", "lru", "toml", "mdns-sd", "rand", "futures-lite", "negentropy", "hive-mesh/automerge-backend"]
 # HIVE-Lite transport - UDP-based communication with embedded devices (ADR-035)
-lite-transport = ["log", "hive-mesh/lite-transport"]
+lite-transport = ["log", "hive-mesh/lite-bridge"]
 # Bluetooth LE transport - BLE mesh networking (ADR-032, ADR-039)
 bluetooth = ["hive-btle", "hive-mesh/bluetooth"]
 


### PR DESCRIPTION
## Summary
- Bump `hive-mesh` workspace dependency from 0.2.1 to 0.2.2
- Fix `hive-protocol` feature reference: `lite-transport` → `lite-bridge` (feature was renamed in hive-mesh 0.2.2)

hive-mesh 0.2.2 replaces duplicated wire protocol types with imports from the newly published `hive-lite-protocol` crate, fixing the `SENSOR_INPUT` capability bit mismatch.

## Test plan
- [x] `cargo check` passes for full workspace
- [x] `cargo build --example lite_aggregator --features "automerge-backend,lite-transport"` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)