### PR TITLE
ci: add cargo-deny and cargo-vet supply chain checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,3 +184,33 @@ jobs:
         run: |
           cargo audit 2>&1 || true
           cargo audit --json 2>/dev/null | jq -e '.vulnerabilities.count == 0'
+
+  supply-chain:
+    name: Supply Chain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h
+
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler mold clang libdbus-1-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: supply-chain
+
+      - name: Install cargo-deny and cargo-vet
+        run: cargo install cargo-deny cargo-vet --quiet
+
+      - name: Run cargo-deny
+        run: cargo deny check advisories bans licenses sources
+
+      - name: Run cargo-vet
+        run: cargo vet

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2,3 +2,207 @@
 # cargo-vet audits file
 
 [audits]
+
+[[trusted.argon2]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2021-01-29"
+end = "2027-03-26"
+
+[[trusted.argon2]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2021-07-20"
+end = "2027-03-26"
+
+[[trusted.aws-lc-rs]]
+criteria = "safe-to-deploy"
+user-id = 156764 # Justin W Smith (justsmth)
+start = "2023-04-11"
+end = "2027-03-26"
+
+[[trusted.aws-lc-sys]]
+criteria = "safe-to-deploy"
+user-id = 156764 # Justin W Smith (justsmth)
+start = "2022-11-09"
+end = "2027-03-26"
+
+[[trusted.blake2]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2019-08-25"
+end = "2027-03-26"
+
+[[trusted.blake3]]
+criteria = "safe-to-deploy"
+user-id = 3589 # Jack O'Connor (oconnor663)
+start = "2019-09-17"
+end = "2027-03-26"
+
+[[trusted.chacha20poly1305]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2019-08-30"
+end = "2027-03-26"
+
+[[trusted.chacha20poly1305]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2021-07-20"
+end = "2027-03-26"
+
+[[trusted.cipher]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2020-10-15"
+end = "2027-03-26"
+
+[[trusted.cipher]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2022-02-10"
+end = "2027-03-26"
+
+[[trusted.crypto_box]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2020-02-25"
+end = "2027-03-26"
+
+[[trusted.crypto_secretbox]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2022-11-29"
+end = "2027-03-26"
+
+[[trusted.hkdf]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2021-12-07"
+end = "2027-03-26"
+
+[[trusted.password-hash]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2021-01-29"
+end = "2027-03-26"
+
+[[trusted.password-hash]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2020-08-18"
+end = "2027-03-26"
+
+[[trusted.pem]]
+criteria = "safe-to-deploy"
+user-id = 3635 # Jonathan Creekmore (jcreekmore)
+start = "2019-04-22"
+end = "2027-03-26"
+
+[[trusted.rcgen]]
+criteria = "safe-to-deploy"
+user-id = 3941
+start = "2019-04-26"
+end = "2027-03-26"
+
+[[trusted.rcgen]]
+criteria = "safe-to-deploy"
+user-id = 4556 # Dirkjan Ochtman (djc)
+start = "2024-03-28"
+end = "2027-03-26"
+
+[[trusted.ring]]
+criteria = "safe-to-deploy"
+user-id = 2342 # Brian Smith (briansmith)
+start = "2019-07-03"
+end = "2027-03-26"
+
+[[trusted.rustls]]
+criteria = "safe-to-deploy"
+user-id = 4556 # Dirkjan Ochtman (djc)
+start = "2022-05-18"
+end = "2027-03-26"
+
+[[trusted.rustls]]
+criteria = "safe-to-deploy"
+user-id = 209038 # Daniel McCarney (cpu)
+start = "2023-07-05"
+end = "2027-03-26"
+
+[[trusted.rustls-webpki]]
+criteria = "safe-to-deploy"
+user-id = 2751 # Joe Birr-Pixton (ctz)
+start = "2023-01-09"
+end = "2027-03-26"
+
+[[trusted.rustls-webpki]]
+criteria = "safe-to-deploy"
+user-id = 4556 # Dirkjan Ochtman (djc)
+start = "2023-09-01"
+end = "2027-03-26"
+
+[[trusted.salsa20]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2019-06-24"
+end = "2027-03-26"
+
+[[trusted.salsa20]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2019-07-30"
+end = "2027-03-26"
+
+[[trusted.sha1]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2024-01-08"
+end = "2027-03-26"
+
+[[trusted.sha1]]
+criteria = "safe-to-deploy"
+user-id = 5059 # Artyom Pavlov (newpavlov)
+start = "2022-01-17"
+end = "2027-03-26"
+
+[[trusted.tokio-rustls]]
+criteria = "safe-to-deploy"
+user-id = 4556 # Dirkjan Ochtman (djc)
+start = "2023-06-09"
+end = "2027-03-26"
+
+[[trusted.untrusted]]
+criteria = "safe-to-deploy"
+user-id = 2342 # Brian Smith (briansmith)
+start = "2019-07-03"
+end = "2027-03-26"
+
+[[trusted.webpki-roots]]
+criteria = "safe-to-deploy"
+user-id = 2751 # Joe Birr-Pixton (ctz)
+start = "2019-07-21"
+end = "2027-03-26"
+
+[[trusted.webpki-roots]]
+criteria = "safe-to-deploy"
+user-id = 4556 # Dirkjan Ochtman (djc)
+start = "2023-03-31"
+end = "2027-03-26"
+
+[[trusted.x25519-dalek]]
+criteria = "safe-to-deploy"
+user-id = 5289
+start = "2019-02-28"
+end = "2027-03-26"
+
+[[trusted.x25519-dalek]]
+criteria = "safe-to-deploy"
+user-id = 6979 # Michael Rosenberg (rozbb)
+start = "2023-03-31"
+end = "2027-03-26"
+
+[[trusted.zeroize]]
+criteria = "safe-to-deploy"
+user-id = 267 # Tony Arcieri (tarcieri)
+start = "2021-11-05"
+end = "2027-03-26"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -84,10 +84,6 @@ criteria = "safe-to-deploy"
 version = "0.5.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.argon2]]
-version = "0.5.3"
-criteria = "safe-to-deploy"
-
 [[exemptions.arrayref]]
 version = "0.3.9"
 criteria = "safe-to-deploy"
@@ -152,14 +148,6 @@ criteria = "safe-to-deploy"
 version = "0.7.4"
 criteria = "safe-to-deploy"
 
-[[exemptions.aws-lc-rs]]
-version = "1.16.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.aws-lc-sys]]
-version = "0.38.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.axum]]
 version = "0.7.9"
 criteria = "safe-to-deploy"
@@ -214,14 +202,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.bitflags]]
 version = "2.11.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.blake2]]
-version = "0.10.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.blake3]]
-version = "1.8.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.block-buffer]]
@@ -304,16 +284,8 @@ criteria = "safe-to-deploy"
 version = "0.10.0-rc.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.chacha20poly1305]]
-version = "0.10.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.chrono]]
 version = "0.4.44"
-criteria = "safe-to-deploy"
-
-[[exemptions.cipher]]
-version = "0.5.0-rc.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.clang-sys]]
@@ -426,14 +398,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.crypto-common]]
 version = "0.2.0-rc.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto_box]]
-version = "0.10.0-pre.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.crypto_secretbox]]
-version = "0.2.0-pre.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.curve25519-dalek]]
@@ -838,10 +802,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.hickory-resolver]]
 version = "0.25.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.hkdf]]
-version = "0.12.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.http]]
@@ -1312,10 +1272,6 @@ criteria = "safe-to-deploy"
 version = "0.9.12"
 criteria = "safe-to-deploy"
 
-[[exemptions.password-hash]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.paste]]
 version = "1.0.15"
 criteria = "safe-to-deploy"
@@ -1330,10 +1286,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.peat-mesh]]
 version = "0.5.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.pem]]
-version = "3.0.6"
 criteria = "safe-to-deploy"
 
 [[exemptions.pem-rfc7468]]
@@ -1520,10 +1472,6 @@ criteria = "safe-to-deploy"
 version = "0.2.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.rcgen]]
-version = "0.14.7"
-criteria = "safe-to-deploy"
-
 [[exemptions.redb]]
 version = "2.6.3"
 criteria = "safe-to-deploy"
@@ -1568,10 +1516,6 @@ criteria = "safe-to-deploy"
 version = "0.7.6"
 criteria = "safe-to-deploy"
 
-[[exemptions.ring]]
-version = "0.17.14"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustc-demangle]]
 version = "0.1.27"
 criteria = "safe-to-deploy"
@@ -1586,10 +1530,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.rustix]]
 version = "1.1.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.rustls]]
-version = "0.23.37"
 criteria = "safe-to-deploy"
 
 [[exemptions.rustls-native-certs]]
@@ -1616,10 +1556,6 @@ criteria = "safe-to-deploy"
 version = "0.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.rustls-webpki]]
-version = "0.103.10"
-criteria = "safe-to-deploy"
-
 [[exemptions.rustversion]]
 version = "1.0.22"
 criteria = "safe-to-deploy"
@@ -1638,10 +1574,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.safer_ffi-proc_macros]]
 version = "0.1.13"
