### PR TITLE
fix: Resolve Android BLE GATT status=133 failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2894,10 +2894,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "hive-mesh"
-version = "0.2.1"
+name = "hive-lite-protocol"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009685787623e4cc62ec47e8419ea6bc61d00e823a2c1a018806bbea90ce33a2"
+checksum = "7e21f6e1444c0dbc33d72eb9dc09e55cba32492e29b259c302b2f1897525a651"
+
+[[package]]
+name = "hive-mesh"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8bd85f1be0372643c7b223a87f4ce2f94f92c4fc1a27923dd148a18fe8ed5ec"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2910,6 +2916,7 @@ dependencies = [
  "geohash",
  "hex",
  "hive-btle",
+ "hive-lite-protocol",
  "hkdf",
  "hmac",
  "iroh",

--- a/Makefile
+++ b/Makefile
@@ -596,6 +596,11 @@ dual-transport-test: deploy-dual-test-peer build-ble-test-app deploy-ble-test-ap
 		echo "--- Android attempt $$attempt/3 ---"; \
 		adb shell am force-stop com.revolveteam.hive.test 2>/dev/null || true; \
 		adb logcat -c 2>/dev/null || true; \
+		if [ $$attempt -gt 1 ]; then \
+			echo "Resetting Pi BLE adapter and restarting dual_test_peer..."; \
+			ssh $(BLE_TEST_PI_USER)@$(BLE_TEST_PI) 'pkill -x dual_test_peer 2>/dev/null || true; sleep 1; bluetoothctl power off 2>/dev/null; sleep 1; bluetoothctl power on 2>/dev/null; sleep 1; nohup ~/dual_test_peer > ~/dual_test_peer.log 2>&1 &'; \
+			sleep 3; \
+		fi; \
 		echo "Toggling Android BLE..."; \
 		adb shell cmd bluetooth_manager disable 2>/dev/null || true; \
 		sleep 2; \

