### PR TITLE
ci: add release workflow for tag-triggered crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Release
+
+# Tag-triggered release pipeline for the peat workspace.
+#
+# On push of a `v*` tag, this workflow:
+#   1. Reuses the regular CI gates (format, clippy, tests, feature builds).
+#   2. Verifies the tag version matches `[workspace.package].version` in Cargo.toml.
+#   3. Publishes `peat-schema` to crates.io, then waits for the index to
+#      propagate, then publishes `peat-protocol`. Order matters — peat-protocol
+#      depends on peat-schema by version.
+#   4. Creates a GitHub release with the CHANGELOG.md entry as the body.
+#
+# Prerequisites:
+#   - `CARGO_REGISTRY_TOKEN` repository secret with publish-new-crates scope.
+#
+# See `docs/RELEASING.md` for the end-to-end release process this workflow
+# automates.
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  checks: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  validate-tag:
+    name: Validate tag matches workspace version
+    needs: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Compare tag vs workspace.package.version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION=$(cargo metadata --no-deps --format-version=1 \
+            | jq -r '.packages[] | select(.name == "peat-protocol") | .version')
+          if [ "$TAG" != "$VERSION" ]; then
+            echo "::error::Tag v$TAG does not match workspace version $VERSION"
+            exit 1
+          fi
+          echo "Tag v$TAG matches workspace version $VERSION"
+
+  publish:
+    name: Publish to crates.io
+    needs: validate-tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Publish peat-schema
+        working-directory: peat-schema
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Wait for peat-schema to appear on crates.io index
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Poll the crates.io API for up to 5 minutes. Index propagation is
+          # usually well under 60 seconds but can be slower under load.
+          for i in $(seq 1 60); do
+            if curl -sfL "https://crates.io/api/v1/crates/peat-schema" \
+                 | jq -e --arg v "$VERSION" '.versions[] | select(.num == $v)' > /dev/null; then
+              echo "peat-schema $VERSION is indexed"
+              exit 0
+            fi
+            echo "Waiting for peat-schema $VERSION to be indexed... ($((i * 5))s elapsed)"
+            sleep 5
+          done
+          echo "::error::peat-schema $VERSION did not appear on the crates.io index within 5 minutes"
+          exit 1
+
+      - name: Publish peat-protocol
+        working-directory: peat-protocol
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release:
+    name: GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Pull everything between this version's header and the next one.
+          NOTES=$(awk "/^## \[${VERSION}\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "::warning::No CHANGELOG.md entry found for $VERSION, falling back to auto-generated notes"
+            echo "fallback=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "$NOTES" > /tmp/release-notes.md
+            echo "fallback=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create GitHub Release
+        run: |
+          # Mark pre-releases (rc, alpha, beta) distinctly so they don't show
+          # up as the "Latest" release on the repo landing page.
+          PRERELEASE_FLAG=""
+          case "$GITHUB_REF_NAME" in
+            *-rc.*|*-alpha.*|*-beta.*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+          if [ "${{ steps.changelog.outputs.fallback }}" = "true" ]; then
+            gh release create "$GITHUB_REF_NAME" --generate-notes $PRERELEASE_FLAG
+          else
+            gh release create "$GITHUB_REF_NAME" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -80,40 +80,50 @@ One branch, one PR. Make the release changes on a branch named `chore/release-<v
 
 ## Publish
 
-**Publish order matters** because `peat-protocol` depends on `peat-schema` by version: `peat-schema` must be on crates.io before `peat-protocol` can be published.
+The release is driven by `.github/workflows/release.yml`. Push a tag matching `v*` and the workflow runs CI → tag validation → `peat-schema` publish → wait for index → `peat-protocol` publish → GitHub Release (CHANGELOG-extracted notes, auto-flagged as pre-release for `-rc.*` / `-alpha.*` / `-beta.*`).
+
+**Publish order is enforced by the workflow.** It is worth knowing why: `peat-protocol` depends on `peat-schema` by version, so `peat-schema` must be on crates.io before `peat-protocol` can be published. The workflow publishes schema first, polls the crates.io API until the new version is indexed (up to 5 minutes), then publishes protocol.
+
+### Prerequisites (one-time)
+
+- `CARGO_REGISTRY_TOKEN` repository secret configured with publish-new-crates scope (the first release establishes the crates on crates.io; later releases only need publish-update scope).
+
+### Cutting a release
 
 From `main` at the merged release commit:
 
-1. **Tag the release:**
-   ```bash
-   git tag v0.9.0-rc.1 <merge-commit>
-   git push origin v0.9.0-rc.1
-   ```
+```bash
+git tag v0.9.0-rc.1 <merge-commit-sha>
+git push origin v0.9.0-rc.1
+```
 
-2. **Publish `peat-schema` first:**
-   ```bash
-   cd peat-schema
-   cargo publish
-   cd ..
-   ```
+Then watch the workflow at `gh run watch` or in the Actions tab. On success, the crates appear on crates.io and the GitHub Release lands automatically.
 
-3. **Wait for the crates.io index to propagate** (usually 30–60 seconds). Verify with:
-   ```bash
-   curl -s https://crates.io/api/v1/crates/peat-schema | \
-     python3 -c "import sys,json;d=json.load(sys.stdin);print([v['num'] for v in d['versions'][:3]])"
-   ```
-   The target version should be in the list.
+### Manual publish (fallback)
 
-4. **Publish `peat-protocol`:**
-   ```bash
-   cd peat-protocol
-   cargo publish
-   cd ..
-   ```
+If the automated release workflow is unavailable, the same steps can be run by hand. Requires a crates.io token on the local machine (`cargo login`).
 
-5. **Create the GitHub release** with the CHANGELOG entry as the body. Either:
-   - via `gh release create v0.9.0-rc.1 --notes-file <(awk '/^## \[0.9.0-rc.1\]/{found=1;next} /^## \[/{if(found)exit} found{print}' CHANGELOG.md)`
-   - or in the GitHub UI from the new tag.
+```bash
+# 1. Tag the release and push
+git tag v0.9.0-rc.1 <merge-commit>
+git push origin v0.9.0-rc.1
+
+# 2. Publish peat-schema
+cd peat-schema && cargo publish && cd ..
+
+# 3. Wait ~60 seconds, then verify
+curl -s https://crates.io/api/v1/crates/peat-schema | \
+  python3 -c "import sys,json;d=json.load(sys.stdin);print([v['num'] for v in d['versions'][:3]])"
+
+# 4. Publish peat-protocol
+cd peat-protocol && cargo publish && cd ..
+
+# 5. Create the GitHub release
+gh release create v0.9.0-rc.1 --prerelease \
+  --notes-file <(awk '/^## \[0.9.0-rc.1\]/{found=1;next} /^## \[/{if(found)exit} found{print}' CHANGELOG.md)
+```
+
+Drop `--prerelease` for a stable cut.
 
 ## After publish
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` — the tag-triggered release pipeline for the peat workspace, matching the pattern already in use on peat-mesh. With this in place, a release is kicked off by pushing a `v*` tag; the workflow handles everything else.

Tag pushed → CI → tag-validation → `peat-schema` publish → wait for crates.io index → `peat-protocol` publish → GitHub release (CHANGELOG-extracted notes, auto-flagged as pre-release for `-rc.*` / `-alpha.*` / `-beta.*`).

## Why the two-step publish

`peat-protocol` depends on `peat-schema` by version, so `peat-schema` must be on crates.io before `peat-protocol` can be published. peat-mesh's workflow only publishes one crate; this workspace needs an ordered pair with index propagation in between. The workflow polls the crates.io API for up to 5 minutes after the schema publish, then proceeds.

## Prerequisites (one-time, on the repo side)

- `CARGO_REGISTRY_TOKEN` secret configured under Settings → Secrets and variables → Actions, with **publish-new-crates** scope — the first release establishes `peat-schema` and `peat-protocol` on crates.io.

## Docs

`docs/RELEASING.md` updated: automated tag push is now the primary path; the manual `cargo publish` sequence is preserved as a fallback for when the workflow is unavailable.

## Test plan

- [ ] Workflow passes lint (actionlint via pre-commit, if configured)
- [ ] CI green
- [ ] After merge: push `v0.9.0-rc.1` tag and confirm:
  - [ ] CI job runs
  - [ ] validate-tag job passes
  - [ ] `peat-schema` publishes
  - [ ] Index-wait step completes
  - [ ] `peat-protocol` publishes
  - [ ] GitHub release is created with the CHANGELOG `[0.9.0-rc.1]` entry as body, marked pre-release

## Note on the v0.9.0-rc.1 tag

The `v0.9.0-rc.1` tag I pushed earlier has been deleted (both local and origin) so that merging this workflow and re-tagging will exercise the pipeline end-to-end.