-criteria = "safe-to-deploy"
-
-[[exemptions.salsa20]]
-version = "0.11.0-rc.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.same-file]]
@@ -1747,10 +1679,6 @@ criteria = "safe-to-run"
 [[exemptions.serial_test_derive]]
 version = "3.4.0"
 criteria = "safe-to-run"
-
-[[exemptions.sha1]]
-version = "0.11.0-rc.2"
-criteria = "safe-to-deploy"
 
 [[exemptions.sha2]]
 version = "0.11.0-rc.2"
@@ -1960,10 +1888,6 @@ criteria = "safe-to-deploy"
 version = "2.6.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.tokio-rustls]]
-version = "0.26.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.tokio-stream]]
 version = "0.1.18"
 criteria = "safe-to-deploy"
@@ -2096,10 +2020,6 @@ criteria = "safe-to-deploy"
 version = "0.6.0-rc.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.untrusted]]
-version = "0.9.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.unwind_safe]]
 version = "0.1.0"
 criteria = "safe-to-deploy"
@@ -2173,10 +2093,6 @@ version = "0.26.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.webpki-root-certs]]
-version = "1.0.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.webpki-roots]]
 version = "1.0.6"
 criteria = "safe-to-deploy"
 
@@ -2456,10 +2372,6 @@ criteria = "safe-to-deploy"
 version = "0.7.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.x25519-dalek]]
