### PR TITLE
fix: correct peat-ffi feature flags for Android build

### DIFF
--- a/peat-ffi/android/build.gradle.kts
+++ b/peat-ffi/android/build.gradle.kts
@@ -86,20 +86,17 @@ tasks.register<Exec>("buildNativeLibs") {
 
         # Build for arm64-v8a (modern Android devices)
         echo "Building for aarch64-linux-android (arm64-v8a)..."
-        cargo build --release --lib -p peat-ffi --target aarch64-linux-android --features automerge-backend
-        mkdir -p peat-ffi/android/src/main/jniLibs/arm64-v8a
+        cargo build --release --lib -p peat-ffi --target aarch64-linux-android         mkdir -p peat-ffi/android/src/main/jniLibs/arm64-v8a
         cp target/aarch64-linux-android/release/libpeat_ffi.so peat-ffi/android/src/main/jniLibs/arm64-v8a/
 
         # Build for armeabi-v7a (older devices)
         echo "Building for armv7-linux-androideabi (armeabi-v7a)..."
-        cargo build --release --lib -p peat-ffi --target armv7-linux-androideabi --features automerge-backend
-        mkdir -p peat-ffi/android/src/main/jniLibs/armeabi-v7a
+        cargo build --release --lib -p peat-ffi --target armv7-linux-androideabi         mkdir -p peat-ffi/android/src/main/jniLibs/armeabi-v7a
         cp target/armv7-linux-androideabi/release/libpeat_ffi.so peat-ffi/android/src/main/jniLibs/armeabi-v7a/
 
         # Build for x86_64 (emulators)
         echo "Building for x86_64-linux-android (x86_64)..."
-        cargo build --release --lib -p peat-ffi --target x86_64-linux-android --features automerge-backend
-        mkdir -p peat-ffi/android/src/main/jniLibs/x86_64
+        cargo build --release --lib -p peat-ffi --target x86_64-linux-android         mkdir -p peat-ffi/android/src/main/jniLibs/x86_64
         cp target/x86_64-linux-android/release/libpeat_ffi.so peat-ffi/android/src/main/jniLibs/x86_64/
 
         echo "Native libraries built successfully!"


### PR DESCRIPTION
## Summary

peat-ffi's automerge support is via the `sync` feature (included in defaults), not a direct `automerge-backend` flag. Remove the invalid `--features` argument from the cargo build commands.

## Test plan

Trigger `publish-maven.yml` after merge.