--- a/android-ble-test/app/src/main/java/com/revolveteam/hive/test/BleGattClient.kt
+++ b/android-ble-test/app/src/main/java/com/revolveteam/hive/test/BleGattClient.kt
@@ -256,8 +256,9 @@ class BleGattClient(private val context: Context) {
 
                 val gatt = connectGatt(device)
 
-                // Delay for connection to stabilize
-                delay(500)
+                // Delay for connection to stabilize — 1500ms gives BlueZ GATT
+                // registration time to complete on the Pi side (status=133 fix)
+                delay(1500)
 
                 // Clear GATT cache to avoid stale service discovery results
                 // (Android caches GATT services per MAC address)
@@ -294,56 +295,60 @@ class BleGattClient(private val context: Context) {
     }
 
     private suspend fun connectGatt(device: BluetoothDevice): BluetoothGatt {
-        return suspendCancellableCoroutine { cont ->
-            val connectCallback = object : BluetoothGattCallback() {
-                override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
-                    gattCallback.onConnectionStateChange(g, status, newState)
-                    when (newState) {
-                        BluetoothProfile.STATE_CONNECTED -> {
-                            Log.i(TAG, "Connected to ${device.address}")
-                            bluetoothGatt = g
-                            if (cont.isActive) cont.resume(g)
-                        }
-                        BluetoothProfile.STATE_DISCONNECTED -> {
-                            val err = RuntimeException("Connection failed (status=$status)")
-                            if (cont.isActive) {
-                                cont.resumeWithException(err)
+        return withTimeout(15_000) {
+            suspendCancellableCoroutine { cont ->
+                val connectCallback = object : BluetoothGattCallback() {
+                    override fun onConnectionStateChange(g: BluetoothGatt, status: Int, newState: Int) {
+                        gattCallback.onConnectionStateChange(g, status, newState)
+                        when (newState) {
+                            BluetoothProfile.STATE_CONNECTED -> {
+                                Log.i(TAG, "Connected to ${device.address}")
+                                bluetoothGatt = g
+                                if (cont.isActive) cont.resume(g)
                             }
-                            // Cancel any pending operations if disconnected after connect
-                            pendingServiceDiscovery?.let { if (it.isActive) it.resumeWithException(err) }
-                            pendingServiceDiscovery = null
-                            pendingCharRead?.let { if (it.isActive) it.resumeWithException(err) }
-                            pendingCharRead = null
-                            pendingCharWrite?.let { if (it.isActive) it.resumeWithException(err) }
-                            pendingCharWrite = null
+                            BluetoothProfile.STATE_DISCONNECTED -> {
+                                val err = RuntimeException("Connection failed (status=$status)")
+                                if (cont.isActive) {
+                                    cont.resumeWithException(err)
+                                }
+                                // Cancel any pending operations if disconnected after connect
+                                pendingServiceDiscovery?.let { if (it.isActive) it.resumeWithException(err) }
+                                pendingServiceDiscovery = null
+                                pendingCharRead?.let { if (it.isActive) it.resumeWithException(err) }
+                                pendingCharRead = null
+                                pendingCharWrite?.let { if (it.isActive) it.resumeWithException(err) }
+                                pendingCharWrite = null
+                            }
                         }
+                    }
+
+                    override fun onServicesDiscovered(g: BluetoothGatt, status: Int) {
+                        gattCallback.onServicesDiscovered(g, status)
+                    }
+
+                    @Suppress("DEPRECATION")
+                    override fun onCharacteristicRead(
+                        g: BluetoothGatt,
+                        characteristic: BluetoothGattCharacteristic,
+                        status: Int
+                    ) {
+                        gattCallback.onCharacteristicRead(g, characteristic, status)
+                    }
+
+                    override fun onCharacteristicWrite(
+                        g: BluetoothGatt,
+                        characteristic: BluetoothGattCharacteristic,
+                        status: Int
+                    ) {
+                        gattCallback.onCharacteristicWrite(g, characteristic, status)
                     }
                 }
 
-                override fun onServicesDiscovered(g: BluetoothGatt, status: Int) {
-                    gattCallback.onServicesDiscovered(g, status)
-                }
-
-                @Suppress("DEPRECATION")
-                override fun onCharacteristicRead(
-                    g: BluetoothGatt,
-                    characteristic: BluetoothGattCharacteristic,
-                    status: Int
-                ) {
-                    gattCallback.onCharacteristicRead(g, characteristic, status)
-                }
-
-                override fun onCharacteristicWrite(
-                    g: BluetoothGatt,
-                    characteristic: BluetoothGattCharacteristic,
-                    status: Int
-                ) {
-                    gattCallback.onCharacteristicWrite(g, characteristic, status)
-                }
+                // autoConnect=true lets Android's BLE stack manage connection timing,
+                // avoiding immediate status=133 when the remote GATT service isn't ready yet
+                device.connectGatt(context, true, connectCallback, BluetoothDevice.TRANSPORT_LE)
+                cont.invokeOnCancellation { bluetoothGatt?.disconnect() }
             }
-
-            device.connectGatt(context, false, connectCallback, BluetoothDevice.TRANSPORT_LE)
-            cont.invokeOnCancellation { bluetoothGatt?.disconnect() }
         }
     }
 

--- a/android-ble-test/app/src/main/java/com/revolveteam/hive/test/TestRunner.kt
+++ b/android-ble-test/app/src/main/java/com/revolveteam/hive/test/TestRunner.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.util.Base64
 import android.util.Log
 import com.revolveteam.atak.hive.HiveJni
+import kotlinx.coroutines.delay
 import org.json.JSONArray
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -231,6 +232,9 @@ class TestRunner(
 
             val device = discoveredDevice
                 ?: return recordPhase(5, "GATT Sync", false, "No discovered device from phase 4")
+
+            // Let the Pi's GATT service fully register before connecting (status=133 fix)
+            delay(1000)
 
             // Connect and discover services
             val (gatt, service) = client.connectAndDiscover(device.device)


### PR DESCRIPTION
## Summary
- Fix timing race between Android GATT connection and Pi BlueZ service registration that caused Phase 5 (BLE GATT Sync) to fail with status=133 on all retry attempts
- Increase post-connect stabilization delay (500ms → 1500ms), add 1s pre-connect delay between discovery and GATT connect, switch to `autoConnect=true` with 15s timeout, and reset Pi BLE adapter between Makefile-level retries
- Verified with full functional test suite: 3/3 PASS, Android 12/12 phases on first attempt

## Test plan
- [x] `./gradlew assembleDebug` — APK builds clean
- [x] `./scripts/functional-suite.sh` — all 3 tracks PASS (rpi-rpi BLE, rpi-android dual-transport, k8s cluster)
- [x] Android Phase 5 BLE GATT Sync passes on first attempt (previously failed all 3 attempts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)