### PR TITLE
chore(deps): bump rustls-webpki 0.103.9 → 0.103.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5746,9 +5746,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` from 0.103.9 to 0.103.10 (security fix for GHSA-pwjx-qhcg-rvj4)
- Replaces #728 which was stale and failing CI due to being based on old main

## Context
The dependabot PR (#728) was opened March 21st against a stale main. The beacon_storage_integration tests it was failing are Ditto credential-dependent and were fixed in CI by #730 (`fix/skip-ditto-tests-without-credentials`). This PR applies the same 2-line Cargo.lock bump on current main where CI is green.

Closes #728

## Test plan
- [ ] CI passes (all checks green)