### PR TITLE
fix(ci): install mold/clang/libdbus-1-dev in release.yml publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Install protoc
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - name: Install system dependencies
+        # Match ci.yml — `.cargo/config.toml` forces `-fuse-ld=mold` for the
+        # x86_64-unknown-linux-gnu target, so `cargo publish`'s verify step
+        # needs mold, clang, and the dbus headers (pulled transitively by
+        # some BLE-adjacent deps) to link.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler mold clang libdbus-1-dev
 
       - name: Publish peat-schema
         working-directory: peat-schema


### PR DESCRIPTION
## Summary

First `v0.9.0-rc.1` tag-triggered release workflow failed at the `cargo publish` verify step on `peat-schema`:

```
clang: error: invalid linker name in argument '-fuse-ld=mold'
error: could not compile `libc` (build script) due to 1 previous error
error: failed to verify package tarball
```

Root cause: `.cargo/config.toml` pins the linker to `-fuse-ld=mold` for `x86_64-unknown-linux-gnu`. `ci.yml` installs `mold clang libdbus-1-dev` in every job that compiles, but `release.yml`'s publish job was only installing `protobuf-compiler`. `cargo publish` runs a verify-compile step (between packaging and uploading), which hit the missing linker.

## Fix

Expand the release.yml system-deps apt-get to match ci.yml: `protobuf-compiler mold clang libdbus-1-dev`.

## Impact on the failed tag

The verify step failed *before* the crates.io upload happened, so nothing landed on the index — no yank required. The `v0.9.0-rc.1` tag I pushed earlier has been deleted (both local and origin); once this merges I'll re-tag and exercise the pipeline.

## Test plan

- [ ] CI green
- [ ] After merge: push `v0.9.0-rc.1`, workflow completes end-to-end