### PR TITLE
chore: gitignore stale peat-sim/hive-sim binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ local.properties
 # Shadow simulator
 shadow.data/
 
+# Stale binaries
+peat-sim/hive-sim
+
 # ContainerLab / Simulation
 peat-sim/topologies/clab-*/
 peat-sim/test-results-*/


### PR DESCRIPTION
## Summary
- Adds `peat-sim/hive-sim` to `.gitignore` to prevent the stale pre-rename binary from being accidentally committed

## Test plan
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)