### PR TITLE
chore: release 0.9.0-rc.1 — peat-protocol as public facade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to the Peat workspace are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This changelog covers the crates published to crates.io from this workspace:
+
+- `peat-protocol` — public facade; depends on `peat-schema` and `peat-mesh`
+- `peat-schema` — wire format (Protobuf) definitions
+
+Sub-crates that stay internal (`peat-transport`, `peat-persistence`, `peat-discovery`, `peat-ffi`, `examples/*`) share the workspace version but are not published and are not documented here.
+
+## [0.9.0-rc.1] - 2026-04-23
+
+First public release candidate for the Peat workspace. Published to
+crates.io so downstream integrators (peat-sim, peat-atak-plugin, future
+SDK consumers) can depend on a single crate — `peat-protocol` — which
+re-exports `peat-schema` and `peat-mesh`.
+
+### Added
+
+- `peat-protocol` as the public facade for the Peat stack. It re-exports
+  `peat_mesh` and `peat_schema`, so downstream consumers depend on one
+  crate:
+
+  ```toml
+  peat-protocol = "=0.9.0-rc.1"
+  ```
+
+- `peat-schema` published as a standalone crate for consumers that need
+  the Protobuf types without the full protocol layer.
+
+- `CHANGELOG.md` at the repository root (this file).
+
+- `docs/RELEASING.md` describing the release process.
+
+### Changed
+
+- Workspace version unified at `0.9.0-rc.1` to track the underlying
+  `peat-mesh` release candidate.
+
+- `peat-protocol` → `peat-schema` path dep now carries an explicit
+  version (`=0.9.0-rc.1`) so it resolves on crates.io.
+
+### Pinned
+
+- `peat-mesh = "=0.9.0-rc.1"` at the workspace level with
+  `default-features = false`. Each consumer opts in to the backend it
+  needs (peat-protocol's `automerge-backend` feature pulls
+  `peat-mesh/automerge-backend` explicitly). This preserves the
+  pre-0.9.0 behavior for size-constrained / lite-transport builds,
+  which would otherwise silently pull `automerge`, `iroh-blobs`,
+  `redb`, and `negentropy` via the new peat-mesh default features.
+
+### Ecosystem alignment
+
+This release aligns with:
+
+- `peat-mesh` 0.9.0-rc.1 on crates.io
+- `peat-node`, `peat-registry`, `peat-gateway` pinned to
+  `peat-mesh = "=0.9.0-rc.1"` (validation PRs open)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,4 +60,7 @@ This release aligns with:
 
 - `peat-mesh` 0.9.0-rc.1 on crates.io
 - `peat-node`, `peat-registry`, `peat-gateway` pinned to
