### PR TITLE
fix: replace unwrap() in priority library modules

### DIFF
--- a/peat-protocol/src/command/conflict_resolver.rs
+++ b/peat-protocol/src/command/conflict_resolver.rs
@@ -75,7 +75,7 @@ impl ConflictResolver {
         }
 
         if commands.len() == 1 {
-            return Ok(commands.into_iter().next().unwrap());
+            return Ok(commands.into_iter().next().expect("len checked to be 1"));
         }
 
         match policy {
@@ -141,7 +141,10 @@ impl ConflictResolver {
             b_time.cmp(&a_time) // Descending order (most recent first)
         });
 
-        Ok(commands.into_iter().next().unwrap())
+        Ok(commands
+            .into_iter()
+            .next()
+            .expect("commands verified non-empty at function entry"))
     }
 
     /// Resolve using HIGHEST_PRIORITY_WINS policy
@@ -159,7 +162,10 @@ impl ConflictResolver {
             b_priority.cmp(&a_priority) // Descending order (highest priority first)
         });
 
-        Ok(commands.into_iter().next().unwrap())
+        Ok(commands
+            .into_iter()
+            .next()
+            .expect("commands verified non-empty at function entry"))
     }
 
     /// Resolve using HIGHEST_AUTHORITY_WINS policy
@@ -179,7 +185,10 @@ impl ConflictResolver {
             b_authority.cmp(&a_authority) // Descending order (highest authority first)
         });
 
-        Ok(commands.into_iter().next().unwrap())
+        Ok(commands
+            .into_iter()
+            .next()
+            .expect("commands verified non-empty at function entry"))
     }
 
     /// Resolve using MERGE_COMPATIBLE policy
@@ -193,7 +202,10 @@ impl ConflictResolver {
     ) -> Result<HierarchicalCommand> {
         // TODO: Implement actual compatibility checking and merging
         // For now, just return the first command
-        Ok(commands.into_iter().next().unwrap())
+        Ok(commands
+            .into_iter()
+            .next()
+            .expect("commands verified non-empty at function entry"))
     }
 
     /// Derive authority level from node ID