-version = "2.0.1"
-criteria = "safe-to-deploy"
-
 [[exemptions.x509-parser]]
 version = "0.18.1"
 criteria = "safe-to-deploy"
@@ -2494,10 +2406,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy-derive]]
 version = "0.8.42"
-criteria = "safe-to-deploy"
-
-[[exemptions.zeroize]]
-version = "1.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zeroize_derive]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1,6 +1,41 @@
 
 # cargo-vet imports lock
 
+[[publisher.argon2]]
+version = "0.5.3"
+when = "2024-01-20"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
+[[publisher.aws-lc-rs]]
+version = "1.16.1"
+when = "2026-03-02"
+user-id = 156764
+user-login = "justsmth"
+user-name = "Justin W Smith"
+
+[[publisher.aws-lc-sys]]
+version = "0.38.0"
+when = "2026-03-02"
+user-id = 156764
+user-login = "justsmth"
+user-name = "Justin W Smith"
+
+[[publisher.blake2]]
+version = "0.10.6"
+when = "2022-12-16"
+user-id = 5059
+user-login = "newpavlov"
+user-name = "Artyom Pavlov"
+
+[[publisher.blake3]]
+version = "1.8.3"
+when = "2026-01-08"
+user-id = 3589
+user-login = "oconnor663"
+user-name = "Jack O'Connor"
+
 [[publisher.bumpalo]]
 version = "3.20.2"
 when = "2026-02-19"
@@ -15,6 +50,20 @@ user-id = 3788
 user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
+[[publisher.chacha20poly1305]]
+version = "0.10.1"
+when = "2022-08-10"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
+[[publisher.cipher]]
+version = "0.5.0-rc.1"
+when = "2025-09-02"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
 [[publisher.core-foundation]]
 version = "0.9.3"
 when = "2022-02-07"