-  `peat-mesh = "=0.9.0-rc.1"` (validation PRs open)
+  `peat-mesh = "=0.9.0-rc.1"` — see
+  [peat-node#21](https://github.com/defenseunicorns/peat-node/pull/21),
+  [peat-registry#128](https://github.com/defenseunicorns/peat-registry/pull/128),
+  [peat-gateway#86](https://github.com/defenseunicorns/peat-gateway/pull/86)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3743,7 +3743,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peat-ble-test"
-version = "0.1.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3788,7 +3788,7 @@ dependencies = [
 
 [[package]]
 name = "peat-discovery"
-version = "0.1.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3873,7 +3873,7 @@ dependencies = [
 
 [[package]]
 name = "peat-persistence"
-version = "0.1.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3898,7 +3898,7 @@ dependencies = [
 
 [[package]]
 name = "peat-protocol"
-version = "0.1.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3947,7 +3947,7 @@ dependencies = [
 
 [[package]]
 name = "peat-schema"
-version = "0.1.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "peat-tak-bridge"
-version = "0.1.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3985,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "peat-transport"
-version = "0.1.0"
+version = "0.9.0-rc.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude = ["examples/m5stack-core2-peat"]
 # peat-btle = { path = "../peat-btle" }
 
 [workspace.package]
-version = "0.1.0"
+version = "0.9.0-rc.1"
 edition = "2021"
 authors = ["Kit Plummer <kitplummer@defenseunicorns.com>"]
 license = "Apache-2.0"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -25,6 +25,17 @@ The workspace uses a single version (`[workspace.package].version`) for all publ
 
 Pre-1.0, minor bumps may contain breaking changes per Rust ecosystem convention.
 
+### Two distribution channels, independent cadences
+
+The Peat workspace publishes to two separate ecosystems with their own version streams:
+
+| Channel | Artifact | Versioned by |
+|---------|----------|--------------|
+| crates.io | `peat-protocol`, `peat-schema` | `[workspace.package].version` in `/Cargo.toml` |
+| Maven Central | `peat-ffi` AAR | `peat-ffi/android/build.gradle.kts` (independent of the workspace version) |
+
+These are deliberately decoupled. Rust SDK consumers and Android integrators usually do not overlap, and the FFI surface matures on a different cadence from the protocol. When in doubt, bump each channel only when its own artifact changes, and call out the relationship in CHANGELOG entries if a coordinated bump is needed.
+
 ## Pre-flight checklist
 
 Before starting a release PR:
@@ -118,8 +129,10 @@ When a release candidate has soaked sufficiently and no regressions have surface
 2. Bump `peat-mesh` workspace dep from `=<version>-rc.N` to the stable caret range (`"<major>.<minor>"`)
 3. Bump workspace version from `<version>-rc.N` to `<version>`
 4. Bump the `peat-schema` path-dep version in `peat-protocol/Cargo.toml` the same way
-5. Update `CHANGELOG.md` with a new `## [<version>]` heading
-6. Follow the Publish section above (tag, publish `peat-schema`, publish `peat-protocol`, GitHub release)
+5. **Re-audit the re-exported surface.** `peat-protocol` re-exports `peat_mesh` and `peat_schema`, so the full public API of both is part of `peat-protocol`'s own semver contract. Before relaxing the `peat-mesh` pin from exact (`=<version>-rc.N`) to caret (`"<major>.<minor>"`), scan the `peat-mesh` changelog for any breaking changes that would leak through the re-export and require a `peat-protocol` major bump. If in doubt, keep the exact pin.
+6. Also update `peat-protocol/src/lib.rs` — the docstring example should show the stable caret selector (`"0.9"`) instead of the exact rc pin, since Cargo resolves pre-release versions by default only under an exact requirement.
+7. Update `CHANGELOG.md` with a new `## [<version>]` heading
+8. Follow the Publish section above (tag, publish `peat-schema`, publish `peat-protocol`, GitHub release)
 
 Only promote to stable after:
 - All downstream repos have been on the rc for long enough to surface issues

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,148 @@
+# Releasing the Peat Workspace
+
+This document describes how to cut a new release of the crates published from this workspace. It is meant to be repeatable: following the steps in order produces the same result each time.
+
+## What gets published
+
+Only two crates from this workspace go to crates.io:
+
+| Crate | Role |
+|-------|------|
+| `peat-schema` | Wire format (Protobuf) definitions |
+| `peat-protocol` | Public facade — re-exports `peat-schema` and `peat-mesh`; downstream consumers depend on this crate alone |
+
+All other workspace members (`peat-transport`, `peat-persistence`, `peat-discovery`, `peat-ffi`, `examples/*`) share the workspace version but stay internal. They are not published.
+
+`peat-ffi` publishes to **Maven Central** on its own cadence via `.github/workflows/publish-maven.yml`; it is decoupled from the crates.io release flow.
+
+## Versioning
+
+The workspace uses a single version (`[workspace.package].version`) for all published crates. The chosen version must track the `peat-mesh` release it pins against — that is the load-bearing dependency, and version drift between the two is a source of ecosystem confusion.
+
+- **Minor / breaking** — increment when `peat-mesh` cuts a minor (e.g. `0.9.x`)
+- **Patch** — internal fixes that keep the same `peat-mesh` pin
+- **Pre-release** — use `-rc.N` suffix when soaking a release before promoting to stable (matches the `peat-mesh` release pattern)
+
+Pre-1.0, minor bumps may contain breaking changes per Rust ecosystem convention.
+
+## Pre-flight checklist
+
+Before starting a release PR:
+
+- [ ] `peat-mesh` is already on crates.io at the target version (or the corresponding `-rc.N`)
+- [ ] `peat-sim`, `peat-registry`, `peat-node`, `peat-gateway`, `peat-atak-plugin` either already pin the target `peat-mesh` version or have open bump PRs
+- [ ] No call sites of removed `peat-mesh` APIs (grep the workspace for the removed symbols listed in the `peat-mesh` CHANGELOG)
+- [ ] Feature-tree sanity check passes for size-constrained builds:
+      `cargo tree -e features -p peat-protocol --no-default-features --features lite-transport`
+      should not pull `automerge`, `redb`, `iroh-blobs`, or `negentropy`
+
+## Release PR
+
+One branch, one PR. Make the release changes on a branch named `chore/release-<version>` (for example, `chore/release-0.9.0-rc.1` or `chore/release-0.9.0`).
+
+1. **Bump the workspace version** in `/Cargo.toml`:
+   ```toml
+   [workspace.package]
+   version = "0.9.0-rc.1"  # target version
+   ```
+
+2. **Version-ify path deps between published crates.** `peat-protocol` must reference `peat-schema` with an explicit version matching the bump:
+   ```toml
+   peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.1" }
+   ```
+   Without this, `cargo publish` refuses to upload.
+
+3. **Add the CHANGELOG entry.** Update `/CHANGELOG.md` with a `## [<version>] - YYYY-MM-DD` section. Follow Keep a Changelog conventions (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`). Include a `Pinned` section documenting the `peat-mesh` version and any default-feature decisions.
+
+4. **Run the pre-flight validation:**
+
+   ```bash
+   cargo check --workspace --all-features
+   cargo test --workspace --exclude peat-ffi --features automerge-backend
+   (cd peat-schema && cargo publish --dry-run --allow-dirty)
+   (cd peat-protocol && cargo publish --dry-run --allow-dirty)
+   ```
+
+   Note that `cargo publish --dry-run` on `peat-protocol` will fail with `no matching package named peat-schema found` until `peat-schema` is actually on crates.io at the new version. That is expected and is the reason publish order matters (see below). The packaging step passing (the error appears on the `Updating crates.io index` step afterward) is sufficient evidence that `peat-protocol` is release-ready.
+
+5. **Open the PR**, let CI go green, get review, merge.
+
+## Publish
+
+**Publish order matters** because `peat-protocol` depends on `peat-schema` by version: `peat-schema` must be on crates.io before `peat-protocol` can be published.
+
+From `main` at the merged release commit:
+
+1. **Tag the release:**
+   ```bash
+   git tag v0.9.0-rc.1 <merge-commit>
+   git push origin v0.9.0-rc.1
+   ```
+
+2. **Publish `peat-schema` first:**
+   ```bash
+   cd peat-schema
+   cargo publish
+   cd ..
+   ```
+
+3. **Wait for the crates.io index to propagate** (usually 30–60 seconds). Verify with:
+   ```bash
+   curl -s https://crates.io/api/v1/crates/peat-schema | \
+     python3 -c "import sys,json;d=json.load(sys.stdin);print([v['num'] for v in d['versions'][:3]])"
+   ```
+   The target version should be in the list.
+
+4. **Publish `peat-protocol`:**
+   ```bash
+   cd peat-protocol
+   cargo publish
+   cd ..
+   ```
+
+5. **Create the GitHub release** with the CHANGELOG entry as the body. Either:
+   - via `gh release create v0.9.0-rc.1 --notes-file <(awk '/^## \[0.9.0-rc.1\]/{found=1;next} /^## \[/{if(found)exit} found{print}' CHANGELOG.md)`
+   - or in the GitHub UI from the new tag.
+
+## After publish
+
+- [ ] Confirm both crates render correctly on crates.io (titles, descriptions, READMEs)
+- [ ] Open bump PRs in downstream repos (`peat-sim`, `peat-atak-plugin`, any future SDK consumer) to pin the new `peat-protocol` version
+- [ ] Watch for any missing field / metadata issues reported by docs.rs — fix in a follow-up patch release if needed
+
+## RC-to-stable promotion
+
+When a release candidate has soaked sufficiently and no regressions have surfaced:
+
+1. New branch `chore/release-<stable-version>` from `main` (`main` already has the rc pin)
+2. Bump `peat-mesh` workspace dep from `=<version>-rc.N` to the stable caret range (`"<major>.<minor>"`)
+3. Bump workspace version from `<version>-rc.N` to `<version>`
+4. Bump the `peat-schema` path-dep version in `peat-protocol/Cargo.toml` the same way
+5. Update `CHANGELOG.md` with a new `## [<version>]` heading
+6. Follow the Publish section above (tag, publish `peat-schema`, publish `peat-protocol`, GitHub release)
+
+Only promote to stable after:
+- All downstream repos have been on the rc for long enough to surface issues
+- At least one round of real-world usage (not just CI) has confirmed no regressions
+- There is no pending rc.N+1 in-flight
+
+## Yanking
+
+If a published version turns out to be broken:
+
+```bash
+cargo yank --version <bad-version> peat-protocol
+cargo yank --version <bad-version> peat-schema   # if applicable
+```
+
+Yanking does **not** remove the version — it stops new projects from resolving to it while leaving existing Cargo.lock files intact. Publish a fixed version (patch or rc.N+1) and land a CHANGELOG entry explaining the yank.
+
+## Troubleshooting
+
+**`cargo publish` rejects the crate with "missing description":** the crate's `Cargo.toml` needs `description`, `license`, `repository` (and ideally `homepage`, `documentation`, `keywords`, `categories`). Inherit from workspace where possible (`license.workspace = true`) and set crate-specific fields directly.
+
+**`cargo publish` rejects with "no matching package named <sibling>" for `peat-protocol`:** you tried to publish `peat-protocol` before `peat-schema` (or before the crates.io index propagated). Publish `peat-schema` first and wait ~60 seconds.
+
+**Downstream build fails with "`peat-mesh` features mismatch":** confirm the workspace-level `peat-mesh` dep has `default-features = false` and each consumer's own feature flags opt in to the peat-mesh features they need. See `peat/#789` for the pattern.
+
+**Publishing from a dirty working tree:** `cargo publish` refuses by default. Use `--allow-dirty` only for `--dry-run`. For the real publish, ensure the working tree matches the tagged commit.

--- a/peat-protocol/Cargo.toml
+++ b/peat-protocol/Cargo.toml
@@ -5,10 +5,16 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Peat Coordination Protocol — hierarchical capability composition over CRDTs for heterogeneous mesh networks"
+homepage = "https://github.com/defenseunicorns/peat"
+documentation = "https://docs.rs/peat-protocol"
+keywords = ["peat", "protocol", "mesh", "crdt", "coordination"]
+categories = ["network-programming"]
 
 [dependencies]
-# CAP dependencies
-peat-schema = { path = "../peat-schema" }
+# Peat facade: peat-protocol re-exports peat-schema and peat-mesh so
+# downstream consumers can depend on peat-protocol alone.
+peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.1" }
 peat-mesh = { workspace = true }
 
 tokio = { workspace = true }

--- a/peat-protocol/src/lib.rs
+++ b/peat-protocol/src/lib.rs
@@ -6,8 +6,18 @@
 //!
 //! The Peat protocol enables scalable coordination of autonomous nodes through:
 //! - **Three-phase protocol**: Discovery, Cell Formation, Hierarchical Operations
-//! - **CRDT-based state**: Eventual consistency via Ditto SDK
+//! - **CRDT-based state**: Eventual consistency via Automerge over Iroh QUIC
 //! - **Capability composition**: Additive, emergent, redundant, and constraint-based patterns
+//!
+//! ## Facade
+//!
+//! `peat-protocol` is the public entry point to the Peat stack. It re-exports
+//! `peat_schema` (wire types) and `peat_mesh` (P2P plumbing) so downstream
+//! consumers can depend on `peat-protocol` alone:
+//!
+//! ```toml
+//! peat-protocol = "0.9"
+//! ```
 //!
 //! ## Architecture
 //!
@@ -44,6 +54,10 @@ pub mod traits;
 pub mod transport; // Backend-agnostic transport abstraction for mesh topology // Peat-specific adapters for peat-mesh
 
 pub use error::{Error, Result};
+
+// Facade re-exports: downstream consumers depend on peat-protocol alone.
+pub use peat_mesh;
+pub use peat_schema;
 
 /// Protocol version
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/peat-protocol/src/lib.rs
+++ b/peat-protocol/src/lib.rs
@@ -16,7 +16,12 @@
 //! consumers can depend on `peat-protocol` alone:
 //!
 //! ```toml
-//! peat-protocol = "0.9"
+//! # During an rc window, Cargo does not pick pre-release versions by default
+//! # — use the exact pin:
+//! peat-protocol = "=0.9.0-rc.1"
+//!
+//! # Once 0.9.0 stable is published, the normal caret selector is fine:
+//! # peat-protocol = "0.9"
 //! ```
 //!
 //! ## Architecture

--- a/peat-schema/Cargo.toml
+++ b/peat-schema/Cargo.toml
@@ -5,6 +5,11 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Wire format (Protobuf) definitions for the Peat Coordination Protocol"
+homepage = "https://github.com/defenseunicorns/peat"
+documentation = "https://docs.rs/peat-schema"
+keywords = ["peat", "protobuf", "protocol", "mesh", "crdt"]
+categories = ["network-programming", "data-structures"]
 
 [dependencies]
 # Protobuf serialization


### PR DESCRIPTION
## Summary

First public release of the Peat workspace on crates.io. Establishes `peat-protocol` as the single SDK deliverable: it re-exports `peat-mesh` and `peat-schema` so downstream integrators (peat-sim, peat-atak-plugin, future SDK consumers) can depend on one crate:

```toml
peat-protocol = "=0.9.0-rc.1"
```

## Scope

- **Publishes:** `peat-schema`, `peat-protocol`
- **Stays internal:** `peat-transport`, `peat-persistence`, `peat-discovery`, `peat-ffi`, `examples/*`
- **Unaffected:** `peat-ffi` Maven Central publish (still via `publish-maven.yml` on its own cadence)

## Changes

- Workspace version `0.1.0` → `0.9.0-rc.1` (tracks the `peat-mesh` pin already on `main`)
- Facade re-exports in `peat-protocol/src/lib.rs`: `pub use peat_mesh; pub use peat_schema;`
- Publish-required metadata (description, homepage, documentation, keywords, categories) on the two published crates
- `peat-protocol` → `peat-schema` path dep gets an explicit version
- New `CHANGELOG.md` at repo root (Keep a Changelog)
- New `docs/RELEASING.md` — the repeatable release process, including publish order, pre-flight checks, rc→stable promotion, yank procedure, and troubleshooting. The doc is the artifact that makes this release process repeatable; future releases follow it step by step.
- Minor prose update to `peat-protocol` module docs to reflect the Automerge/Iroh CRDT stack (not a code change)

## Validation

- `cargo check --workspace --all-features` clean
- `cd peat-schema && cargo publish --dry-run --allow-dirty` — packaging clean
- `cd peat-protocol && cargo publish --dry-run --allow-dirty` — packaging clean; fails only on the expected "peat-schema not yet on crates.io" index lookup, documented in `docs/RELEASING.md`

## Post-merge release steps

1. Tag `v0.9.0-rc.1` at the merge commit
2. `cd peat-schema && cargo publish`
3. Wait for crates.io index to propagate (~60s)
4. `cd peat-protocol && cargo publish`
5. Create GitHub release with CHANGELOG entry

Full procedure in `docs/RELEASING.md`.

## Test plan

- [x] Local workspace build clean
- [x] Publish dry-run on both crates (packaging stage)
- [ ] CI green
- [ ] QA Review