--- a/peat-protocol/src/command/coordinator.rs
+++ b/peat-protocol/src/command/coordinator.rs
@@ -124,7 +124,7 @@ impl CommandCoordinator {
             last_updated: Some(peat_schema::common::v1::Timestamp {
                 seconds: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
+                    .expect("system clock is before Unix epoch")
                     .as_secs(),
                 nanos: 0,
             }),
@@ -258,7 +258,7 @@ impl CommandCoordinator {
                     last_updated: Some(peat_schema::common::v1::Timestamp {
                         seconds: std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap()
+                            .expect("system clock is before Unix epoch")
                             .as_secs(),
                         nanos: 0,
                     }),
@@ -301,7 +301,7 @@ impl CommandCoordinator {
             timestamp: Some(peat_schema::common::v1::Timestamp {
                 seconds: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
+                    .expect("system clock is before Unix epoch")
                     .as_secs(),
                 nanos: 0,
             }),

--- a/peat-protocol/src/network/iroh_transport.rs
+++ b/peat-protocol/src/network/iroh_transport.rs
@@ -140,7 +140,7 @@ fn create_tactical_transport_config() -> TransportConfig {
     config.max_idle_timeout(Some(
         Duration::from_secs(QUIC_MAX_IDLE_TIMEOUT_SECS)
             .try_into()
-            .unwrap(),
+            .expect("valid idle timeout duration"),
     ));
 
     // Enable keep-alive packets every 3 seconds to prevent healthy connections
@@ -638,7 +638,10 @@ impl IrohTransport {
     pub async fn enable_mdns_discovery(&self) -> Result<()> {
         // Check if already enabled
         {
-            let guard = self.mdns_discovery.read().unwrap();
+            let guard = self
+                .mdns_discovery
+                .read()
+                .expect("mdns_discovery lock poisoned");
             if guard.is_some() {
                 anyhow::bail!("mDNS discovery is already enabled");
             }
@@ -657,7 +660,10 @@ impl IrohTransport {
         );
 
         // Store the discovery service for later access
-        *self.mdns_discovery.write().unwrap() = Some(discovery);
+        *self
+            .mdns_discovery
+            .write()
+            .expect("mdns_discovery lock poisoned") = Some(discovery);
 
         Ok(())
     }
@@ -815,7 +821,7 @@ impl IrohTransport {
 
         // Check if we already have a live connection to this peer
         {
-            let connections = self.connections.read().unwrap();
+            let connections = self.connections.read().expect("connections lock poisoned");
             if let Some(existing) = connections.get(&remote_id) {
                 if existing.close_reason().is_none() {
                     tracing::debug!(
@@ -845,7 +851,7 @@ impl IrohTransport {
         // Issue #346: We always store and return our connection. Conflict resolution
         // happens in accept() if there's a simultaneous connection from the peer.
         // This supports both symmetric (both initiate) and asymmetric (one initiates) cases.
-        let mut connections = self.connections.write().unwrap();
+        let mut connections = self.connections.write().expect("connections lock poisoned");
         if let Some(existing) = connections.get(&remote_id) {
             if existing.close_reason().is_none() {
                 // Accept loop already stored a connection from this peer.
@@ -883,7 +889,7 @@ impl IrohTransport {
         // Track connection timestamp for recycling (Issue #435 workaround)
         self.connection_timestamps
             .write()
-            .unwrap()
+            .expect("connection_timestamps lock poisoned")
             .insert(remote_id, std::time::Instant::now());
 
         // NOTE: Connected event is NOT emitted here (Issue #346).
@@ -992,7 +998,10 @@ impl IrohTransport {
 
     /// Check if mDNS discovery is enabled
     pub fn has_discovery(&self) -> bool {
-        self.mdns_discovery.read().unwrap().is_some()
+        self.mdns_discovery
+            .read()
+            .expect("mdns_discovery lock poisoned")
+            .is_some()
     }
 
     /// Get a clone of the mDNS discovery service (Issue #233)
@@ -1025,7 +1034,10 @@ impl IrohTransport {
     /// }
     /// ```
     pub fn mdns_discovery(&self) -> Option<MdnsDiscovery> {
-        self.mdns_discovery.read().unwrap().clone()
+        self.mdns_discovery
+            .read()
+            .expect("mdns_discovery lock poisoned")
+            .clone()
     }
 
     /// Accept an incoming connection
@@ -1080,7 +1092,7 @@ impl IrohTransport {
         let remote_id = conn.remote_id();
         let our_id = self.endpoint_id();
 
-        let mut connections = self.connections.write().unwrap();
+        let mut connections = self.connections.write().expect("connections lock poisoned");
 
         // Check for existing connection (conflict detection)
         if let Some(existing) = connections.get(&remote_id) {
@@ -1124,7 +1136,7 @@ impl IrohTransport {
         // Track connection timestamp for recycling (Issue #435 workaround)
         self.connection_timestamps
             .write()
-            .unwrap()
+            .expect("connection_timestamps lock poisoned")
             .insert(remote_id, std::time::Instant::now());
 
         // NOTE: Connected event is NOT emitted here (Issue #346).
@@ -1139,7 +1151,11 @@ impl IrohTransport {
 
     /// Get an existing connection to a peer
     pub fn get_connection(&self, endpoint_id: &EndpointId) -> Option<Connection> {
-        self.connections.read().unwrap().get(endpoint_id).cloned()
+        self.connections
+            .read()
+            .expect("connections lock poisoned")
+            .get(endpoint_id)
+            .cloned()
     }
 
     /// Disconnect from a peer
@@ -1147,10 +1163,15 @@ impl IrohTransport {
         // Remove timestamp tracking (Issue #435 workaround)
         self.connection_timestamps
             .write()
-            .unwrap()
+            .expect("connection_timestamps lock poisoned")
             .remove(endpoint_id);
 
-        if let Some(conn) = self.connections.write().unwrap().remove(endpoint_id) {
+        if let Some(conn) = self
+            .connections
+            .write()
+            .expect("connections lock poisoned")
+            .remove(endpoint_id)
+        {
             conn.close(0u32.into(), b"disconnecting");
             // Emit disconnect event (Issue #275)
             self.emit_event(TransportPeerEvent::Disconnected {
@@ -1176,7 +1197,10 @@ impl IrohTransport {
     /// Vector of EndpointIds for connections older than `max_age`
     pub fn connections_older_than(&self, max_age: Duration) -> Vec<EndpointId> {
         let now = std::time::Instant::now();
-        let timestamps = self.connection_timestamps.read().unwrap();
+        let timestamps = self
+            .connection_timestamps
+            .read()
+            .expect("connection_timestamps lock poisoned");
         timestamps
             .iter()
             .filter_map(|(id, &connected_at)| {
@@ -1254,7 +1278,10 @@ impl IrohTransport {
     /// ```
     pub fn subscribe_peer_events(&self) -> TransportEventReceiver {
         let (tx, rx) = mpsc::channel(TRANSPORT_EVENT_CHANNEL_CAPACITY);
-        self.event_senders.write().unwrap().push(tx);
+        self.event_senders
+            .write()
+            .expect("event_senders lock poisoned")
+            .push(tx);
         rx
     }
 
@@ -1262,7 +1289,10 @@ impl IrohTransport {
     ///
     /// Called internally when connections are established or closed.
     fn emit_event(&self, event: TransportPeerEvent) {
-        let senders = self.event_senders.read().unwrap();
+        let senders = self
+            .event_senders
+            .read()
+            .expect("event_senders lock poisoned");
         for sender in senders.iter() {
             // Non-blocking send - drop if channel is full
             let _ = sender.try_send(event.clone());
@@ -1301,7 +1331,7 @@ impl IrohTransport {
             // 3. Monitor for A wakes up - must NOT remove B!
             let should_emit_disconnect;
             {
-                let mut conns = connections.write().unwrap();
+                let mut conns = connections.write().expect("connections lock poisoned");
                 if let Some(current_conn) = conns.get(&endpoint_id) {
                     if current_conn.stable_id() == monitored_stable_id {
                         // Same connection - safe to remove
@@ -1330,7 +1360,7 @@ impl IrohTransport {
                     endpoint_id,
                     reason,
                 };
-                let senders = event_senders.read().unwrap();
+                let senders = event_senders.read().expect("event_senders lock poisoned");
                 for sender in senders.iter() {
                     let _ = sender.try_send(event.clone());
                 }
@@ -1344,7 +1374,10 @@ impl IrohTransport {
     /// Automatically cleans up closed connections from the map.
     pub fn peer_count(&self) -> usize {
         self.cleanup_closed_connections();
-        self.connections.read().unwrap().len()
+        self.connections
+            .read()
+            .expect("connections lock poisoned")
+            .len()
     }
 
     /// Get all currently connected peer IDs
@@ -1353,7 +1386,12 @@ impl IrohTransport {
     /// Automatically cleans up closed connections from the map.
     pub fn connected_peers(&self) -> Vec<EndpointId> {
         self.cleanup_closed_connections();
-        self.connections.read().unwrap().keys().copied().collect()
+        self.connections
+            .read()
+            .expect("connections lock poisoned")
+            .keys()
+            .copied()
+            .collect()
     }
 
     /// Remove closed connections from the connections map
@@ -1364,7 +1402,7 @@ impl IrohTransport {
     pub fn cleanup_closed_connections(&self) {
         // Collect closed connections to emit events after releasing lock
         let closed_peers: Vec<(EndpointId, String)> = {
-            let mut connections = self.connections.write().unwrap();
+            let mut connections = self.connections.write().expect("connections lock poisoned");
             let mut closed = Vec::new();
 
             connections.retain(|endpoint_id, conn| {
@@ -1416,7 +1454,10 @@ impl IrohTransport {
 
         // Clean up timestamps for removed connections (Issue #435 workaround)
         if !closed_peers.is_empty() {
-            let mut timestamps = self.connection_timestamps.write().unwrap();
+            let mut timestamps = self
+                .connection_timestamps
+                .write()
+                .expect("connection_timestamps lock poisoned");
             for (endpoint_id, _) in &closed_peers {
                 timestamps.remove(endpoint_id);
             }
@@ -1474,7 +1515,7 @@ impl IrohTransport {
             tracing::debug!("Accept loop stopped");
         });
 
-        *self.accept_task.write().unwrap() = Some(task);
+        *self.accept_task.write().expect("accept_task lock poisoned") = Some(task);
 
         Ok(())
     }
@@ -1522,7 +1563,12 @@ impl IrohTransport {
         }
 
         // Close all connections
-        for (_endpoint_id, conn) in self.connections.write().unwrap().drain() {
+        for (_endpoint_id, conn) in self
+            .connections
+            .write()
+            .expect("connections lock poisoned")
+            .drain()
+        {
             conn.close(0u32.into(), b"shutdown");
         }
 

--- a/peat-protocol/src/security/audit.rs
+++ b/peat-protocol/src/security/audit.rs
@@ -204,7 +204,8 @@ impl AuditLogEntry {
 fn format_timestamp(secs: u64) -> String {
     // Simple ISO 8601 format without external dependencies
     let dt = chrono::DateTime::from_timestamp(secs as i64, 0)
-        .unwrap_or_else(|| chrono::DateTime::from_timestamp(0, 0).unwrap());
+        .or_else(|| chrono::DateTime::from_timestamp(0, 0))
+        .expect("Unix epoch is always a valid timestamp");
     dt.format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
@@ -262,14 +263,14 @@ impl MemoryAuditLogger {
 
     /// Get all logged entries
     pub fn entries(&self) -> Vec<AuditLogEntry> {
-        self.entries.lock().unwrap().clone()
+        self.entries.lock().expect("entries lock poisoned").clone()
     }
 
     /// Get entries filtered by event type
     pub fn entries_by_type(&self, event_type: AuditEventType) -> Vec<AuditLogEntry> {
         self.entries
             .lock()
-            .unwrap()
+            .expect("entries lock poisoned")
             .iter()
             .filter(|e| e.event_type == event_type)
             .cloned()
@@ -278,17 +279,20 @@ impl MemoryAuditLogger {
 
     /// Clear all entries
     pub fn clear(&self) {
-        self.entries.lock().unwrap().clear();
+        self.entries.lock().expect("entries lock poisoned").clear();
     }
 
     fn next_sequence(&self) -> u64 {
-        let mut seq = self.sequence.lock().unwrap();
+        let mut seq = self.sequence.lock().expect("sequence lock poisoned");
         *seq += 1;
         *seq
     }
 
     fn add_entry(&self, entry: AuditLogEntry) {
-        self.entries.lock().unwrap().push(entry);
+        self.entries
+            .lock()
+            .expect("entries lock poisoned")
+            .push(entry);
     }
 }
 
@@ -431,7 +435,7 @@ impl AuditLogger for MemoryAuditLogger {
     }
 
     fn entry_count(&self) -> u64 {
-        self.entries.lock().unwrap().len() as u64
+        self.entries.lock().expect("entries lock poisoned").len() as u64
     }
 
     fn flush(&self) -> Result<(), SecurityError> {
@@ -468,7 +472,7 @@ impl FileAuditLogger {
     }
 
     fn next_sequence(&self) -> u64 {
-        let mut seq = self.sequence.lock().unwrap();
+        let mut seq = self.sequence.lock().expect("sequence lock poisoned");
         *seq += 1;
         *seq
     }
@@ -625,7 +629,7 @@ impl AuditLogger for FileAuditLogger {
     }
 
     fn entry_count(&self) -> u64 {
-        *self.sequence.lock().unwrap()
+        *self.sequence.lock().expect("sequence lock poisoned")
     }
 
     fn flush(&self) -> Result<(), SecurityError> {

--- a/peat-protocol/src/security/membership.rs
+++ b/peat-protocol/src/security/membership.rs
@@ -369,7 +369,11 @@ impl MembershipCertificate {
                 "truncated issued_at".to_string(),
             ));
         }
-        let issued_at_ms = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+        let issued_at_ms = u64::from_le_bytes(
+            data[offset..offset + 8]
+                .try_into()
+                .expect("slice length verified by preceding bounds check"),
+        );
         offset += 8;
 
         // expires_at_ms (8)
@@ -378,7 +382,11 @@ impl MembershipCertificate {
                 "truncated expires_at".to_string(),
             ));
         }
-        let expires_at_ms = u64::from_le_bytes(data[offset..offset + 8].try_into().unwrap());
+        let expires_at_ms = u64::from_le_bytes(
+            data[offset..offset + 8]
+                .try_into()
+                .expect("slice length verified by preceding bounds check"),
+        );
         offset += 8;
 
         // permissions (1)

--- a/peat-protocol/src/security/transport.rs
+++ b/peat-protocol/src/security/transport.rs
@@ -227,7 +227,11 @@ impl<T: MeshTransport + 'static, A: AuthenticationChannel + 'static> MeshTranspo
         // Return an authenticated connection wrapper
         Ok(Box::new(AuthenticatedConnection {
             inner: conn,
-            device_id: self.get_peer_device_id(peer_id).unwrap(), // Safe: just authenticated
+            device_id: self.get_peer_device_id(peer_id).ok_or_else(|| {
+                TransportError::ConnectionFailed(
+                    "peer device ID missing after authentication".to_string(),
+                )
+            })?,
         }))
     }
 

--- a/peat-protocol/src/security/user_auth.rs
+++ b/peat-protocol/src/security/user_auth.rs
@@ -510,7 +510,7 @@ impl LocalUserStore {
     pub fn with_users(users: Vec<UserRecord>) -> Self {
         let store = Self::new();
         {
-            let mut map = store.users.write().unwrap();
+            let mut map = store.users.write().expect("users lock poisoned");
             for user in users {
                 map.insert(user.identity.username.clone(), user);
             }
@@ -521,11 +521,14 @@ impl LocalUserStore {
 
 impl UserStore for LocalUserStore {
     fn get_user(&self, username: &str) -> Option<UserRecord> {
-        self.users.read().unwrap().get(username).cloned()
+        self.users.read().ok()?.get(username).cloned()
     }
 
     fn store_user(&self, record: UserRecord) -> Result<(), SecurityError> {
-        let mut users = self.users.write().unwrap();
+        let mut users = self
+            .users
+            .write()
+            .map_err(|e| SecurityError::Internal(format!("users lock poisoned: {e}")))?;
         if users.contains_key(&record.identity.username) {
             return Err(SecurityError::UserAlreadyExists {
                 username: record.identity.username,
@@ -536,7 +539,10 @@ impl UserStore for LocalUserStore {
     }
 
     fn update_user(&self, record: UserRecord) -> Result<(), SecurityError> {
-        let mut users = self.users.write().unwrap();
+        let mut users = self
+            .users
+            .write()
+            .map_err(|e| SecurityError::Internal(format!("users lock poisoned: {e}")))?;
         if !users.contains_key(&record.identity.username) {
             return Err(SecurityError::UserNotFound {
                 username: record.identity.username,
@@ -547,7 +553,10 @@ impl UserStore for LocalUserStore {
     }
 
     fn delete_user(&self, username: &str) -> Result<(), SecurityError> {
-        let mut users = self.users.write().unwrap();
+        let mut users = self
+            .users
+            .write()
+            .map_err(|e| SecurityError::Internal(format!("users lock poisoned: {e}")))?;
         if users.remove(username).is_none() {
             return Err(SecurityError::UserNotFound {
                 username: username.to_string(),
@@ -557,7 +566,10 @@ impl UserStore for LocalUserStore {
     }
 
     fn list_users(&self) -> Vec<String> {
-        self.users.read().unwrap().keys().cloned().collect()
+        self.users
+            .read()
+            .map(|u| u.keys().cloned().collect())
+            .unwrap_or_default()
     }
 }
 
@@ -710,7 +722,7 @@ impl UserAuthenticator {
         // Store session
         self.sessions
             .write()
-            .unwrap()
+            .map_err(|e| SecurityError::Internal(format!("sessions lock poisoned: {e}")))?
             .insert(session.session_id, session.clone());
 
         Ok(session)
@@ -802,7 +814,7 @@ impl UserAuthenticator {
         // Store session
         self.sessions
             .write()
-            .unwrap()
+            .map_err(|e| SecurityError::Internal(format!("sessions lock poisoned: {e}")))?
             .insert(session.session_id, session.clone());
 
         Ok(session)
@@ -810,7 +822,10 @@ impl UserAuthenticator {
 
     /// Validate a session and return the user identity.
     pub fn validate_session(&self, session_id: &SessionId) -> Result<UserIdentity, SecurityError> {
-        let sessions = self.sessions.read().unwrap();
+        let sessions = self
+            .sessions
+            .read()
+            .map_err(|e| SecurityError::Internal(format!("sessions lock poisoned: {e}")))?;
         let session = sessions
             .get(session_id)
             .ok_or(SecurityError::SessionNotFound)?;
@@ -826,30 +841,34 @@ impl UserAuthenticator {
 
     /// Get a session by ID.
     pub fn get_session(&self, session_id: &SessionId) -> Option<UserSession> {
-        self.sessions.read().unwrap().get(session_id).cloned()
+        self.sessions.read().ok()?.get(session_id).cloned()
     }
 
     /// Invalidate (logout) a session.
     pub fn invalidate_session(&self, session_id: &SessionId) {
-        self.sessions.write().unwrap().remove(session_id);
+        if let Ok(mut sessions) = self.sessions.write() {
+            sessions.remove(session_id);
+        }
     }
 
     /// Invalidate all sessions for a user.
     pub fn invalidate_user_sessions(&self, username: &str) {
-        let mut sessions = self.sessions.write().unwrap();
-        sessions.retain(|_, session| session.identity.username != username);
+        if let Ok(mut sessions) = self.sessions.write() {
+            sessions.retain(|_, session| session.identity.username != username);
+        }
     }
 
     /// Clean up expired sessions.
     pub fn cleanup_expired_sessions(&self) {
         let now = SystemTime::now();
-        let mut sessions = self.sessions.write().unwrap();
-        sessions.retain(|_, session| session.expires_at > now);
+        if let Ok(mut sessions) = self.sessions.write() {
+            sessions.retain(|_, session| session.expires_at > now);
+        }
     }
 
     /// Get count of active sessions.
     pub fn active_session_count(&self) -> usize {
-        self.sessions.read().unwrap().len()
+        self.sessions.read().map(|s| s.len()).unwrap_or(0)
     }
 
     /// Bind a session to a device.
@@ -858,7 +877,10 @@ impl UserAuthenticator {
         session_id: &SessionId,
         device_id: DeviceId,
     ) -> Result<(), SecurityError> {
-        let mut sessions = self.sessions.write().unwrap();
+        let mut sessions = self
+            .sessions
+            .write()
+            .map_err(|e| SecurityError::Internal(format!("sessions lock poisoned: {e}")))?;
         let session = sessions
             .get_mut(session_id)
             .ok_or(SecurityError::SessionNotFound)?;

--- a/peat-protocol/src/sync/automerge.rs
+++ b/peat-protocol/src/sync/automerge.rs
@@ -485,7 +485,10 @@ impl AutomergeBackend {
         peer_id: &str,
     ) -> Result<Vec<u8>> {
         let key = Self::doc_key(collection, doc_id);
-        let docs = self.documents.lock().unwrap();
+        let docs = self
+            .documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?;
 
         let automerge_doc = docs.get(&key).ok_or_else(|| Error::NotFound {
             resource_type: "Document".to_string(),
@@ -493,7 +496,10 @@ impl AutomergeBackend {
         })?;
 
         // Get or create sync state for this peer
-        let mut sync_states = self.sync_states.lock().unwrap();
+        let mut sync_states = self
+            .sync_states
+            .lock()
+            .map_err(|_| Error::Internal("sync_states lock poisoned".into()))?;
         let sync_state = sync_states
             .entry(format!("{}:{}", peer_id, key))
             .or_default();
@@ -519,7 +525,10 @@ impl AutomergeBackend {
         message: &[u8],
     ) -> Result<()> {
         let key = Self::doc_key(collection, doc_id);
-        let mut docs = self.documents.lock().unwrap();
+        let mut docs = self
+            .documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?;
 
         let automerge_doc = docs.get_mut(&key).ok_or_else(|| Error::NotFound {
             resource_type: "Document".to_string(),
@@ -531,7 +540,10 @@ impl AutomergeBackend {
             .map_err(|e| Error::Internal(format!("Message decode failed: {:?}", e)))?;
 
         // Get sync state
-        let mut sync_states = self.sync_states.lock().unwrap();
+        let mut sync_states = self
+            .sync_states
+            .lock()
+            .map_err(|_| Error::Internal("sync_states lock poisoned".into()))?;
         let sync_state = sync_states
             .entry(format!("{}:{}", peer_id, key))
             .or_default();
@@ -565,7 +577,10 @@ impl DocumentStore for AutomergeBackend {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
 
         let key = Self::doc_key(collection, &doc_id);
-        let mut docs = self.documents.lock().unwrap();
+        let mut docs = self
+            .documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?;
 
         if let Some(existing_doc) = docs.get_mut(&key) {
             // Update existing document
@@ -581,7 +596,10 @@ impl DocumentStore for AutomergeBackend {
 
         // Notify observers
         drop(docs); // Release lock before notifying
-        let observers = self.observers.lock().unwrap();
+        let observers = self
+            .observers
+            .lock()
+            .map_err(|_| Error::Internal("observers lock poisoned".into()))?;
         for observer in observers.iter() {
             let _ = observer.send(ChangeEvent::Updated {
                 collection: collection.to_string(),
@@ -594,7 +612,10 @@ impl DocumentStore for AutomergeBackend {
     }
 
     async fn query(&self, collection: &str, query: &Query) -> anyhow::Result<Vec<Document>> {
-        let docs = self.documents.lock().unwrap();
+        let docs = self
+            .documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?;
         let mut results = Vec::new();
 
         // Iterate all documents in collection
@@ -627,7 +648,10 @@ impl DocumentStore for AutomergeBackend {
 
     async fn remove(&self, collection: &str, doc_id: &DocumentId) -> anyhow::Result<()> {
         let key = Self::doc_key(collection, doc_id);
-        let mut docs = self.documents.lock().unwrap();
+        let mut docs = self
+            .documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?;
 
         docs.remove(&key).ok_or_else(|| Error::NotFound {
             resource_type: "Document".to_string(),
@@ -636,7 +660,10 @@ impl DocumentStore for AutomergeBackend {
 
         // Notify observers
         drop(docs); // Release lock before notifying
-        let observers = self.observers.lock().unwrap();
+        let observers = self
+            .observers
+            .lock()
+            .map_err(|_| Error::Internal("observers lock poisoned".into()))?;
         for observer in observers.iter() {
             let _ = observer.send(ChangeEvent::Removed {
                 collection: collection.to_string(),
@@ -650,7 +677,10 @@ impl DocumentStore for AutomergeBackend {
 
     async fn get(&self, collection: &str, doc_id: &DocumentId) -> anyhow::Result<Option<Document>> {
         let key = Self::doc_key(collection, doc_id);
-        let docs = self.documents.lock().unwrap();
+        let docs = self
+            .documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?;
 
         if let Some(automerge_doc) = docs.get(&key) {
             let document = Self::automerge_to_document(automerge_doc, doc_id.clone())?;
@@ -669,7 +699,10 @@ impl DocumentStore for AutomergeBackend {
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 
         // Send initial snapshot of matching documents
-        let docs = self.documents.lock().unwrap();
+        let docs = self
+            .documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?;
         let mut initial_docs = Vec::new();
 
         for (key, automerge_doc) in docs.iter() {
@@ -693,7 +726,10 @@ impl DocumentStore for AutomergeBackend {
         });
 
         // Register this observer for future updates
-        self.observers.lock().unwrap().push(tx.clone());
+        self.observers
+            .lock()
+            .map_err(|_| Error::Internal("observers lock poisoned".into()))?
+            .push(tx.clone());
 
         Ok(ChangeStream { receiver: rx })
     }
@@ -748,7 +784,7 @@ impl DocumentStore for AutomergeBackend {
                 // Store tombstone
                 self.tombstones
                     .lock()
-                    .unwrap()
+                    .map_err(|_| Error::Internal("tombstones lock poisoned".into()))?
                     .insert(tombstone_id.clone(), tombstone.clone());
 
                 // Remove the actual document
@@ -797,7 +833,12 @@ impl DocumentStore for AutomergeBackend {
         let key = format!("{}:{}", collection, doc_id);
 
         // Check if there's a tombstone
-        if self.tombstones.lock().unwrap().contains_key(&key) {
+        if self
+            .tombstones
+            .lock()
+            .map_err(|_| Error::Internal("tombstones lock poisoned".into()))?
+            .contains_key(&key)
+        {
             return Ok(true);
         }
 
@@ -816,7 +857,10 @@ impl DocumentStore for AutomergeBackend {
     }
 
     async fn get_tombstones(&self, collection: &str) -> anyhow::Result<Vec<crate::qos::Tombstone>> {
-        let tombstones = self.tombstones.lock().unwrap();
+        let tombstones = self
+            .tombstones
+            .lock()
+            .map_err(|_| Error::Internal("tombstones lock poisoned".into()))?;
         let prefix = format!("{}:", collection);
 
         Ok(tombstones
@@ -832,7 +876,7 @@ impl DocumentStore for AutomergeBackend {
         // Store the tombstone
         self.tombstones
             .lock()
-            .unwrap()
+            .map_err(|_| Error::Internal("tombstones lock poisoned".into()))?
             .insert(key, tombstone.clone());
 
         // Remove the document if it exists
@@ -900,7 +944,10 @@ impl SyncEngine for AutomergeBackend {
 
     async fn stop_sync(&self) -> anyhow::Result<()> {
         // Clean up sync states
-        self.sync_states.lock().unwrap().clear();
+        self.sync_states
+            .lock()
+            .map_err(|_| Error::Internal("sync_states lock poisoned".into()))?
+            .clear();
         Ok(())
     }
 
@@ -938,12 +985,18 @@ struct AutomergeSubscriptionHandle {
 #[async_trait]
 impl DataSyncBackend for AutomergeBackend {
     async fn initialize(&self, config: BackendConfig) -> anyhow::Result<()> {
-        let mut initialized = self.initialized.lock().unwrap();
+        let mut initialized = self
+            .initialized
+            .lock()
+            .map_err(|_| Error::Internal("initialized lock poisoned".into()))?;
         if *initialized {
             return Err(Error::Internal("Already initialized".into()).into());
         }
 
-        *self.config.lock().unwrap() = Some(config);
+        *self
+            .config
+            .lock()
+            .map_err(|_| Error::Internal("config lock poisoned".into()))? = Some(config);
         *initialized = true;
 
         Ok(())
@@ -951,9 +1004,18 @@ impl DataSyncBackend for AutomergeBackend {
 
     async fn shutdown(&self) -> anyhow::Result<()> {
         self.stop_sync().await?;
-        self.documents.lock().unwrap().clear();
-        self.sync_states.lock().unwrap().clear();
-        *self.initialized.lock().unwrap() = false;
+        self.documents
+            .lock()
+            .map_err(|_| Error::Internal("documents lock poisoned".into()))?
+            .clear();
+        self.sync_states
+            .lock()
+            .map_err(|_| Error::Internal("sync_states lock poisoned".into()))?
+            .clear();
+        *self
+            .initialized
+            .lock()
+            .map_err(|_| Error::Internal("initialized lock poisoned".into()))? = false;
 
         Ok(())
     }
@@ -975,7 +1037,7 @@ impl DataSyncBackend for AutomergeBackend {
     }
 
     async fn is_ready(&self) -> bool {
-        *self.initialized.lock().unwrap()
+        self.initialized.lock().map(|guard| *guard).unwrap_or(false)
     }
 
     fn backend_info(&self) -> BackendInfo {
@@ -1142,16 +1204,18 @@ impl AutomergeIrohBackend {
 
     /// Get the formation key (if initialized with credentials)
     pub fn formation_key(&self) -> Option<crate::security::FormationKey> {
-        self.formation_key.read().unwrap().clone()
+        self.formation_key
+            .read()
+            .ok()
+            .and_then(|guard| guard.clone())
     }
 
     /// Get the formation ID (app_id used as formation identifier)
     pub fn formation_id(&self) -> Option<String> {
         self.formation_key
             .read()
-            .unwrap()
-            .as_ref()
-            .map(|k| k.formation_id().to_string())
+            .ok()
+            .and_then(|guard| guard.as_ref().map(|k| k.formation_id().to_string()))
     }
 
     /// Create from store and transport (convenience method)
@@ -1416,7 +1480,7 @@ impl AutomergeIrohBackend {
         let formation_key = self
             .formation_key
             .read()
-            .unwrap()
+            .map_err(|_| Error::Internal("formation_key lock poisoned".into()))?
             .clone()
             .ok_or_else(|| Error::config_error("Backend not initialized", None))?;
 
@@ -1558,7 +1622,7 @@ impl DocumentStore for IrohDocumentStore {
             use std::time::SystemTime;
             let timestamp = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
+                .expect("system clock before UNIX epoch")
                 .as_nanos();
             format!("doc-{}", timestamp)
         });
@@ -1869,7 +1933,7 @@ impl PeerDiscovery for IrohPeerDiscovery {
         let formation_key = self
             .formation_key
             .read()
-            .unwrap()
+            .map_err(|_| Error::Internal("formation_key lock poisoned".into()))?
             .clone()
             .ok_or_else(|| Error::Internal("Formation key not initialized".to_string()))?;
 
@@ -2447,7 +2511,7 @@ impl PeerDiscovery for IrohPeerDiscovery {
         let formation_key = self
             .formation_key
             .read()
-            .unwrap()
+            .map_err(|_| Error::Internal("formation_key lock poisoned".into()))?
             .clone()
             .ok_or_else(|| Error::Internal("Formation key not initialized".to_string()))?;
 
@@ -2556,7 +2620,9 @@ impl PeerDiscovery for IrohPeerDiscovery {
     }
 
     fn on_peer_event(&self, callback: Box<dyn Fn(PeerEvent) + Send + Sync>) {
-        self.peer_callbacks.lock().unwrap().push(callback);
+        if let Ok(mut callbacks) = self.peer_callbacks.lock() {
+            callbacks.push(callback);
+        }
 
         // Start event forwarder on first callback registration (Issue #275)
         // Use compare_exchange to ensure we only start once
@@ -2856,9 +2922,16 @@ impl DataSyncBackend for AutomergeIrohBackend {
             })?;
 
         // Store the formation key for peer authentication
-        *self.formation_key.write().unwrap() = Some(formation_key);
+        *self
+            .formation_key
+            .write()
+            .map_err(|_| Error::Internal("formation_key lock poisoned".into()))? =
+            Some(formation_key);
 
-        *self.initialized.lock().unwrap() = true;
+        *self
+            .initialized
+            .lock()
+            .map_err(|_| Error::Internal("initialized lock poisoned".into()))? = true;
         self.peer_discovery().start().await?;
         Ok(())
     }
@@ -2868,7 +2941,10 @@ impl DataSyncBackend for AutomergeIrohBackend {
             let _ = self.sync_engine().stop_sync().await;
             let _ = self.peer_discovery().stop().await;
         }
-        *self.initialized.lock().unwrap() = false;
+        *self
+            .initialized
+            .lock()
+            .map_err(|_| Error::Internal("initialized lock poisoned".into()))? = false;
         Ok(())
     }
 
@@ -2903,7 +2979,7 @@ impl DataSyncBackend for AutomergeIrohBackend {
     }
 
     async fn is_ready(&self) -> bool {
-        *self.initialized.lock().unwrap()
+        self.initialized.lock().map(|guard| *guard).unwrap_or(false)
     }
 
     fn backend_info(&self) -> BackendInfo {

--- a/peat-protocol/src/sync/ditto.rs
+++ b/peat-protocol/src/sync/ditto.rs
@@ -60,7 +60,7 @@ impl DittoBackend {
     fn get_store(&self) -> Result<Arc<DittoStore>> {
         self.store
             .lock()
-            .unwrap()
+            .map_err(|_| Error::Internal("store lock poisoned".into()))?
             .as_ref()
             .cloned()
             .ok_or_else(|| Error::config_error("Backend not initialized", None))
@@ -116,13 +116,21 @@ impl DataSyncBackend for DittoBackend {
         let store = Arc::new(DittoStore::new(ditto_config)?);
 
         // Store it
-        *self.store.lock().unwrap() = Some(store);
+        *self
+            .store
+            .lock()
+            .map_err(|_| Error::Internal("store lock poisoned".into()))? = Some(store);
 
         Ok(())
     }
 
     async fn shutdown(&self) -> anyhow::Result<()> {
-        if let Some(store) = self.store.lock().unwrap().take() {
+        if let Some(store) = self
+            .store
+            .lock()
+            .map_err(|_| Error::Internal("store lock poisoned".into()))?
+            .take()
+        {
             store.stop_sync();
             drop(store);
         }
@@ -142,7 +150,10 @@ impl DataSyncBackend for DittoBackend {
     }
 
     async fn is_ready(&self) -> bool {
-        self.store.lock().unwrap().is_some()
+        self.store
+            .lock()
+            .map(|guard| guard.is_some())
+            .unwrap_or(false)
     }
 
     fn backend_info(&self) -> BackendInfo {
@@ -277,8 +288,12 @@ impl DocumentStore for DittoBackend {
                     })
                     .collect();
 
-                let mut is_first = initial_flag.lock().unwrap();
-                let mut prev = prev_ids.lock().unwrap();
+                let Ok(mut is_first) = initial_flag.lock() else {
+                    return;
+                };
+                let Ok(mut prev) = prev_ids.lock() else {
+                    return;
+                };
 
                 if *is_first {
                     // First callback - send initial snapshot
@@ -549,7 +564,9 @@ impl PeerDiscovery for DittoBackend {
     }
 
     fn on_peer_event(&self, callback: Box<dyn Fn(PeerEvent) + Send + Sync>) {
-        self.peer_callbacks.lock().unwrap().push(callback);
+        if let Ok(mut callbacks) = self.peer_callbacks.lock() {
+            callbacks.push(callback);
+        }
 
         // Register presence observer to trigger callbacks
         if let Ok(store) = self.get_store() {
@@ -568,7 +585,9 @@ impl PeerDiscovery for DittoBackend {
                         metadata: HashMap::new(),
                     };
 
-                    let callbacks = callbacks.lock().unwrap();
+                    let Ok(callbacks) = callbacks.lock() else {
+                        return;
+                    };
                     for callback in callbacks.iter() {
                         callback(PeerEvent::Connected(peer_info.clone()));
                     }
@@ -632,7 +651,11 @@ impl SyncEngine for DittoBackend {
     async fn is_syncing(&self) -> anyhow::Result<bool> {
         // In Ditto, if we have a store and it's initialized, sync is active
         // (it starts when we call start_sync and stops when we call stop_sync)
-        Ok(self.store.lock().unwrap().is_some())
+        Ok(self
+            .store
+            .lock()
+            .map(|guard| guard.is_some())
+            .unwrap_or(false))
     }
 }
 

--- a/peat-protocol/src/transport/ditto.rs
+++ b/peat-protocol/src/transport/ditto.rs
@@ -115,7 +115,10 @@ impl MeshTransport for DittoMeshTransport {
 
     fn subscribe_peer_events(&self) -> PeerEventReceiver {
         let (tx, rx) = mpsc::channel(PEER_EVENT_CHANNEL_CAPACITY);
-        self.event_senders.write().unwrap().push(tx);
+        self.event_senders
+            .write()
+            .expect("event_senders lock poisoned")
+            .push(tx);
         // Note: Ditto handles peer events internally via PresenceObserver
         // In the future, we can bridge Ditto's events to this channel
         rx

--- a/peat-protocol/src/transport/iroh.rs
+++ b/peat-protocol/src/transport/iroh.rs
@@ -186,7 +186,10 @@ impl IrohMeshTransport {
     /// Non-blocking: if a subscriber's channel is full, the event is dropped for that subscriber.
     /// Dead channels are automatically removed.
     fn emit_event(&self, event: PeerEvent) {
-        let mut senders = self.event_senders.write().unwrap();
+        let mut senders = self
+            .event_senders
+            .write()
+            .expect("event_senders lock poisoned");
 
         // Remove closed channels and send to remaining
         senders.retain(|sender| {
@@ -211,7 +214,7 @@ impl IrohMeshTransport {
     ///
     /// This should be called periodically to detect disconnected peers.
     pub fn cleanup_dead_connections(&self) {
-        let mut connections = self.connections.write().unwrap();
+        let mut connections = self.connections.write().expect("connections lock poisoned");
         let dead_peers: Vec<_> = connections
             .iter()
             .filter(|(_, conn)| !conn.is_alive())
@@ -239,11 +242,11 @@ impl IrohMeshTransport {
     pub fn register_peer(&self, node_id: NodeId, endpoint_id: EndpointId) {
         self.node_to_endpoint
             .write()
-            .unwrap()
+            .expect("node_to_endpoint lock poisoned")
             .insert(node_id.clone(), endpoint_id);
         self.endpoint_to_node
             .write()
-            .unwrap()
+            .expect("endpoint_to_node lock poisoned")
             .insert(endpoint_id, node_id);
     }
 
@@ -251,14 +254,18 @@ impl IrohMeshTransport {
     pub fn get_node_id(&self, endpoint_id: &EndpointId) -> Option<NodeId> {
         self.endpoint_to_node
             .read()
-            .unwrap()
+            .expect("endpoint_to_node lock poisoned")
             .get(endpoint_id)
             .cloned()
     }
 
     /// Get EndpointId from NodeId (for outgoing connections)
     pub fn get_endpoint_id(&self, node_id: &NodeId) -> Option<EndpointId> {
-        self.node_to_endpoint.read().unwrap().get(node_id).copied()
+        self.node_to_endpoint
+            .read()
+            .expect("node_to_endpoint lock poisoned")
+            .get(node_id)
+            .copied()
     }
 
     /// Get the underlying IrohTransport
@@ -300,7 +307,7 @@ impl IrohMeshTransport {
 
             // Helper to emit events
             let emit_event = |event: PeerEvent, senders: &Arc<RwLock<Vec<PeerEventSender>>>| {
-                let mut senders = senders.write().unwrap();
+                let mut senders = senders.write().expect("event_senders lock poisoned");
                 senders.retain(|sender| match sender.try_send(event.clone()) {
                     Ok(()) => true,
                     Err(mpsc::error::TrySendError::Full(_)) => true,
@@ -317,7 +324,7 @@ impl IrohMeshTransport {
 
                 // Phase 1: Check for dead connections
                 let dead_peers: Vec<_> = {
-                    let conns = connections.read().unwrap();
+                    let conns = connections.read().expect("connections lock poisoned");
                     conns
                         .iter()
                         .filter(|(_, conn)| !conn.is_alive())
@@ -329,9 +336,9 @@ impl IrohMeshTransport {
 
                 // Remove dead connections, emit events, schedule reconnection
                 if !dead_peers.is_empty() {
-                    let mut conns = connections.write().unwrap();
-                    let static_set = static_peers.read().unwrap();
-                    let mut recon = reconnection.write().unwrap();
+                    let mut conns = connections.write().expect("connections lock poisoned");
+                    let static_set = static_peers.read().expect("static_peers lock poisoned");
+                    let mut recon = reconnection.write().expect("reconnection lock poisoned");
 
                     for (peer_id, reason, connected_at) in dead_peers {
                         conns.remove(&peer_id);
@@ -364,9 +371,12 @@ impl IrohMeshTransport {
                     // If health monitor declares peer dead, we should disconnect
                     // The connection cleanup above will handle it on next iteration
                     // But we can proactively schedule reconnection for static peers
-                    let is_static = static_peers.read().unwrap().contains(&peer_id);
+                    let is_static = static_peers
+                        .read()
+                        .expect("static_peers lock poisoned")
+                        .contains(&peer_id);
                     if is_static {
-                        let mut recon = reconnection.write().unwrap();
+                        let mut recon = reconnection.write().expect("reconnection lock poisoned");
                         recon.schedule_reconnect(peer_id.clone(), true);
                         debug!(
                             "Health monitor detected dead peer, scheduling reconnection: {}",
@@ -377,7 +387,7 @@ impl IrohMeshTransport {
 
                 // Phase 3: Attempt due reconnections (Issue #253)
                 let due_peers: Vec<NodeId> = {
-                    let recon = reconnection.read().unwrap();
+                    let recon = reconnection.read().expect("reconnection lock poisoned");
                     if !recon.is_enabled() {
                         continue;
                     }
@@ -387,7 +397,7 @@ impl IrohMeshTransport {
                 for peer_id in due_peers {
                     // Get current attempt info
                     let (attempt, max_attempts) = {
-                        let recon = reconnection.read().unwrap();
+                        let recon = reconnection.read().expect("reconnection lock poisoned");
                         let state = recon.get_state(&peer_id);
                         let attempt = state.map(|s| s.attempts + 1).unwrap_or(1);
                         let max = recon.policy().max_retries;
@@ -406,7 +416,7 @@ impl IrohMeshTransport {
 
                     // Try to reconnect
                     let peer_info_opt = {
-                        let config = peer_config.read().unwrap();
+                        let config = peer_config.read().expect("peer_config lock poisoned");
                         config
                             .peers
                             .iter()
@@ -428,9 +438,12 @@ impl IrohMeshTransport {
                                 IrohMeshConnection::new(peer_id.clone(), conn, connected_at);
                             connections
                                 .write()
-                                .unwrap()
+                                .expect("connections lock poisoned")
                                 .insert(peer_id.clone(), mesh_conn);
-                            reconnection.write().unwrap().reconnected(&peer_id);
+                            reconnection
+                                .write()
+                                .expect("reconnection lock poisoned")
+                                .reconnected(&peer_id);
 
                             // Start health monitoring for reconnected peer (Issue #254)
                             health_monitor.start_monitoring(peer_id.clone());
@@ -446,13 +459,17 @@ impl IrohMeshTransport {
                         }
                         Ok(None) => {
                             // Accept path is handling connection
-                            reconnection.write().unwrap().reconnected(&peer_id);
+                            reconnection
+                                .write()
+                                .expect("reconnection lock poisoned")
+                                .reconnected(&peer_id);
                             debug!("Reconnection to {} handled by accept path", peer_id);
                         }
                         Err(e) => {
                             let error_msg = e.to_string();
                             let will_retry = {
-                                let mut recon = reconnection.write().unwrap();
+                                let mut recon =
+                                    reconnection.write().expect("reconnection lock poisoned");
                                 let will_retry = recon.failed(&peer_id, error_msg.clone());
                                 if !will_retry {
                                     recon.remove(&peer_id);
@@ -498,8 +515,11 @@ impl MeshTransport for IrohMeshTransport {
             .map_err(|e| TransportError::ConnectionFailed(e.to_string()))?;
 
         // Load static peer config and register peers
-        let config = self.peer_config.read().unwrap();
-        let mut static_peers = self.static_peers.write().unwrap();
+        let config = self.peer_config.read().expect("peer_config lock poisoned");
+        let mut static_peers = self
+            .static_peers
+            .write()
+            .expect("static_peers lock poisoned");
         for peer_info in &config.peers {
             let node_id = NodeId::new(peer_info.name.clone());
             if let Ok(endpoint_id) = peer_info.endpoint_id() {
@@ -532,7 +552,7 @@ impl MeshTransport for IrohMeshTransport {
         let connections = self
             .connections
             .write()
-            .unwrap()
+            .expect("connections lock poisoned")
             .drain()
             .collect::<Vec<_>>();
         for (_node_id, _conn) in connections {
@@ -557,14 +577,14 @@ impl MeshTransport for IrohMeshTransport {
         let _endpoint_id = self
             .node_to_endpoint
             .read()
-            .unwrap()
+            .expect("node_to_endpoint lock poisoned")
             .get(peer_id)
             .copied()
             .ok_or_else(|| TransportError::PeerNotFound(peer_id.as_str().to_string()))?;
 
         // Get peer info from static config
         let peer_info = {
-            let config = self.peer_config.read().unwrap();
+            let config = self.peer_config.read().expect("peer_config lock poisoned");
             config
                 .peers
                 .iter()
@@ -587,7 +607,7 @@ impl MeshTransport for IrohMeshTransport {
                 let mesh_conn = IrohMeshConnection::new(peer_id.clone(), conn, connected_at);
                 self.connections
                     .write()
-                    .unwrap()
+                    .expect("connections lock poisoned")
                     .insert(peer_id.clone(), mesh_conn.clone());
 
                 // Start health monitoring for this peer (Issue #254)
@@ -606,7 +626,7 @@ impl MeshTransport for IrohMeshTransport {
                 // Accept path is handling - check if connection exists
                 self.connections
                     .read()
-                    .unwrap()
+                    .expect("connections lock poisoned")
                     .get(peer_id)
                     .cloned()
                     .map(|c| Box::new(c) as Box<dyn MeshConnection>)
@@ -621,7 +641,12 @@ impl MeshTransport for IrohMeshTransport {
 
     async fn disconnect(&self, peer_id: &NodeId) -> Result<()> {
         // Remove connection from map
-        if let Some(conn) = self.connections.write().unwrap().remove(peer_id) {
+        if let Some(conn) = self
+            .connections
+            .write()
+            .expect("connections lock poisoned")
+            .remove(peer_id)
+        {
             // Stop health monitoring (Issue #254)
             self.health_monitor.stop_monitoring(peer_id);
 
@@ -641,23 +666,34 @@ impl MeshTransport for IrohMeshTransport {
     fn get_connection(&self, peer_id: &NodeId) -> Option<Box<dyn MeshConnection>> {
         self.connections
             .read()
-            .unwrap()
+            .expect("connections lock poisoned")
             .get(peer_id)
             .cloned()
             .map(|c| Box::new(c) as Box<dyn MeshConnection>)
     }
 
     fn peer_count(&self) -> usize {
-        self.connections.read().unwrap().len()
+        self.connections
+            .read()
+            .expect("connections lock poisoned")
+            .len()
     }
 
     fn connected_peers(&self) -> Vec<NodeId> {
-        self.connections.read().unwrap().keys().cloned().collect()
+        self.connections
+            .read()
+            .expect("connections lock poisoned")
+            .keys()
+            .cloned()
+            .collect()
     }
 
     fn subscribe_peer_events(&self) -> PeerEventReceiver {
         let (tx, rx) = mpsc::channel(PEER_EVENT_CHANNEL_CAPACITY);
-        self.event_senders.write().unwrap().push(tx);
+        self.event_senders
+            .write()
+            .expect("event_senders lock poisoned")
+            .push(tx);
         rx
     }
 
@@ -690,7 +726,10 @@ impl Transport for IrohMeshTransport {
     fn can_reach(&self, peer_id: &NodeId) -> bool {
         // Check if we have a mapping for this peer
         // This means we know how to reach them (via static config or discovery)
-        self.node_to_endpoint.read().unwrap().contains_key(peer_id)
+        self.node_to_endpoint
+            .read()
+            .expect("node_to_endpoint lock poisoned")
+            .contains_key(peer_id)
     }
 }
 

--- a/peat-transport/src/http/server.rs
+++ b/peat-transport/src/http/server.rs
@@ -23,7 +23,7 @@ pub struct ServerConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
-            bind_addr: "0.0.0.0:8080".parse().unwrap(),
+            bind_addr: "0.0.0.0:8080".parse().expect("valid default bind address"),
             timeout_secs: 30,
         }
     }

--- a/peat-transport/src/tak/bridge/aggregation.rs
+++ b/peat-transport/src/tak/bridge/aggregation.rs
@@ -30,7 +30,7 @@ impl Aggregator {
     /// Older messages for the same source are replaced.
     pub fn add(&self, message: PeatMessage) {
         let key = message.source_node().to_string();
-        let mut pending = self.pending.write().unwrap();
+        let mut pending = self.pending.write().expect("pending lock poisoned");
         pending.insert(key, message);
     }
 
@@ -38,13 +38,13 @@ impl Aggregator {
     ///
     /// Returns messages that should be published.
     pub fn flush(&self) -> Vec<PeatMessage> {
-        let mut pending = self.pending.write().unwrap();
+        let mut pending = self.pending.write().expect("pending lock poisoned");
         pending.drain().map(|(_, v)| v).collect()
     }
 
     /// Get the number of pending messages
     pub fn pending_count(&self) -> usize {
-        self.pending.read().unwrap().len()
+        self.pending.read().expect("pending lock poisoned").len()
     }
 
     /// Get the window duration for time-windowed policies

--- a/peat-transport/src/tak/config.rs
+++ b/peat-transport/src/tak/config.rs
@@ -31,7 +31,7 @@ impl Default for TakTransportConfig {
     fn default() -> Self {
         Self {
             mode: TakTransportMode::TakServer {
-                address: "127.0.0.1:8087".parse().unwrap(),
+                address: "127.0.0.1:8087".parse().expect("valid default address"),
                 use_tls: false,
             },
             identity: None,

--- a/peat-transport/src/tak/mesh.rs
+++ b/peat-transport/src/tak/mesh.rs
@@ -213,7 +213,7 @@ impl TakTransport for MeshSaTransport {
             TakError::MulticastError(format!("Failed to create async socket: {}", e))
         })?;
 
-        *self.socket.write().unwrap() = Some(Arc::new(socket));
+        *self.socket.write().expect("socket lock poisoned") = Some(Arc::new(socket));
         self.connected.store(true, Ordering::SeqCst);
         self.metrics.record_connect();
 
@@ -225,7 +225,7 @@ impl TakTransport for MeshSaTransport {
         info!("Leaving Mesh SA multicast group");
 
         // Drop the socket
-        *self.socket.write().unwrap() = None;
+        *self.socket.write().expect("socket lock poisoned") = None;
         self.connected.store(false, Ordering::SeqCst);
         self.metrics.record_disconnect();
 
@@ -234,7 +234,7 @@ impl TakTransport for MeshSaTransport {
 
     async fn send_cot(&self, event: &CotEvent, priority: Priority) -> Result<(), TakError> {
         let socket = {
-            let guard = self.socket.read().unwrap();
+            let guard = self.socket.read().expect("socket lock poisoned");
             guard.clone()
         };
 
@@ -249,7 +249,7 @@ impl TakTransport for MeshSaTransport {
         }
 
         // Queue for later
-        let mut queue = self.queue.write().unwrap();
+        let mut queue = self.queue.write().expect("queue lock poisoned");
         queue.enqueue(event.clone(), priority)?;
         debug!("Queued CoT event {} (priority {})", event.uid, priority);
 
@@ -270,7 +270,7 @@ impl TakTransport for MeshSaTransport {
     }
 
     fn queue_depth(&self) -> QueueDepthMetrics {
-        self.queue.read().unwrap().metrics()
+        self.queue.read().expect("queue lock poisoned").metrics()
     }
 }
 

--- a/peat-transport/src/tak/metrics.rs
+++ b/peat-transport/src/tak/metrics.rs
@@ -44,12 +44,18 @@ impl TakMetrics {
     /// Record a successful connection
     pub fn record_connect(&self) {
         self.connections.fetch_add(1, Ordering::Relaxed);
-        *self.connected_since.write().unwrap() = Some(Instant::now());
+        *self
+            .connected_since
+            .write()
+            .expect("connected_since lock poisoned") = Some(Instant::now());
     }
 
     /// Record a disconnection
     pub fn record_disconnect(&self) {
-        *self.connected_since.write().unwrap() = None;
+        *self
+            .connected_since
+            .write()
+            .expect("connected_since lock poisoned") = None;
     }
 
     /// Record a sent message
@@ -77,14 +83,14 @@ impl TakMetrics {
 
     /// Record an error
     pub fn record_error(&self, error: &str) {
-        *self.last_error.write().unwrap() = Some(error.to_string());
+        *self.last_error.write().expect("last_error lock poisoned") = Some(error.to_string());
     }
 
     /// Get connection uptime in seconds
     pub fn uptime_secs(&self) -> Option<u64> {
         self.connected_since
             .read()
-            .unwrap()
+            .expect("connected_since lock poisoned")
             .map(|since| since.elapsed().as_secs())
     }
 
@@ -98,7 +104,11 @@ impl TakMetrics {
             bytes_received: self.bytes_received.load(Ordering::Relaxed),
             messages_dropped: self.messages_dropped.load(Ordering::Relaxed),
             reconnect_attempts: self.reconnect_attempts.load(Ordering::Relaxed),
-            last_error: self.last_error.read().unwrap().clone(),
+            last_error: self
+                .last_error
+                .read()
+                .expect("last_error lock poisoned")
+                .clone(),
             uptime_secs: self.uptime_secs(),
         }
     }
@@ -114,8 +124,18 @@ impl Clone for TakMetrics {
             bytes_received: AtomicU64::new(self.bytes_received.load(Ordering::Relaxed)),
             messages_dropped: AtomicU64::new(self.messages_dropped.load(Ordering::Relaxed)),
             reconnect_attempts: AtomicU64::new(self.reconnect_attempts.load(Ordering::Relaxed)),
-            last_error: RwLock::new(self.last_error.read().unwrap().clone()),
-            connected_since: RwLock::new(*self.connected_since.read().unwrap()),
+            last_error: RwLock::new(
+                self.last_error
+                    .read()
+                    .expect("last_error lock poisoned")
+                    .clone(),
+            ),
+            connected_since: RwLock::new(
+                *self
+                    .connected_since
+                    .read()
+                    .expect("connected_since lock poisoned"),
+            ),
         }
     }
 }

--- a/peat-transport/src/tak/server.rs
+++ b/peat-transport/src/tak/server.rs
@@ -400,7 +400,7 @@ impl TakServerTransport {
         let mut sent = 0;
         loop {
             let msg = {
-                let mut queue = self.queue.write().unwrap();
+                let mut queue = self.queue.write().expect("queue lock poisoned");
                 queue.dequeue()
             };
 
@@ -408,7 +408,7 @@ impl TakServerTransport {
                 Some(queued) => {
                     if let Err(e) = self.send_event_raw(stream, &queued.event).await {
                         // Re-queue the message
-                        let mut queue = self.queue.write().unwrap();
+                        let mut queue = self.queue.write().expect("queue lock poisoned");
                         let _ = queue.enqueue(queued.event, queued.priority);
                         return Err(e);
                     }
@@ -453,7 +453,10 @@ impl TakTransport for TakServerTransport {
         *self.reader_task.write().await = Some(reader_task);
         self.connected.store(true, Ordering::SeqCst);
         self.metrics.record_connect();
-        self.reconnect.write().unwrap().reset();
+        self.reconnect
+            .write()
+            .expect("reconnect lock poisoned")
+            .reset();
 
         Ok(())
     }
@@ -495,7 +498,7 @@ impl TakTransport for TakServerTransport {
         }
 
         // Queue for later
-        let mut queue = self.queue.write().unwrap();
+        let mut queue = self.queue.write().expect("queue lock poisoned");
         queue.enqueue(event.clone(), priority)?;
         debug!("Queued CoT event {} (priority {})", event.uid, priority);
 
@@ -547,7 +550,7 @@ impl TakTransport for TakServerTransport {
     }
 
     fn queue_depth(&self) -> QueueDepthMetrics {
-        self.queue.read().unwrap().metrics()
+        self.queue.read().expect("queue lock poisoned").metrics()
     }
 }
 


### PR DESCRIPTION
## Summary
- Replaces ~100 `.unwrap()` calls across command, security, sync, transport, and network modules
- **Mutex/RwLock**: `.expect("...lock poisoned")` or `.map_err()?` depending on return type
- **SystemTime**: `.expect("system clock before UNIX epoch")`
- **Const parsing**: `.expect("valid ...")`
- **Result returns**: proper `?` propagation
- **Option returns**: `.ok()?` or `.unwrap_or()`
- **Void functions**: `if let Ok(guard) = lock()` for graceful degradation

## Test plan
- [x] 974 lib tests pass locally (peat-protocol + peat-transport)
- [ ] CI passes

Closes #700