### PR TITLE
chore(supply-chain): add peat-protocol audit-as-crates-io + exemption

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -30,15 +30,22 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [policy.peat-schema]
 audit-as-crates-io = true
 
+[policy.peat-protocol]
+audit-as-crates-io = true
+
 [[exemptions.cc]]
 version = "1.2.57"
 criteria = "safe-to-deploy"
 
-# First-party workspace crate. audit-as-crates-io pulls it into the vet
-# graph as a normal crates.io dep; the exemption records that we (as the
-# publisher) are the trust root for this version. A future CI pass can
-# replace this with a proper `cargo vet certify` audit if desired.
+# First-party workspace crates. audit-as-crates-io pulls them into the vet
+# graph as normal crates.io deps; the exemptions record that we (as the
+# publisher) are the trust root for these versions. A future CI pass can
+# replace these with proper `cargo vet certify` audits if desired.
 [[exemptions.peat-schema]]
+version = "0.9.0-rc.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.peat-protocol]]
 version = "0.9.0-rc.1"
 criteria = "safe-to-deploy"
 


### PR DESCRIPTION
## Summary

Post-release follow-up after `peat-protocol 0.9.0-rc.1` landed on crates.io in the v0.9.0-rc.1 release workflow. The After-publish checklist in `docs/RELEASING.md` calls for this: any first-time crate publish needs a matching `[policy.<name>]` + `[[exemptions.<name>]]` pair in `supply-chain/config.toml` or the next CI run's Supply Chain job will fail.

## Changes

- `[policy.peat-protocol]` with `audit-as-crates-io = true` — declares the local path-dep / published-crate overlap
- `[[exemptions.peat-protocol]]` at version `0.9.0-rc.1`, `criteria = "safe-to-deploy"` — records trust (we are the publisher)

Mirrors the pattern added for `peat-schema` in #794.

## Test plan

- [ ] Supply Chain CI green