### PR TITLE
fix: repair build after hive→peat rename

### DIFF
--- a/android-ble-test/settings.gradle.kts
+++ b/android-ble-test/settings.gradle.kts
@@ -12,7 +12,7 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         flatDir {
-            dirs("${rootDir}/../../peat-btle/android/build/outputs/aar")
+            dirs("${rootDir}/../../hive-btle/android/build/outputs/aar")
         }
     }
 }

--- a/atak-plugin/app/build.gradle
+++ b/atak-plugin/app/build.gradle
@@ -155,7 +155,7 @@ android {
     }
 
     bundle {
-        storeArcpeat {
+        storeArchive {
             enable = false
         }
     }
@@ -170,7 +170,7 @@ android {
 
     sourceSets {
         main {
-            setProperty("arcpeatsBaseName", "ATAK-Plugin-PEAT-" + PLUGIN_VERSION + "-" + getVersionName() + "-" + ATAK_VERSION)
+            setProperty("archivesBaseName", "ATAK-Plugin-PEAT-" + PLUGIN_VERSION + "-" + getVersionName() + "-" + ATAK_VERSION)
             defaultConfig.versionCode = getVersionCode()
             defaultConfig.versionName = PLUGIN_VERSION + " (" + getVersionName() + ") - [" + ATAK_VERSION + "]"
 

--- a/atak-plugin/app/src/main/java/com/defenseunicorns/atak/peat/PeatBleManager.kt
+++ b/atak-plugin/app/src/main/java/com/defenseunicorns/atak/peat/PeatBleManager.kt
@@ -23,7 +23,7 @@ import uniffi.peat_btle.PeerConnectionState
 import uniffi.peat_btle.StateCountSummary
 import uniffi.peat_btle.DeviceIdentity
 import uniffi.peat_btle.decodeMeshGenesis
-import uniffi.peat_btle.CannedMessageInfo
+
 import uniffi.peat_lite_android.CannedMessageAckEventData
 import uniffi.peat_lite_android.CannedMessageType
 import uniffi.peat_lite_android.createCannedMessageAckEvent
@@ -459,11 +459,7 @@ class PeatBleManager(
         cannedMessageDocs[key] = event
         updateCannedMessagesObservable()
 
-        // Store in mesh for CRDT sync (convert List<UByte> to ByteArray)
-        val bytes = ByteArray(encoded.size) { encoded[it].toByte() }
-        val stored = peatBtle?.storeCannedMessageDocument(bytes) ?: false
-
-        Log.i(TAG, "Sent canned message: ${messageType.name} from ${String.format("%08X", nodeId)} stored=$stored (${encoded.size} bytes)")
+        Log.i(TAG, "Sent canned message: ${messageType.name} from ${String.format("%08X", nodeId)} (${encoded.size} bytes)")
 
         // Notify callback
         cannedMessageCallback?.invoke(event)
@@ -545,47 +541,7 @@ class PeatBleManager(
      * don't come through onDecryptedData callback.
      */
     private fun pollCannedMessagesFromDeltaSync() {
-        val btle = peatBtle ?: return
-
-        try {
-            val allMessages = btle.getAllCannedMessages()
-            if (allMessages.isEmpty()) return
-
-            var updated = false
-            for (msgInfo in allMessages) {
-                val key = "${msgInfo.sourceNode}:${msgInfo.timestamp}"
-
-                // Decode the CannedMessageAckEvent from bytes
-                val incoming = decodeCannedMessageAckEvent(msgInfo.encodedBytes)
-                if (incoming == null) {
-                    Log.w(TAG, "[DELTA-POLL] Failed to decode CannedMessageAckEvent")
-                    continue
-                }
-
-                // Check if this is new or has more ACKs than what we have
-                val existing = cannedMessageDocs[key]
-                if (existing == null) {
-                    // New message from delta sync
-                    Log.i(TAG, "[DELTA-POLL] NEW message from delta sync: $key, type=${incoming.message}, ACKs=${incoming.acks.size}")
-                    cannedMessageDocs[key] = incoming
-                    cannedMessageCallback?.invoke(incoming)
-                    updated = true
-                } else if (incoming.acks.size > existing.acks.size) {
-                    // Has more ACKs - merge them
-                    val merged = cannedMessageAckEventMerge(existing, incoming)
-                    Log.i(TAG, "[DELTA-POLL] Merged ACKs for $key: ${existing.acks.size} -> ${merged.acks.size}")
-                    cannedMessageDocs[key] = merged
-                    cannedMessageCallback?.invoke(merged)
-                    updated = true
-                }
-            }
-
-            if (updated) {
-                updateCannedMessagesObservable()
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "[DELTA-POLL] Error polling canned messages: ${e.message}", e)
-        }
+        // TODO: Re-enable when getAllCannedMessages/storeCannedMessageDocument land in peat-btle
     }
 
     override fun onMarkerSynced(peer: PeatPeer, marker: PeatMarker) {

--- a/atak-plugin/settings.gradle
+++ b/atak-plugin/settings.gradle
@@ -2,7 +2,7 @@ rootProject.name = 'peat-atak-plugin'
 include ':app'
 
 // Use local peat-btle repo for development
-includeBuild('../../peat-btle/android') {
+includeBuild('../../hive-btle/android') {
     dependencySubstitution {
         substitute(module('com.defenseunicorns:peat')).using(project(':'))
     }


### PR DESCRIPTION
## Summary
- Fix `storeArchive` and `archivesBaseName` mangled by overly broad hive→peat rename (`storeArcpeat` → `storeArchive`)
- Remove dead CannedMessage CRDT API calls from PeatBleManager (not yet in peat-btle main)
- Fix composite build paths to use actual local directory names (`hive-btle` not `peat-btle`)

## Test plan
- [x] ATAK plugin builds: `cd atak-plugin && ./gradlew assembleCivDebug`
- [x] android-ble-test builds: `cd android-ble-test && ./gradlew assembleDebug`
- [x] Both APKs deploy and run on Samsung tablet
- [x] ATAK registers plugin descriptor at `com.defenseunicorns.atak.peat.PeatPluginLifecycle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)