### PR TITLE
chore: fix stale hive/eche references in docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,8 +124,8 @@ Toggle in `peat-protocol/Cargo.toml` features.
 | `docs/adr/005-datasync-abstraction-layer.md` | Sync abstraction |
 | `docs/adr/011-ditto-vs-automerge-iroh.md` | Backend selection |
 | `docs/adr/032-pluggable-transport-abstraction.md` | Transport layer |
-| `docs/adr/035-hive-lite-embedded-nodes.md` | Embedded wire protocol |
-| `docs/adr/049-hive-mesh-extraction.md` | peat-mesh standalone design |
+| `docs/adr/035-peat-lite-embedded-nodes.md` | Embedded wire protocol |
+| `docs/adr/049-peat-mesh-extraction.md` | peat-mesh standalone design |
 
 ## CI Workflows
 
@@ -151,6 +151,6 @@ Toggle in `peat-protocol/Cargo.toml` features.
 
 ## Related Repositories
 
-- **peat-mesh** (`../hive-mesh/`): Standalone mesh networking — topology, sync, K8s, broker
-- **peat-btle** (`../hive-btle/`): BLE mesh transport — multi-platform, GATT sync
-- **peat-lite** (`../hive-lite/`): Embedded CRDT primitives — no_std, wire protocol, ESP32 firmware
+- **peat-mesh** (`../peat-mesh/`): Standalone mesh networking — topology, sync, K8s, broker
+- **peat-btle** (`../peat-btle/`): BLE mesh transport — multi-platform, GATT sync
+- **peat-lite** (`../peat-lite/`): Embedded CRDT primitives — no_std, wire protocol, ESP32 firmware

--- a/Makefile
+++ b/Makefile
@@ -669,7 +669,7 @@ dual-test-peer-logs:
 # Functional Test Suite (all hardware tests)
 # ============================================
 # Orchestrates all functional/hardware tests from one entry point.
-# Tests: rpi-rpi BLE (peat-btle), rpi-android dual-transport (hive),
+# Tests: rpi-rpi BLE (peat-btle), rpi-android dual-transport (peat),
 #        k8s cluster (peat-mesh)
 
 functional-suite:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ peat/
 
 | Crate | Description | Repo |
 |-------|-------------|------|
-| [peat-mesh](https://crates.io/crates/peat-mesh) | P2P topology, Iroh/QUIC transport, Automerge sync | [defenseunicorns/eche-mesh](https://github.com/defenseunicorns/eche-mesh) |
-| [peat-btle](https://crates.io/crates/peat-btle) | BLE GATT mesh for Android/iOS/Linux/ESP32 | [defenseunicorns/hive-btle](https://github.com/defenseunicorns/hive-btle) |
+| [peat-mesh](https://crates.io/crates/peat-mesh) | P2P topology, Iroh/QUIC transport, Automerge sync | [defenseunicorns/peat-mesh](https://github.com/defenseunicorns/peat-mesh) |
+| [peat-btle](https://crates.io/crates/peat-btle) | BLE GATT mesh for Android/iOS/Linux/ESP32 | [defenseunicorns/peat-btle](https://github.com/defenseunicorns/peat-btle) |
 | [peat-lite](https://crates.io/crates/peat-lite) | Embedded UDP protocol + wire format (no_std) | [defenseunicorns/peat-lite](https://github.com/defenseunicorns/peat-lite) |
 
 ## Three-Phase Protocol


### PR DESCRIPTION
## Summary
- Update README.md external repo links (eche-mesh → peat-mesh, hive-btle → peat-btle)
- Fix ADR paths in CLAUDE.md (hive-lite → peat-lite, hive-mesh → peat-mesh)
- Fix repo paths in CLAUDE.md (../hive-mesh/ → ../peat-mesh/, etc.)
- Fix Makefile comment (hive → peat)

## Test plan
- [ ] Verify all links resolve correctly
- [ ] `grep -ri hive README.md CLAUDE.md Makefile` returns no stale refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)