### PR TITLE
chore: pin peat-mesh to =0.9.0-rc.1 for upgrade validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3831,9 +3831,9 @@ dependencies = [
 
 [[package]]
 name = "peat-mesh"
-version = "0.8.2"
+version = "0.9.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1094f45fbd841cb30b39638c43c3c8b69a8c8c70ba055ec24703e79bec02680"
+checksum = "f5374e3e1e25f5d8e80dea875f6898a3d80dea7bdf8ec54c91bf1839fc083335"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/defenseunicorns/peat"
 
 [workspace.dependencies]
 # Mesh networking
-peat-mesh = "0.8.2"
+peat-mesh = "=0.9.0-rc.1"
 
 # BLE mesh transport (ADR-039)
 peat-btle = "0.2.0"


### PR DESCRIPTION
## Summary

Bumps the workspace `peat-mesh` dep from `0.8.2` to exact-pin `=0.9.0-rc.1`. Goal is to exercise the upcoming stable 0.9.0 through peat CI against the real crates.io artifact before we cut the stable release.

- Exact pin (`=0.9.0-rc.1`) keeps pre-release selection deterministic across CI runs (per QA guidance on peat-mesh#83).
- Local validation: 992 workspace tests pass identically against 0.8.2 and 0.9.0-rc.1 on darwin. Six remaining iroh transport unit-test failures are darwin-local (macOS loopback binding), reproduce on 0.8.2, and are tracked in #786 — not regressions from this bump.
- Removed-API scan (`TtlConfig::ditto_alter_system_commands` / `ditto_env_vars`) found zero call sites in this workspace, so the peat-mesh#81 removals have no consumer impact here.

## What's in peat-mesh 0.9.0-rc.1

- **BREAKING**: removed two deprecated `TtlConfig` helper methods (peat-mesh#81)
- **BREAKING**: default features now include `automerge-backend` (peat-mesh#78)
- **Added**: string-based helpers on `NetworkedIrohBlobStore` (peat-mesh#82)
- **Fixed**: per-document striped locks prevent compact/sync data loss (peat-mesh#79)
- **Fixed**: flaky QUIC endpoint tests stabilized (peat-mesh#78)
- **Fixed**: 16 clippy warnings + 2 rust-1.95 lints (peat-mesh#81)

## Test plan

- [ ] Full peat CI green against `0.9.0-rc.1`
- [ ] No regressions vs. main in the iroh transport unit-test set (the six darwin failures pass on Linux CI in prior PRs)
- [ ] QA Review

## Next step

If CI is green, cut peat-mesh `0.9.0` stable on crates.io, then open a follow-up PR replacing `=0.9.0-rc.1` with `peat-mesh = "0.9"` (normal caret selector).