### PR TITLE
fix: add explicit permissions block to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, develop ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1


### PR DESCRIPTION
## Summary

Add `permissions: contents: read` to CI workflow. CodeQL alert #41 flagged the missing permissions block — without it, the GITHUB_TOKEN has broader access than needed.

Also dismissed 20 CodeQL `rust/hard-coded-cryptographic-value` alerts as "used in tests" — all were in the `#[cfg(test)]` module of `user_auth.rs` (RFC test vectors and fixture data).

## Test plan

CI-only change. Restricts token permissions to read-only which is all CI needs.