### PR TITLE
fix: opt out of peat-mesh default features at workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ repository = "https://github.com/defenseunicorns/peat"
 
 [workspace.dependencies]
 # Mesh networking
-peat-mesh = "=0.9.0-rc.1"
+peat-mesh = { version = "=0.9.0-rc.1", default-features = false }
 
 # BLE mesh transport (ADR-039)
 peat-btle = "0.2.0"


### PR DESCRIPTION
## Summary

peat-mesh 0.9.0-rc.1 flipped default features to include `automerge-backend`. Without an explicit opt-out at the consumer, a `cargo build -p peat-protocol --no-default-features --features lite-transport` now silently pulls `automerge`, `iroh-blobs`, `redb`, and `negentropy` through the peat-mesh default. Size-constrained / embedded builds that depend only on the lite-transport path lose their ability to stay small.

Fix: declare the workspace `peat-mesh` dep with `default-features = false`. Each consumer that needs a backend opts in explicitly. The `peat-protocol::automerge-backend` feature already does this via `peat-mesh/automerge-backend`, so the automerge path is unaffected.

Flagged by the QA review on [peat-mesh#83](https://github.com/defenseunicorns/peat-mesh/pull/83) before the stable 0.9.0 cut.

## Verification

`cargo tree -e features` on both feature paths:

| Path | `automerge` | `redb` | `iroh-blobs` | `negentropy` |
|------|-------------|--------|--------------|--------------|
| `-p peat-protocol --no-default-features --features lite-transport` (before) | ✗ (pulled) | ✗ (pulled) | ✗ (pulled) | ✗ (pulled) |
| `-p peat-protocol --no-default-features --features lite-transport` (after) | ✓ (absent) | ✓ (absent) | ✓ (absent) | ✓ (absent) |
| `-p peat-protocol --features automerge-backend` (after) | present | present | present | present |

`cargo check --workspace --all-features` passes.

## Test plan

- [x] Feature tree check on both paths (above)
- [x] Full workspace build clean
- [ ] CI green