### PR TITLE
fix: add pluginManagement for peat-ffi Android build

### DIFF
--- a/peat-ffi/android/settings.gradle.kts
+++ b/peat-ffi/android/settings.gradle.kts
@@ -1,4 +1,21 @@
-// Copyright 2026 Defense Unicorns
-// SPDX-License-Identifier: Apache-2.0
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    plugins {
+        id("com.android.library") version "8.13.0"
+        id("org.jetbrains.kotlin.android") version "2.2.0"
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
 
 rootProject.name = "peat-ffi-android"


### PR DESCRIPTION
## Summary

Fix Gradle plugin resolution for peat-ffi Android build. The `settings.gradle.kts` was missing `pluginManagement` with AGP and Kotlin plugin versions.

## Test plan

Trigger `publish-maven.yml` after merge.