### PR TITLE
fix: resolve rustdoc errors and make doc CI blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
   # ============================================
   docs:
     name: Documentation
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/peat-protocol/src/command/storage_trait.rs
+++ b/peat-protocol/src/command/storage_trait.rs
@@ -156,7 +156,7 @@ pub trait CommandStorage: Send + Sync {
 ///
 /// Dropping this handle should cancel the observation.
 pub struct ObserverHandle {
-    /// Implementation-specific handle (Arc<dyn Any> for type erasure)
+    /// Implementation-specific handle (`Arc<dyn Any>` for type erasure)
     inner: std::sync::Arc<dyn std::any::Any + Send + Sync>,
 }
 

--- a/peat-protocol/src/mesh_integration/aggregator.rs
+++ b/peat-protocol/src/mesh_integration/aggregator.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// Envelope for NodeState + NodeConfig in DataPacket payload
 ///
-/// Since DataPacket payload is opaque Vec<u8>, we need to serialize
+/// Since DataPacket payload is opaque `Vec<u8>`, we need to serialize
 /// both the node configuration and state together.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TelemetryPayload {

--- a/peat-protocol/src/storage/automerge_conversion.rs
+++ b/peat-protocol/src/storage/automerge_conversion.rs
@@ -117,7 +117,7 @@ pub fn automerge_to_node_state(doc: &Automerge) -> Result<NodeState> {
 
 /// Generic: Convert any serializable message to Automerge document
 ///
-/// This is the generic version used by TypedCollection<M>.
+/// This is the generic version used by `TypedCollection<M>`.
 /// Works with any type that implements Serialize.
 #[cfg(feature = "automerge-backend")]
 pub fn message_to_automerge<M: Serialize>(message: &M) -> Result<Automerge> {
@@ -140,7 +140,7 @@ pub fn message_to_automerge<M: Serialize>(message: &M) -> Result<Automerge> {
 
 /// Generic: Convert Automerge document to any deserializable message
 ///
-/// This is the generic version used by TypedCollection<M>.
+/// This is the generic version used by `TypedCollection<M>`.
 /// Works with any type that implements DeserializeOwned.
 #[cfg(feature = "automerge-backend")]
 pub fn automerge_to_message<M: DeserializeOwned>(doc: &Automerge) -> Result<M> {

--- a/peat-protocol/src/sync/mod.rs
+++ b/peat-protocol/src/sync/mod.rs
@@ -16,7 +16,7 @@
 //! ## Supported Backends
 //!
 //! - **Ditto** - Current production backend (proprietary CBOR-based)
-//! - **Automerge** - Future open-source backend (columnar storage) [planned]
+//! - **Automerge** - Future open-source backend (columnar storage) (planned)
 //!
 //! ## Usage Example
 //!

--- a/peat-protocol/src/testing/e2e_harness.rs
+++ b/peat-protocol/src/testing/e2e_harness.rs
@@ -157,7 +157,7 @@ impl E2EHarness {
     /// Create a new isolated Ditto backend for testing
     ///
     /// This is the recommended method for tests using CellStore, which requires
-    /// Arc<DittoBackend>. Each backend gets:
+    /// `Arc<DittoBackend>`. Each backend gets:
     /// - Unique persistence directory
     /// - Shared app_id and shared_key for sync mesh
     /// - Uses mDNS/LAN discovery (no TCP listener/client)

--- a/peat-sim/src/main.rs
+++ b/peat-sim/src/main.rs
@@ -31,13 +31,13 @@
 //!
 //! # Command Line Arguments
 //!
-//! --node-id <id>         Node identifier (e.g., "node1", "squad-1A-leader")
-//! --mode <mode>          "writer" (creates documents) or "reader" (waits for documents)
-//! --backend <type>       Sync backend to use (default: "ditto")
-//! --tcp-listen <port>    Optional: Listen for TCP connections on this port
-//! --tcp-connect <addr>   Optional: Connect to TCP peer at this address
-//! --node-type <type>     Node type for authorization (e.g., "soldier", "squad_leader")
-//! --update-rate-ms <ms>  Update rate in milliseconds (default: 5000)
+//! `--node-id <id>`         Node identifier (e.g., "node1", "squad-1A-leader")
+//! `--mode <mode>`          "writer" (creates documents) or "reader" (waits for documents)
+//! `--backend <type>`       Sync backend to use (default: "ditto")
+//! `--tcp-listen <port>`    Optional: Listen for TCP connections on this port
+//! `--tcp-connect <addr>`   Optional: Connect to TCP peer at this address
+//! `--node-type <type>`     Node type for authorization (e.g., "soldier", "squad_leader")
+//! `--update-rate-ms <ms>`  Update rate in milliseconds (default: 5000)
 //! --peat-filter          Enable Peat capability-based filtering
 //!
 //! # Environment Variables


### PR DESCRIPTION
## Summary

Fix 14 rustdoc errors caused by angle brackets in doc comments being parsed as HTML tags. Backtick-escape generic types and CLI argument syntax.

Remove `continue-on-error` from the Documentation CI job now that the errors are fixed.

## Test plan

`RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace` passes with zero errors.