### PR TITLE
test: deflake startup_optimization_e2e wall-clock assertions

### DIFF
--- a/peat-protocol/tests/startup_optimization_e2e.rs
+++ b/peat-protocol/tests/startup_optimization_e2e.rs
@@ -150,18 +150,13 @@ async fn test_fast_constructor_is_faster_than_mdns_constructor() {
     let avg_fast: u128 = fast_times.iter().sum::<u128>() / fast_times.len() as u128;
     let avg_mdns: u128 = mdns_times.iter().sum::<u128>() / mdns_times.len() as u128;
 
+    // Telemetry-only: wall-clock comparison flaked on shared CI runners.
+    // The functional guarantee (fast constructor skips mDNS setup) is covered
+    // by test_fast_transport_constructor_creates_functional_transport. Perf
+    // tracking for this lives in the benchmark job (see issue #786).
     eprintln!(
         "[STARTUP TIMING] Fast constructor avg: {}ms, mDNS constructor avg: {}ms",
         avg_fast, avg_mdns
-    );
-
-    // Fast constructor should be at least as fast (may not always be faster due to system variance)
-    // The main benefit is avoiding mDNS setup during critical startup path
-    assert!(
-        avg_fast <= avg_mdns + 50, // Allow 50ms variance for system noise
-        "Fast constructor ({}ms) should not be significantly slower than mDNS ({}ms)",
-        avg_fast,
-        avg_mdns
     );
 }
 
@@ -238,10 +233,21 @@ async fn test_fast_transport_can_connect_to_peers() {
     // Connect transport1 to transport2
     transport1.connect_peer(&peer2_info).await.unwrap();
 
-    // Wait for connection to be established
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    // Poll until at least one side registers the connection, with a hard ceiling
+    // that IS the failure signal (no fixed sleep + optimistic assert).
+    let connect_deadline = Duration::from_secs(5);
+    let poll_interval = Duration::from_millis(25);
+    let connected = tokio::time::timeout(connect_deadline, async {
+        loop {
+            if transport1.peer_count() > 0 || transport2.peer_count() > 0 {
+                return;
+            }
+            tokio::time::sleep(poll_interval).await;
+        }
+    })
+    .await
+    .is_ok();
 
-    // Verify connection established (at least one side should show the connection)
     let peer_count_1 = transport1.peer_count();
     let peer_count_2 = transport2.peer_count();
 
@@ -250,10 +256,11 @@ async fn test_fast_transport_can_connect_to_peers() {
         peer_count_1, peer_count_2
     );
 
-    // At least one side should have registered the connection
     assert!(
-        peer_count_1 > 0 || peer_count_2 > 0,
-        "Peers should connect using fast-created transports (no mDNS required)"
+        connected,
+        "Peers should connect using fast-created transports (no mDNS required); \
+         timed out after {:?} with peer counts {}/{}",
+        connect_deadline, peer_count_1, peer_count_2
     );
 
     // Cleanup
@@ -299,27 +306,14 @@ async fn test_sequential_vs_parallel_initialization_timing() {
         start.elapsed()
     };
 
+    // Telemetry-only: wall-clock comparisons flaked on shared CI runners even
+    // with tolerance windows. Performance-regression tracking belongs in the
+    // benchmark job (see issue #786), not a yes/no correctness gate.
     eprintln!(
         "[STARTUP TIMING] Sequential: {}ms, Parallel: {}ms, Improvement: {:.1}%",
         sequential_time.as_millis(),
         parallel_time.as_millis(),
         (1.0 - parallel_time.as_secs_f64() / sequential_time.as_secs_f64()) * 100.0
-    );
-
-    // Parallel should generally be faster or at least not significantly slower.
-    // Allow the larger of +500 ms or +50% over sequential so the assertion still
-    // catches genuine regressions without flaking on loaded CI runners (GitHub
-    // Actions shared hosts show non-trivial scheduler jitter at this scale).
-    let seq_ms = sequential_time.as_millis();
-    let par_ms = parallel_time.as_millis();
-    let allowed_ms = seq_ms + std::cmp::max(500, seq_ms / 2);
-    assert!(
-        par_ms <= allowed_ms,
-        "Parallel init should not be significantly slower than sequential \
-         (sequential={}ms, parallel={}ms, allowed={}ms)",
-        seq_ms,
-        par_ms,
-        allowed_ms
     );
 }
 
@@ -391,12 +385,11 @@ async fn test_full_startup_timing_like_ffi() {
     // Cleanup
     backend.stop_sync().unwrap();
 
-    // Verify reasonable startup time (should be well under 1 second on modern hardware)
-    assert!(
-        total_ms < 1000,
-        "Total startup should be under 1 second, was {}ms",
-        total_ms
-    );
+    // Telemetry-only: a hard wall-clock budget flaked on shared CI runners
+    // (e.g. 1366ms on a 1000ms budget). Startup-performance tracking belongs
+    // in the benchmark job (see issue #786). This test still proves the FFI
+    // startup sequence completes end-to-end via the unwraps above.
+    let _ = total_ms;
 }
 
 /// Helper to extract first IP address from transport


### PR DESCRIPTION
## Summary

First tranche of the test-determinism refactor tracked in #786. This commit converts wall-clock performance assertions into telemetry-only printouts in `peat-protocol/tests/startup_optimization_e2e.rs`, and replaces one fixed-sleep+assert with a bounded poll where the timeout is the failure signal.

These tests were responsible for repeated false-positive CI failures on unrelated PRs (#781, #783, #784, #785) — the code started up and worked correctly; it just exceeded an arbitrary millisecond budget on a noisy shared GitHub Actions runner.

## Changes

| Test | Before | After |
|------|--------|-------|
| `test_full_startup_timing_like_ffi` | `assert!(total_ms < 1000)` | Telemetry `eprintln!`, functional startup still validated by unwraps |
| `test_sequential_vs_parallel_initialization_timing` | `assert!(par <= seq + max(500, seq/2))` | Telemetry `eprintln!` only |
| `test_fast_constructor_is_faster_than_mdns_constructor` | `assert!(avg_fast <= avg_mdns + 50)` | Telemetry `eprintln!`; functional no-mDNS guarantee covered elsewhere |
| `test_fast_transport_can_connect_to_peers` | `sleep(300ms)` then assert peers | `tokio::time::timeout(5s, poll_peer_count)`; timeout IS the failure |

## Rationale

Performance regressions belong in a benchmark workflow that tracks trends over time, not in a yes/no PR gate. The telemetry printouts are kept so anyone running the suite locally still sees the timing data.

See #786 for the rest of the cleanup (the `sleep+assert` pattern appears in several other `*_e2e.rs` files).

## Test plan
- [x] `cargo test --package peat-protocol --test startup_optimization_e2e --features automerge-backend` — 8/8 passing locally
- [x] `cargo clippy --package peat-protocol --tests --features automerge-backend -- -D warnings` — clean
- [ ] CI green

Fixes (partially) #786