### PR TITLE
fix(ci): make release publish steps idempotent + use sparse index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,32 +69,73 @@ jobs:
         # some BLE-adjacent deps) to link.
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler mold clang libdbus-1-dev
 
-      - name: Publish peat-schema
-        working-directory: peat-schema
-        run: cargo publish
+      # Each publish step is idempotent: if the version is already on the
+      # crates.io sparse index (what cargo itself reads), the publish is
+      # skipped. This lets us re-run the job safely after any intermediate
+      # failure without hitting "crate already uploaded" errors.
+      #
+      # The sparse index (index.crates.io) is preferred over the v1 API
+      # because it is what cargo uses during dependency resolution, so
+      # appearance on the sparse index is the authoritative "fully
+      # published" signal. The v1 API sits behind a longer-lived CDN cache
+      # that can mask a fresh publish for minutes.
+      - name: Publish peat-schema (idempotent) and wait for index
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          UA="peat-release (github.com/defenseunicorns/peat)"
+          INDEX_URL="https://index.crates.io/pe/at/peat-schema"
+
+          is_indexed() {
+            curl -sfL -H "User-Agent: $UA" "$INDEX_URL" 2>/dev/null \
+              | jq -e --arg v "$VERSION" 'select(.vers == $v)' > /dev/null 2>&1
+          }
+
+          if is_indexed; then
+            echo "peat-schema $VERSION already on crates.io, skipping publish"
+          else
+            (cd peat-schema && cargo publish)
+            for i in $(seq 1 60); do
+              if is_indexed; then
+                echo "peat-schema $VERSION is indexed after $((i * 5))s"
+                exit 0
+              fi
+              echo "Waiting for peat-schema $VERSION to be indexed... ($((i * 5))s elapsed)"
+              sleep 5
+            done
+            echo "::error::peat-schema $VERSION did not appear on the crates.io sparse index within 5 minutes"
+            exit 1
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-      - name: Wait for peat-schema to appear on crates.io index
+      - name: Publish peat-protocol (idempotent) and wait for index
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
-          # Poll the crates.io API for up to 5 minutes. Index propagation is
-          # usually well under 60 seconds but can be slower under load.
-          for i in $(seq 1 60); do
-            if curl -sfL "https://crates.io/api/v1/crates/peat-schema" \
-                 | jq -e --arg v "$VERSION" '.versions[] | select(.num == $v)' > /dev/null; then
-              echo "peat-schema $VERSION is indexed"
-              exit 0
-            fi
-            echo "Waiting for peat-schema $VERSION to be indexed... ($((i * 5))s elapsed)"
-            sleep 5
-          done
-          echo "::error::peat-schema $VERSION did not appear on the crates.io index within 5 minutes"
-          exit 1
+          UA="peat-release (github.com/defenseunicorns/peat)"
+          INDEX_URL="https://index.crates.io/pe/at/peat-protocol"
 
-      - name: Publish peat-protocol
-        working-directory: peat-protocol
-        run: cargo publish
+          is_indexed() {
+            curl -sfL -H "User-Agent: $UA" "$INDEX_URL" 2>/dev/null \
+              | jq -e --arg v "$VERSION" 'select(.vers == $v)' > /dev/null 2>&1
+          }
+
+          if is_indexed; then
+            echo "peat-protocol $VERSION already on crates.io, skipping publish"
+          else
+            (cd peat-protocol && cargo publish)
+            for i in $(seq 1 60); do
+              if is_indexed; then
+                echo "peat-protocol $VERSION is indexed after $((i * 5))s"
+                exit 0
+              fi
+              echo "Waiting for peat-protocol $VERSION to be indexed... ($((i * 5))s elapsed)"
+              sleep 5
+            done
+            echo "::error::peat-protocol $VERSION did not appear on the crates.io sparse index within 5 minutes"
+            exit 1
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
@@ -119,18 +160,31 @@ jobs:
             echo "$NOTES" > /tmp/release-notes.md
             echo "fallback=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         run: |
+          set -euo pipefail
           # Mark pre-releases (rc, alpha, beta) distinctly so they don't show
           # up as the "Latest" release on the repo landing page.
           PRERELEASE_FLAG=""
           case "$GITHUB_REF_NAME" in
             *-rc.*|*-alpha.*|*-beta.*) PRERELEASE_FLAG="--prerelease" ;;
           esac