@@ -22,12 +71,96 @@ user-id = 5946
 user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
+[[publisher.crypto_box]]
+version = "0.10.0-pre.0"
+when = "2025-10-05"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
+[[publisher.crypto_secretbox]]
+version = "0.2.0-pre.0"
+when = "2025-10-05"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
 [[publisher.encoding_rs]]
 version = "0.8.35"
 when = "2024-10-24"
 user-id = 4484
 user-login = "hsivonen"
 user-name = "Henri Sivonen"
+
+[[publisher.hkdf]]
+version = "0.12.4"
+when = "2023-12-13"
+user-id = 5059
+user-login = "newpavlov"
+user-name = "Artyom Pavlov"
+
+[[publisher.password-hash]]
+version = "0.5.0"
+when = "2023-03-04"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
+[[publisher.pem]]
+version = "3.0.6"
+when = "2025-10-10"
+user-id = 3635
+user-login = "jcreekmore"
+user-name = "Jonathan Creekmore"
+
+[[publisher.rcgen]]
+version = "0.14.7"
+when = "2026-01-19"
+user-id = 4556
+user-login = "djc"
+user-name = "Dirkjan Ochtman"
+
+[[publisher.ring]]
+version = "0.17.14"
+when = "2025-03-11"
+user-id = 2342
+user-login = "briansmith"
+user-name = "Brian Smith"
+
+[[publisher.rustls]]
+version = "0.23.37"
+when = "2026-02-24"
+user-id = 209038
+user-login = "cpu"
+user-name = "Daniel McCarney"
+
+[[publisher.rustls-webpki]]
+version = "0.103.10"
+when = "2026-03-20"
+user-id = 2751
+user-login = "ctz"
+user-name = "Joe Birr-Pixton"
+
+[[publisher.salsa20]]
+version = "0.11.0-rc.1"
+when = "2025-09-02"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
+[[publisher.sha1]]
+version = "0.11.0-rc.2"
+when = "2025-09-02"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
+
+[[publisher.tokio-rustls]]
+version = "0.26.4"
+when = "2025-09-26"
+user-id = 4556
+user-login = "djc"
+user-name = "Dirkjan Ochtman"
 
 [[publisher.unicode-segmentation]]
 version = "1.12.0"
@@ -160,6 +293,13 @@ user-id = 111105
 user-login = "mhammond"
 user-name = "Mark Hammond"
 
+[[publisher.untrusted]]
+version = "0.9.0"
+when = "2021-07-13"
+user-id = 2342
+user-login = "briansmith"
+user-name = "Brian Smith"
+
 [[publisher.utf8_iter]]
 version = "1.0.4"
 when = "2023-12-01"
@@ -197,6 +337,13 @@ version = "0.244.0"
 when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
+[[publisher.webpki-roots]]
+version = "1.0.6"
+when = "2026-02-03"
+user-id = 2751
+user-login = "ctz"
+user-name = "Joe Birr-Pixton"
+
 [[publisher.weedle2]]
 version = "5.0.0"
 when = "2024-01-24"
@@ -232,6 +379,20 @@ trusted-publisher = "github:bytecodealliance/wasm-tools"
 version = "0.244.0"
 when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
+
+[[publisher.x25519-dalek]]
+version = "2.0.1"
+when = "2024-02-07"
+user-id = 6979
+user-login = "rozbb"
+user-name = "Michael Rosenberg"
+
+[[publisher.zeroize]]
+version = "1.8.2"
+when = "2025-09-29"
+user-id = 267
+user-login = "tarcieri"
+user-name = "Tony Arcieri"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"


### PR DESCRIPTION
## Summary

Add a parallel CI job that enforces supply chain policies established in #734:
- `cargo deny check` — advisories, license allowlist, source restrictions, crate bans
- `cargo vet` — audit verification against trusted imports (Mozilla, Google, Bytecode Alliance, ISRG)

## Test plan

- [x] `cargo deny check` passes locally
- [x] `cargo vet` passes locally
- [ ] CI pipeline