### PR TITLE
chore: bump peat-mesh dependency to 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/defenseunicorns/peat"
 
 [workspace.dependencies]
 # Mesh networking
-peat-mesh = "0.3.1"
+peat-mesh = "0.3.2"
 
 # BLE mesh transport (ADR-039)
 peat-btle = "0.2.0"


### PR DESCRIPTION
## Summary

- Bump `peat-mesh` from 0.3.1 to 0.3.2 in workspace dependencies
- 0.3.2 includes: background Automerge compaction, formation key peer auth, full-duplex sync transport

Closes defenseunicorns/peat-mesh#10

## Test plan

- [x] `cargo check --workspace` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)