### PR TITLE
fix: remove unused MeshTransport import

### DIFF
--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -73,7 +73,7 @@ use peat_protocol::sync::{BackendConfig, DataSyncBackend, TransportConfig};
 use peat_protocol::transport::btle::PeatBleTransport;
 #[cfg(feature = "sync")]
 use peat_protocol::transport::{
-    iroh::IrohMeshTransport, CollectionRouteTable, MeshTransport, Transport, TransportCapabilities,
+    iroh::IrohMeshTransport, CollectionRouteTable, Transport, TransportCapabilities,
     TransportInstance, TransportManager, TransportManagerConfig, TransportPolicy, TransportType,
 };
 #[cfg(feature = "sync")]


### PR DESCRIPTION
## Summary
- Remove unused `MeshTransport` import in `peat-ffi/src/lib.rs` flagged by clippy

## Test plan
- [x] `cargo clippy --workspace` passes clean
- [x] 1,178 unit tests pass (`cargo test --workspace --exclude peat-inference --exclude peat-ffi --lib`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)