### PR TITLE
fix: audit job fails only on vulnerabilities, not unmaintained warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,12 +170,14 @@ jobs:
   # ============================================
   audit:
     name: Security Audit
-    continue-on-error: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo generate-lockfile
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --quiet
+      - name: Run audit (fail on vulnerabilities, warn on unmaintained)
+        run: |
+          cargo audit 2>&1 || true
+          cargo audit --json 2>/dev/null | jq -e '.vulnerabilities.count == 0'


### PR DESCRIPTION
## Summary

The `rustsec/audit-check` action exits non-zero on unmaintained crate warnings even when there are zero vulnerabilities. This causes the Security Audit job to show red despite no security issues.

Replaced with direct `cargo audit` invocation that:
1. Runs full audit for human-readable output (warnings visible in logs)
2. Checks JSON output — fails only if `vulnerabilities.count > 0`

Removed `continue-on-error` since the job now correctly distinguishes vulnerabilities from warnings.

## Test plan

Current main has 0 vulnerabilities and 7 unmaintained warnings — this will pass green.