### PR TITLE
fix(ci): add workflow_call trigger so release.yml can reuse CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+  # Allow the release workflow (.github/workflows/release.yml) to reuse this
+  # pipeline as a gate before publishing to crates.io.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,10 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    # Secrets do not propagate to reusable workflows automatically. The called
+    # CI workflow's test and test-e2e jobs consume PEAT_APP_ID / PEAT_SHARED_KEY,
+    # so we inherit the caller's full secret set.
+    secrets: inherit
 
   validate-tag:
     name: Validate tag matches workspace version

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -88,6 +88,15 @@ The release is driven by `.github/workflows/release.yml`. Push a tag matching `v
 
 - `CARGO_REGISTRY_TOKEN` repository secret configured with publish-new-crates scope (the first release establishes the crates on crates.io; later releases only need publish-update scope).
 
+### How release.yml and ci.yml are coupled
+
+`release.yml` reuses `ci.yml` via `uses: ./.github/workflows/ci.yml`. Two constraints must hold for this to work, and both are easy to regress on:
+
+1. **`ci.yml` must declare `workflow_call:`** under its `on:` block. Without it, GitHub refuses to parse `release.yml` and no tag-triggered run fires (see peat#792 for the symptom).
+2. **Secrets must be inherited explicitly.** Reusable workflows do not receive the caller's secrets by default. `release.yml` sets `secrets: inherit` on the `ci:` job so the nested `test` / `test-e2e` jobs still see `PEAT_APP_ID` and `PEAT_SHARED_KEY`.
+
+Anyone modifying either file should keep both constraints in mind — adding a new secret consumed by CI, or splitting CI into separate workflows, will require updates on both sides.
+
 ### Cutting a release
 
 From `main` at the merged release commit:


### PR DESCRIPTION
## Summary

The release workflow added in #791 calls CI via `uses: ./.github/workflows/ci.yml`. That reusable-workflow pattern requires the called workflow to declare `workflow_call:` as a trigger. Our `ci.yml` only had `push` and `pull_request`, so GitHub rejected `release.yml` at parse time — no logs, no tag-triggered run. peat-mesh's `ci.yml` has the trigger, which is why its release pipeline has been working.

## Fix

Add `workflow_call:` alongside the existing triggers in `.github/workflows/ci.yml`.

## Symptom reproduced

Pushing `v0.9.0-rc.1` on `main` (merge commit of #791) produced a failed run of `release.yml` on the **main push** event (not the tag push), with no logs and "workflow file issue." No run was created for the tag push at all — GitHub couldn't parse the workflow to decide it should fire.

## Followup

After this merges, I'll delete the failed tag artifact history and re-push `v0.9.0-rc.1` to exercise the pipeline end-to-end.

## Test plan

- [ ] CI green