+
           if [ "${{ steps.changelog.outputs.fallback }}" = "true" ]; then
-            gh release create "$GITHUB_REF_NAME" --generate-notes $PRERELEASE_FLAG
+            NOTES_ARG="--generate-notes"
           else
-            gh release create "$GITHUB_REF_NAME" --notes-file /tmp/release-notes.md $PRERELEASE_FLAG
+            NOTES_ARG="--notes-file /tmp/release-notes.md"
+          fi
+
+          # Idempotent: if a release for this tag already exists (e.g. from a
+          # prior failed-but-partial run), update its body/flags instead of
+          # failing with "release already exists".
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists, updating..."
+            gh release edit "$GITHUB_REF_NAME" $PRERELEASE_FLAG \
+              $(if [ "${{ steps.changelog.outputs.fallback }}" != "true" ]; then echo "--notes-file /tmp/release-notes.md"; fi)
+          else
+            gh release create "$GITHUB_REF_NAME" $NOTES_ARG $PRERELEASE_FLAG
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -146,6 +146,7 @@ Drop `--prerelease` for a stable cut.
 ## After publish
 
 - [ ] Confirm both crates render correctly on crates.io (titles, descriptions, READMEs)
+- [ ] For any crate being published for the **first time**, add a `policy.<name>.audit-as-crates-io = true` entry to `supply-chain/config.toml`. cargo-vet detects the overlap between the local path dep and the now-published crate and errors until this is declared. This step must come after the first publish — adding the policy before publish causes `Cannot fetch crate information` (see peat#794 for context).
 - [ ] Open bump PRs in downstream repos (`peat-sim`, `peat-atak-plugin`, any future SDK consumer) to pin the new `peat-protocol` version
 - [ ] Watch for any missing field / metadata issues reported by docs.rs — fix in a follow-up patch release if needed
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -146,7 +146,10 @@ Drop `--prerelease` for a stable cut.
 ## After publish
 
 - [ ] Confirm both crates render correctly on crates.io (titles, descriptions, READMEs)
-- [ ] For any crate being published for the **first time**, add a `policy.<name>.audit-as-crates-io = true` entry to `supply-chain/config.toml`. cargo-vet detects the overlap between the local path dep and the now-published crate and errors until this is declared. This step must come after the first publish — adding the policy before publish causes `Cannot fetch crate information` (see peat#794 for context).
+- [ ] For any crate being published for the **first time**, add two entries to `supply-chain/config.toml`:
+  - `[policy.<name>]` with `audit-as-crates-io = true` — declares the crate overlap (must come **after** first publish; declaring before publish causes `Cannot fetch crate information`)
+  - `[[exemptions.<name>]]` with the published `version` and `criteria = "safe-to-deploy"` — records that we (as the publisher) are the trust root for this version. Alternative: run `cargo vet certify` to record a proper audit instead of an exemption.
+  Both entries together are required; the policy alone leaves cargo-vet asking for audits (see peat#794 for context).
 - [ ] Open bump PRs in downstream repos (`peat-sim`, `peat-atak-plugin`, any future SDK consumer) to pin the new `peat-protocol` version
 - [ ] Watch for any missing field / metadata issues reported by docs.rs — fix in a follow-up patch release if needed
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -88,6 +88,15 @@ The release is driven by `.github/workflows/release.yml`. Push a tag matching `v
 
 - `CARGO_REGISTRY_TOKEN` repository secret configured with publish-new-crates scope (the first release establishes the crates on crates.io; later releases only need publish-update scope).
 
+### Idempotent steps
+
+The release workflow is designed to be re-runnable. Each step that mutates crates.io or GitHub state first checks whether the mutation has already happened:
+
+- **Publish steps** consult the crates.io sparse index (`https://index.crates.io/pe/at/<crate>`) for the target version. If the version is already there, `cargo publish` is skipped. The sparse index is preferred over the v1 API because it is what cargo uses during dependency resolution — appearance on the sparse index is the authoritative "fully published" signal. The v1 API sits behind a longer-lived CDN cache that can mask a fresh publish for minutes.
+- **GitHub Release step** uses `gh release edit` if a release for the tag already exists; otherwise `gh release create`.
+
+This means that if any step fails partway through (e.g. runner flake during index polling), re-running the failed job (or re-pushing the tag after a fix) resumes cleanly instead of tripping on "already published" errors.
+
 ### How release.yml and ci.yml are coupled
 
 `release.yml` reuses `ci.yml` via `uses: ./.github/workflows/ci.yml`. Two constraints must hold for this to work, and both are easy to regress on:

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,10 +22,12 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 # artifact resolve to the same version. Setting audit-as-crates-io = true tells
 # vet to audit the local copy as if it were the crates.io version (which is
 # accurate — we are the publisher).
+#
+# Add an entry here only AFTER the crate's first publish — `audit-as-crates-io
+# = true` makes vet attempt to fetch the crate from crates.io, which fails with
+# "Cannot fetch crate information" if the crate is not yet published.
+# peat-protocol's entry should land in a follow-up PR after its first release.
 [policy.peat-schema]
-audit-as-crates-io = true
-
-[policy.peat-protocol]
 audit-as-crates-io = true
 
 [[exemptions.cc]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -16,6 +16,18 @@ url = "https://raw.githubusercontent.com/divviup/libprio-rs/main/supply-chain/au
 [imports.mozilla]
 url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 
+# First-party workspace crates that also publish to crates.io.
+# cargo-vet would otherwise flag them as "non-crates.io-fetched packages match
+# published crates.io versions" because the local path dep and the published
+# artifact resolve to the same version. Setting audit-as-crates-io = true tells
+# vet to audit the local copy as if it were the crates.io version (which is
+# accurate — we are the publisher).
+[policy.peat-schema]
+audit-as-crates-io = true
+
+[policy.peat-protocol]
+audit-as-crates-io = true
+
 [[exemptions.cc]]
 version = "1.2.57"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -34,6 +34,14 @@ audit-as-crates-io = true
 version = "1.2.57"
 criteria = "safe-to-deploy"
 
+# First-party workspace crate. audit-as-crates-io pulls it into the vet
+# graph as a normal crates.io dep; the exemption records that we (as the
+# publisher) are the trust root for this version. A future CI pass can
+# replace this with a proper `cargo vet certify` audit if desired.
+[[exemptions.peat-schema]]
+version = "0.9.0-rc.1"
+criteria = "safe-to-deploy"
+
 [[exemptions.cesu8]]
 version = "1.1.0"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
## Summary

The prior `v0.9.0-rc.1` release run published `peat-schema` successfully, then stalled in the "wait for index" step for the full 5-minute timeout and failed before publishing `peat-protocol`. peat-schema was on the sparse index within seconds; the v1 API was caching a pre-publish empty response for much longer.

Two fixes so the workflow can recover from that class of failure without re-tagging:

### 1. Switch index checks to the sparse index

Replace `https://crates.io/api/v1/crates/<crate>` (v1 API, aggressively cached by CDN) with `https://index.crates.io/pe/at/<crate>` (sparse index, what `cargo` itself uses during dependency resolution). Appearance on the sparse index is the authoritative "fully published" signal — the v1 API can lag by minutes.

### 2. Make each mutation idempotent

Each publish step checks the sparse index first. If the target version is already there, `cargo publish` is skipped. Re-runs become safe.

The GitHub Release step uses `gh release edit` when a release for the tag already exists, falling back to `gh release create`.

## Impact on the in-flight v0.9.0-rc.1

`peat-schema 0.9.0-rc.1` is already on crates.io from the earlier partial run. With this fix in place, the re-tagged v0.9.0-rc.1 workflow will:

1. Check sparse index → peat-schema 0.9.0-rc.1 present → skip publish
2. Proceed to publish `peat-protocol` (first time)
3. Create the GitHub release

No yank needed; no version burn.

## Docs

Added an "Idempotent steps" section to `docs/RELEASING.md` covering the sparse-index rationale and the re-run semantics.

## Test plan

- [ ] CI green
- [ ] After merge: re-push `v0.9.0-rc.1`. Expected behavior:
  - [ ] `peat-schema` publish step logs "already on crates.io, skipping publish"
  - [ ] `peat-protocol` publishes fresh
  - [ ] GitHub release is created