### PR TITLE
feat(m5stack): join WEARTAK encrypted mesh, harden against BLE thrash, polish UI

### DIFF
--- a/examples/m5stack-core2-peat/Cargo.lock
+++ b/examples/m5stack-core2-peat/Cargo.lock
@@ -31,6 +31,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,12 +52,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "as-slice"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "askama"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75363874b771be265f4ffe307ca705ef6f3baa19011c149da8674a87f1b75c4"
+dependencies = [
+ "askama_derive",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129397200fe83088e8a68407a8e2b1f826cf0086b21ccdb866a722c8bcd3a94f"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6ab5630b3d5eaf232620167977f95eb51f3432fc76852328774afbd242d4358"
+dependencies = [
+ "memchr",
+ "serde",
+ "serde_derive",
+ "winnow",
 ]
 
 [[package]]
@@ -84,6 +144,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +195,20 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "blake3"
+version = "1.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
 
 [[package]]
 name = "block-buffer"
@@ -166,6 +261,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
 name = "camino"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +296,20 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -236,7 +351,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -295,6 +410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "const_format"
 version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +452,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -378,8 +514,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -482,6 +619,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,6 +655,31 @@ dependencies = [
  "display-interface",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -756,7 +928,7 @@ checksum = "fb77a3d02b579a60a811ed9be22b78c5e794bc492d833ee7fc44d3a0155885e1"
 dependencies = [
  "anyhow",
  "build-time",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "cmake",
  "const_format",
  "embuild",
@@ -812,6 +984,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "fs_at"
@@ -927,12 +1114,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "goblin"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+dependencies = [
+ "log",
+ "plain",
+ "scroll",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
 ]
 
 [[package]]
@@ -958,23 +1167,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hive-btle"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "bitflags 2.10.0",
- "chacha20poly1305",
- "esp-idf-hal",
- "esp-idf-svc",
- "hkdf",
- "log",
- "rand_core",
- "sha2",
- "spin",
- "thiserror 2.0.17",
- "uuid",
- "x25519-dalek",
-]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hkdf"
@@ -1056,7 +1252,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1139,18 +1337,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "m5stack-core2-hive"
+name = "m5stack-core2-peat"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "display-interface-spi",
  "embedded-graphics",
  "embuild",
  "esp-idf-hal",
  "esp-idf-svc",
- "hive-btle",
  "log",
  "mipidsi",
+ "peat-btle",
 ]
 
 [[package]]
@@ -1274,6 +1473,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "peat-btle"
+version = "0.2.4"
+dependencies = [
+ "async-trait",
+ "bitflags 2.10.0",
+ "blake3",
+ "chacha20poly1305",
+ "ed25519-dalek",
+ "esp-idf-hal",
+ "esp-idf-svc",
+ "hashbrown 0.15.5",
+ "hkdf",
+ "log",
+ "peat-lite",
+ "rand_core",
+ "sha2",
+ "spin",
+ "thiserror 2.0.17",
+ "uniffi",
+ "uuid",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "peat-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a73bd9afe1c8c4d57f6a26e01b84d3211997c8f8dc5454798bd048b61946de8e"
+dependencies = [
+ "heapless",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,12 +1524,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1485,6 +1739,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "scroll"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
+dependencies = [
+ "scroll_derive",
+]
+
+[[package]]
+name = "scroll_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1538,13 +1812,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -1555,16 +1838,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strum"
@@ -1590,7 +1910,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1603,7 +1923,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1652,6 +1972,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +2021,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,6 +2066,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +2097,137 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "uniffi"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.19.2",
+ "uniffi_bindgen",
+ "uniffi_build",
+ "uniffi_core",
+ "uniffi_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_bindgen"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+dependencies = [
+ "anyhow",
+ "askama",
+ "camino",
+ "cargo_metadata 0.19.2",
+ "fs-err",
+ "glob",
+ "goblin",
+ "heck 0.5.0",
+ "indexmap",
+ "once_cell",
+ "serde",
+ "tempfile",
+ "textwrap",
+ "toml",
+ "uniffi_internal_macros",
+ "uniffi_meta",
+ "uniffi_pipeline",
+ "uniffi_udl",
+]
+
+[[package]]
+name = "uniffi_build"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
+dependencies = [
+ "anyhow",
+ "camino",
+ "uniffi_bindgen",
+]
+
+[[package]]
+name = "uniffi_core"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "once_cell",
+ "static_assertions",
+]
+
+[[package]]
+name = "uniffi_internal_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "uniffi_macros"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+dependencies = [
+ "camino",
+ "fs-err",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.111",
+ "toml",
+ "uniffi_meta",
+]
+
+[[package]]
+name = "uniffi_meta"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+dependencies = [
+ "anyhow",
+ "siphasher",
+ "uniffi_internal_macros",
+ "uniffi_pipeline",
+]
+
+[[package]]
+name = "uniffi_pipeline"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "tempfile",
+ "uniffi_internal_macros",
+]
+
+[[package]]
+name = "uniffi_udl"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+dependencies = [
+ "anyhow",
+ "textwrap",
+ "uniffi_meta",
+ "weedle2",
+]
 
 [[package]]
 name = "universal-hash"
@@ -1848,6 +2329,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "weedle2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
+dependencies = [
+ "nom",
 ]
 
 [[package]]

--- a/examples/m5stack-core2-peat/Cargo.toml
+++ b/examples/m5stack-core2-peat/Cargo.toml
@@ -22,13 +22,16 @@ log = "0.4"
 # Error handling
 anyhow = "1.0"
 
+# Base64 — for decoding the shared mesh genesis blob
+base64 = "0.22"
+
 # Display
 display-interface-spi = "0.5"
 mipidsi = "0.8"
 embedded-graphics = "0.8"
 
 # Peat libraries (external repo - radicle)
-peat-btle = { path = "../../../revolve/peat-btle", default-features = false, features = ["esp32"] }
+peat-btle = { path = "../../../peat-btle", default-features = false, features = ["esp32"] }
 
 [build-dependencies]
 embuild = "0.33"

--- a/examples/m5stack-core2-peat/Cargo.toml
+++ b/examples/m5stack-core2-peat/Cargo.toml
@@ -30,7 +30,19 @@ display-interface-spi = "0.5"
 mipidsi = "0.8"
 embedded-graphics = "0.8"
 
-# Peat libraries (external repo - radicle)
+# Peat libraries (external repo). Resolved as a sibling-repo path because
+# `peat-btle` is published separately; the relative path expects the
+# layout:
+#
+#   <parent>/peat/                      <- this repo
+#   <parent>/peat/examples/m5stack-core2-peat/
+#   <parent>/peat-btle/                 <- defenseunicorns/peat-btle clone
+#
+# i.e. clone `peat-btle` next to `peat`, not under it. CI doesn't currently
+# cross-check this layout, so a missing checkout fails at build time with
+# "no manifest found at <path>". Until peat-btle is consumed via
+# crates.io / a registry path, treat this as a developer-environment
+# requirement.
 peat-btle = { path = "../../../peat-btle", default-features = false, features = ["esp32"] }
 
 [build-dependencies]

--- a/examples/m5stack-core2-peat/Makefile
+++ b/examples/m5stack-core2-peat/Makefile
@@ -8,9 +8,9 @@
 #   make clean      - Clean build artifacts
 
 # Device serial ports (update if your devices differ)
-DEV1 := /dev/cu.usbserial-02036C1A
-DEV2 := /dev/cu.usbserial-5A490605921
-DEV3 := /dev/cu.usbserial-5A490607481
+DEV1 := /dev/ttyACM0
+DEV2 := /dev/ttyACM1
+DEV3 := /dev/ttyACM2
 
 TARGET := target/xtensa-esp32-espidf/release/m5stack-core2-peat
 

--- a/examples/m5stack-core2-peat/README.md
+++ b/examples/m5stack-core2-peat/README.md
@@ -82,6 +82,43 @@ Edit `src/main.rs`:
 - `DEVICE_NAME`: BLE device name
 - `ADVERTISING_INTERVAL_MS`: Beacon interval
 
+## Known limitations
+
+This example targets a small (≤4-node) BLE mesh — sensor + watch + ATAK
+plugin. Two structural choices in `src/nimble.rs` and `sdkconfig.defaults`
+trade flexibility for stability and need to be revisited before any
+larger-scale validation:
+
+- **`PERIPHERAL_ONLY = true`** — the M5Stack never initiates outbound BLE
+  connections; it only advertises and accepts incoming connections. This
+  removes the connect/disconnect storms that overloaded NimBLE under
+  concurrent bidirectional discovery, but it means M5Stack-to-M5Stack
+  links require *some other* node (a watch or phone) in range that
+  actively scans + connects. Two M5Stacks in range of only each other
+  will not link, even though both are advertising. Flip to `false` and
+  re-validate the per-peer + global connect-backoffs under sustained
+  load before relying on M5Stack-as-central topologies.
+- **`MULTIHOP_FORWARD = false`** — receiving and merging a peer document
+  no longer triggers an immediate fanout to other connections. State
+  propagates via the 5 s periodic gossip instead. For 1-hop topologies
+  this is invisible; for an N-hop chain, end-to-end convergence becomes
+  ~`N × 5 s` instead of ~one round-trip per hop. Flip to `true` for
+  multi-hop scenarios and re-soak.
+- **`CONFIG_BT_NIMBLE_MAX_CONNECTIONS = 2`** — halved from the
+  ESP-IDF default of 4. Halves the worst-case mbuf cleanup chain on
+  disconnect, which is what was tripping the task watchdog. The
+  larger-mesh demo will need this raised; doing so re-introduces the
+  cleanup pressure, so the doc-drain cap (`DOC_DRAIN_PER_TICK`) and
+  the per-peer/global connect backoffs all need to hold under the
+  higher ceiling.
+- **Demo-only embedded mesh genesis.** The `SHARED_GENESIS_BASE64`
+  fallback in `src/main.rs` is the badge-demo genesis. For any
+  non-demo build, set `PEAT_GENESIS_BASE64=<base64>` at build time so
+  the secret lives in the build environment rather than repo history.
+  The runtime emits a `WARN` at boot when the fallback is in use.
+  ADR-044 is the planned path for real (MLS-based) group key
+  distribution.
+
 ## Troubleshooting
 
 ### Build fails with "esp toolchain not found"

--- a/examples/m5stack-core2-peat/sdkconfig.defaults
+++ b/examples/m5stack-core2-peat/sdkconfig.defaults
@@ -3,10 +3,21 @@
 # Rust runtime
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=32768
 
+# Keep the Rust main task pinned to CPU 0 alongside the NimBLE host
+# (CONFIG_BT_NIMBLE_PINNED_TO_CORE_0). NimBLE's internal critical
+# sections aren't designed for cross-core contention — pinning main to
+# CPU 1 caused our gossip_document calls (on CPU 1) to spin on the
+# same hw locks NimBLE was holding on CPU 0, starving IDLE1 and
+# tripping the task watchdog. Co-locating them lets FreeRTOS
+# timeshare the core via preemption, with no spinlock fight. The
+# doc-drain cap (one queued doc per main-loop tick) is what keeps
+# main from monopolizing CPU 0 under sync-burst load.
+CONFIG_ESP_MAIN_TASK_AFFINITY_CPU0=y
+
 # Bluetooth
 CONFIG_BT_ENABLED=y
 CONFIG_BT_NIMBLE_ENABLED=y
-CONFIG_BT_NIMBLE_MAX_CONNECTIONS=4
+CONFIG_BT_NIMBLE_MAX_CONNECTIONS=2
 CONFIG_BT_NIMBLE_MAX_BONDS=3
 CONFIG_BT_NIMBLE_MAX_CCCDS=8
 CONFIG_BT_NIMBLE_SVC_GAP_DEVICE_NAME="PEAT-M5Core2"
@@ -39,8 +50,12 @@ CONFIG_ESP32_SPIRAM_SUPPORT=y
 CONFIG_SPIRAM_USE_MALLOC=y
 CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096
 
-# Watchdog
-CONFIG_ESP_TASK_WDT_TIMEOUT_S=30
+# Watchdog. 60 s timeout (up from 30 s) gives headroom for legitimate
+# slow paths (NVS flush during a sync burst, NimBLE disconnect cleanup
+# chains). IDLE0/IDLE1 stay subscribed — when the device truly locks
+# we want a backtrace logged, not silent freeze. Panic stays off so
+# WDT triggers don't reboot the device on a transient stall.
+CONFIG_ESP_TASK_WDT_TIMEOUT_S=60
 
 # Optimize for size
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y

--- a/examples/m5stack-core2-peat/src/audio.rs
+++ b/examples/m5stack-core2-peat/src/audio.rs
@@ -1,0 +1,2 @@
+// M5Stack Core2 audio (buzzer) stub
+// Hardware buzzer on Core2 is driven via I2S or DAC — not used in current demo.

--- a/examples/m5stack-core2-peat/src/imu.rs
+++ b/examples/m5stack-core2-peat/src/imu.rs
@@ -35,8 +35,13 @@ impl Accel {
     }
 }
 
-/// |accel.z| (in g) above this means the device is lying flat — taken as prone.
-const PRONE_Z_THRESHOLD_G: f32 = 0.7;
+/// Minimum |accel.z| (in g) for a Prone classification. The dominant-axis
+/// check below also requires z to be the largest-magnitude axis, but we
+/// keep an absolute floor so a stationary device with weak/noisy gravity
+/// readings doesn't flip flat just because z is marginally larger than x
+/// and y. 0.5 g picks up any reasonably-flat orientation while staying
+/// above noise.
+const PRONE_Z_MIN_G: f32 = 0.5;
 
 /// High-g threshold for fall-impact detection. Set well above anything a human
 /// can produce handling the device (a device flip briefly crosses 3 g; actual
@@ -96,9 +101,21 @@ impl ImuState {
 
         self.last_classify_ms = now_ms;
 
+        // Orientation: device is "Prone" iff the z-axis is dominant (gravity
+        // mostly aligned with z), i.e. the unit is lying flat. We don't
+        // hardcode "z must be 1 g" because the chip's z mapping vs the
+        // device body isn't the same on every board — checking z against
+        // the larger of |x| and |y| keeps the classifier orientation-
+        // invariant. PRONE_Z_MIN_G is an absolute floor so noisy
+        // near-zero gravity readings don't flip the classification.
+        let ax = accel.x.abs();
+        let ay = accel.y.abs();
+        let az = accel.z.abs();
+        let z_is_dominant = az > ax && az > ay && az > PRONE_Z_MIN_G;
+
         let activity = if confirmed_fall {
             Activity::PossibleFall
-        } else if accel.z.abs() > PRONE_Z_THRESHOLD_G {
+        } else if z_is_dominant {
             Activity::Prone
         } else {
             Activity::Standing

--- a/examples/m5stack-core2-peat/src/imu.rs
+++ b/examples/m5stack-core2-peat/src/imu.rs
@@ -1,0 +1,156 @@
+// MPU6886 IMU driver for M5Stack Core2
+// Provides accelerometer reading and simple activity classification.
+
+use esp_idf_hal::i2c::I2cDriver;
+use log::{info, warn};
+
+const MPU6886_ADDR: u8 = 0x68;
+const REG_WHO_AM_I: u8 = 0x75;
+const REG_PWR_MGMT_1: u8 = 0x6B;
+const REG_ACCEL_CONFIG: u8 = 0x1C;
+const REG_ACCEL_XOUT_H: u8 = 0x3B;
+
+const EXPECTED_WHO_AM_I: u8 = 0x19; // MPU6886
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Activity {
+    /// Device upright (gravity not on the z-axis).
+    Standing,
+    /// Device lying flat (gravity dominantly on the z-axis).
+    Prone,
+    /// Sudden high-g spike or freefall signature.
+    PossibleFall,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Accel {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
+
+impl Accel {
+    pub fn magnitude(&self) -> f32 {
+        (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
+    }
+}
+
+/// |accel.z| (in g) above this means the device is lying flat — taken as prone.
+const PRONE_Z_THRESHOLD_G: f32 = 0.7;
+
+/// High-g threshold for fall-impact detection. Set well above anything a human
+/// can produce handling the device (a device flip briefly crosses 3 g; actual
+/// fall impacts typically exceed 6 g). Raised from an earlier 3.0 g after the
+/// demo flip accidentally auto-triggered EMERGENCY.
+const FALL_IMPACT_G: f32 = 5.0;
+
+/// Low-g (freefall) threshold.
+const FALL_FREEFALL_G: f32 = 0.3;
+
+/// Number of back-to-back fall-candidate samples required before we call it.
+/// At the 100 ms IMU poll cadence this is ~`N * 100 ms` of sustained signal.
+const FALL_CONFIRM_SAMPLES: u8 = 3;
+
+pub struct ImuState {
+    last_classify_ms: u64,
+    last_activity: Activity,
+    /// Consecutive samples currently matching the fall signature. Resets as
+    /// soon as one sample disagrees, so a single noisy spike never escalates.
+    fall_streak: u8,
+}
+
+impl Default for ImuState {
+    fn default() -> Self {
+        Self {
+            last_classify_ms: 0,
+            last_activity: Activity::Standing,
+            fall_streak: 0,
+        }
+    }
+}
+
+impl ImuState {
+    pub fn update(&mut self, accel: &Accel, now_ms: u64) -> Activity {
+        let mag = accel.magnitude();
+
+        // Per-sample fall-candidate check + streak debounce. Only declare a
+        // PossibleFall once we've seen FALL_CONFIRM_SAMPLES in a row — this
+        // filters out incidental high-g spikes from device handling.
+        let sample_looks_like_fall = mag > FALL_IMPACT_G || mag < FALL_FREEFALL_G;
+        if sample_looks_like_fall {
+            self.fall_streak = self.fall_streak.saturating_add(1);
+        } else {
+            self.fall_streak = 0;
+        }
+        let confirmed_fall = self.fall_streak >= FALL_CONFIRM_SAMPLES;
+
+        // Fast path between classifications: fall only fires after a confirmed
+        // streak; otherwise keep the last stable classification so the badge
+        // doesn't flicker Standing/Prone on a single noisy sample.
+        if now_ms.saturating_sub(self.last_classify_ms) < 500 {
+            if confirmed_fall {
+                return Activity::PossibleFall;
+            }
+            return self.last_activity;
+        }
+
+        self.last_classify_ms = now_ms;
+
+        let activity = if confirmed_fall {
+            Activity::PossibleFall
+        } else if accel.z.abs() > PRONE_Z_THRESHOLD_G {
+            Activity::Prone
+        } else {
+            Activity::Standing
+        };
+
+        self.last_activity = activity;
+        activity
+    }
+}
+
+pub fn init(i2c: &mut I2cDriver) -> bool {
+    let mut buf = [0u8; 1];
+
+    // Check WHO_AM_I
+    if i2c.write_read(MPU6886_ADDR, &[REG_WHO_AM_I], &mut buf, 100).is_err() {
+        warn!("MPU6886: I2C read failed");
+        return false;
+    }
+    if buf[0] != EXPECTED_WHO_AM_I {
+        warn!("MPU6886: unexpected WHO_AM_I=0x{:02X} (expected 0x{:02X})", buf[0], EXPECTED_WHO_AM_I);
+        // Continue anyway — some Core2 v1.1 units have a different ID
+    }
+
+    // Wake up (clear sleep bit)
+    if i2c.write(MPU6886_ADDR, &[REG_PWR_MGMT_1, 0x00], 100).is_err() {
+        warn!("MPU6886: failed to wake");
+        return false;
+    }
+    esp_idf_hal::delay::FreeRtos::delay_ms(10);
+
+    // Set accel range to ±4g (enough for fall detection)
+    let _ = i2c.write(MPU6886_ADDR, &[REG_ACCEL_CONFIG, 0x08], 100);
+
+    info!("MPU6886: initialized (±4g)");
+    true
+}
+
+pub fn read_accel(i2c: &mut I2cDriver) -> Option<Accel> {
+    let mut buf = [0u8; 6];
+    if i2c.write_read(MPU6886_ADDR, &[REG_ACCEL_XOUT_H], &mut buf, 100).is_err() {
+        return None;
+    }
+
+    let raw_x = i16::from_be_bytes([buf[0], buf[1]]);
+    let raw_y = i16::from_be_bytes([buf[2], buf[3]]);
+    let raw_z = i16::from_be_bytes([buf[4], buf[5]]);
+
+    // ±4g range: 8192 LSB/g
+    let scale = 4.0 / 32768.0;
+    Some(Accel {
+        x: raw_x as f32 * scale,
+        y: raw_y as f32 * scale,
+        z: raw_z as f32 * scale,
+    })
+}

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -988,6 +988,15 @@ fn main() -> anyhow::Result<()> {
     let mut current_activity = imu::Activity::Standing;
     let mut fall_detected = false;
 
+    // IMU read-failure tracking. On the M5Stack Core2 the AXP2101 power
+    // mgmt and the MPU6886 share an I2C bus; an interrupted transaction
+    // can leave reads silently returning None for an indefinite stretch,
+    // which presents as the activity badge "stuck" on its last value.
+    // Track consecutive failures and re-init the chip after a short
+    // streak so we self-recover instead of staying frozen.
+    let mut imu_consecutive_fails: u32 = 0;
+    const IMU_REINIT_THRESHOLD: u32 = 10; // ~1 s of failures at 10 Hz poll
+
     // Alert state
     let mut alert_active = false;
     let mut vibration_on = false;
@@ -1024,6 +1033,13 @@ fn main() -> anyhow::Result<()> {
             last_imu_read = current_time;
 
             if let Some(accel) = imu::read_accel(&mut i2c) {
+                if imu_consecutive_fails > 0 {
+                    info!(
+                        "IMU: read recovered after {} failures",
+                        imu_consecutive_fails
+                    );
+                    imu_consecutive_fails = 0;
+                }
                 let activity = imu_state.update(&accel, now_ms());
 
                 // Periodic accel snapshot (~every 2 s) regardless of activity
@@ -1074,6 +1090,32 @@ fn main() -> anyhow::Result<()> {
                 // Reset fall detection when activity returns to normal
                 if fall_detected && activity != imu::Activity::PossibleFall {
                     fall_detected = false;
+                }
+            } else {
+                // IMU read returned None (likely an I2C bus glitch from
+                // contention with AXP2101 battery reads). Without the
+                // recovery below we'd silently fall through every IMU
+                // tick from now on — the badge would stay on its last
+                // classification ("stuck on STAND/PRONE") with no log
+                // trail showing why.
+                imu_consecutive_fails += 1;
+                if imu_consecutive_fails == 1 {
+                    warn!("IMU: read returned None (first failure)");
+                } else if imu_consecutive_fails == IMU_REINIT_THRESHOLD {
+                    warn!(
+                        "IMU: {} consecutive failed reads, attempting re-init",
+                        imu_consecutive_fails
+                    );
+                    if imu::init(&mut i2c) {
+                        info!("IMU: re-initialized successfully");
+                        imu_consecutive_fails = 0;
+                    } else {
+                        warn!("IMU: re-init failed; will retry on next failure streak");
+                        // Reset counter so the next IMU_REINIT_THRESHOLD
+                        // failures trigger another attempt rather than
+                        // logging a re-init every single tick forever.
+                        imu_consecutive_fails = 0;
+                    }
                 }
             }
         }

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -40,9 +40,21 @@ use mipidsi::models::ILI9342CRgb565;
 use mipidsi::options::Orientation;
 use mipidsi::Builder;
 
+use peat_btle::canned_message::CannedMessageDocument;
 use peat_btle::peat_mesh::{PeatMesh, PeatMeshConfig};
 use peat_btle::sync::PeripheralType;
-use peat_btle::NodeId;
+use peat_btle::{MeshGenesis, NodeId};
+
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+
+/// Shared mesh genesis for WEARTAK encrypted mesh. Matches the
+/// `SHARED_GENESIS_BASE64` constant baked into the WearTAK-CIV app
+/// (app/src/main/java/com/aitech/weartak_civ/service/PeatBtleService.kt).
+/// All nodes — WearOS watch, ATAK plugin, and this M5Stack — must use the
+/// same blob for encrypted sync to interop.
+const SHARED_GENESIS_BASE64: &str =
+    "BwBXRUFSVEFL4O7thA03dXXBNkT+gG22aTRGICECcX5RHtOgIdLBrb7tU7LTxkFLCLP+De21IALSXAbi6ZR/c3VXW9lKWacbM0YqfK9n5JXqob7/stIM63nBMLzJiFTGl9E6wcF8Gz0gUerY2JsBAAAA";
 
 // NVS storage
 const NVS_NAMESPACE: &str = "peat";
@@ -448,6 +460,7 @@ struct DisplayState {
     connected_peers: Vec<u32>,    // Node IDs of currently connected peers
     acked_peers: Vec<u32>,        // Node IDs that have ACK'd the current emergency
     activity: u8,                 // Activity state (0=Stationary, 1=Walking, 2=Running, 3=Fall)
+    last_canned_msg: Option<(u8, u32, u64)>, // (code, source_node, timestamp)
 }
 
 /// Draw initial static UI elements (call once at startup)
@@ -513,6 +526,20 @@ where
 }
 
 
+/// Draw canned message ticker at bottom of content area
+fn draw_canned_ticker<D>(display: &mut D, msg_name: &str, source_node: u32)
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    // Ticker bar: y=185-205, just above the button separator
+    let _ = Rectangle::new(Point::new(0, 185), Size::new(320, 20))
+        .into_styled(PrimitiveStyle::with_fill(Rgb565::new(4, 8, 4))) // dark green bg
+        .draw(display);
+    let style = MonoTextStyle::new(&FONT_10X20, Rgb565::YELLOW);
+    let text = format!("{:08X}: {}", source_node, &msg_name[..msg_name.len().min(22)]);
+    let _ = Text::new(&text, Point::new(5, 202), style).draw(display);
+}
+
 /// Update only changed parts of the display (minimizes flicker)
 /// Returns the new display state for comparison on next update
 fn update_display<D>(
@@ -539,9 +566,8 @@ where
 
     // Convert activity to u8 for comparison
     let activity_u8 = match activity {
-        imu::Activity::Stationary => 0,
-        imu::Activity::Walking => 1,
-        imu::Activity::Running => 2,
+        imu::Activity::Standing => 0,
+        imu::Activity::Prone => 1,
         imu::Activity::PossibleFall => 3,
     };
 
@@ -555,6 +581,12 @@ where
         connected_peers: connected_peers.clone(),
         acked_peers: acked_peers.to_vec(),
         activity: activity_u8,
+        last_canned_msg: {
+            let msgs = mesh.get_all_app_documents_of_type::<CannedMessageDocument>();
+            msgs.iter()
+                .max_by_key(|m| m.timestamp())
+                .map(|m| (m.message_code(), m.source_node(), m.timestamp()))
+        },
     };
 
     // Skip if nothing changed
@@ -583,29 +615,34 @@ where
             .draw(display);
     }
 
-    // Main content area - update if alert state, peers, connections, acks, or activity changed
-    let content_changed = current.alert_active != prev.alert_active
-        || current.peer_ids != prev.peer_ids
-        || current.connected_peers != prev.connected_peers
-        || current.acked_peers != prev.acked_peers
-        || current.activity != prev.activity;
+    // Main content area: split into zones so each one only redraws when its
+    // own state changes. Full-area clears only happen on alert-mode transition.
+    let mode_changed = current.alert_active != prev.alert_active;
 
-    if content_changed {
-        // Clear main content area
-        let _ = Rectangle::new(Point::new(0, 40), Size::new(320, 160))
-            .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
-            .draw(display);
-
-        if current.alert_active {
-            // ALERT MODE - big red box with EMERGENCY and ACK status
+    if current.alert_active {
+        // ALERT MODE — full red-box scene on entry, peer list refresh on ack
+        if mode_changed {
+            let _ = Rectangle::new(Point::new(0, 40), Size::new(320, 160))
+                .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
+                .draw(display);
             let _ = Rectangle::new(Point::new(20, 50), Size::new(280, 150))
                 .into_styled(PrimitiveStyle::with_fill(Rgb565::RED))
                 .draw(display);
             let white_style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
-            let green_style = MonoTextStyle::new(&FONT_10X20, Rgb565::GREEN);
             let _ = Text::new("EMERGENCY", Point::new(90, 80), white_style).draw(display);
+            let _ = Text::new("Tap ACK to clear", Point::new(70, 185), white_style).draw(display);
+        }
 
-            // Show ACK and connection status for each peer
+        let peers_changed = current.peer_ids != prev.peer_ids
+            || current.connected_peers != prev.connected_peers
+            || current.acked_peers != prev.acked_peers;
+        if mode_changed || peers_changed {
+            // Redraw only the peer-list band inside the red box.
+            let _ = Rectangle::new(Point::new(25, 100), Size::new(270, 80))
+                .into_styled(PrimitiveStyle::with_fill(Rgb565::RED))
+                .draw(display);
+            let white_style = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
+            let green_style = MonoTextStyle::new(&FONT_10X20, Rgb565::GREEN);
             let gray_style = MonoTextStyle::new(&FONT_10X20, Rgb565::CSS_GRAY);
             if !peer_ids.is_empty() {
                 let mut y = 110;
@@ -613,11 +650,11 @@ where
                     let is_connected = current.connected_peers.contains(id);
                     let acked = current.acked_peers.contains(id);
                     let (status, style) = if !is_connected {
-                        (format!("{:08X} [--]", id), gray_style)  // Disconnected
+                        (format!("{:08X} [--]", id), gray_style)
                     } else if acked {
-                        (format!("{:08X} [ACK]", id), green_style)  // Connected + ACK'd
+                        (format!("{:08X} [ACK]", id), green_style)
                     } else {
-                        (format!("{:08X} ...", id), white_style)  // Connected, waiting
+                        (format!("{:08X} ...", id), white_style)
                     };
                     let _ = Text::new(&status, Point::new(70, y), style).draw(display);
                     y += 25;
@@ -625,47 +662,66 @@ where
             } else {
                 let _ = Text::new("No peers known", Point::new(80, 120), white_style).draw(display);
             }
+        }
+    } else {
+        // READY MODE — zoned invalidation. Only the zones whose inputs changed
+        // clear+redraw, so STAND↔PRONE flips don't wipe the peer list etc.
+        let green = MonoTextStyle::new(&FONT_10X20, Rgb565::GREEN);
+        let white = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
+        let gray = MonoTextStyle::new(&FONT_10X20, Rgb565::CSS_GRAY);
+        let yellow = MonoTextStyle::new(&FONT_10X20, Rgb565::YELLOW);
 
-            let _ = Text::new("Tap ACK to clear", Point::new(70, 185), white_style).draw(display);
-        } else {
-            // READY MODE with peer info
-            let green = MonoTextStyle::new(&FONT_10X20, Rgb565::GREEN);
-            let white = MonoTextStyle::new(&FONT_10X20, Rgb565::WHITE);
-            let gray = MonoTextStyle::new(&FONT_10X20, Rgb565::CSS_GRAY);
-            let yellow = MonoTextStyle::new(&FONT_10X20, Rgb565::YELLOW);
+        if mode_changed {
+            // Coming out of alert: wipe once so the zones below paint on a
+            // black canvas instead of on top of the old red box.
+            let _ = Rectangle::new(Point::new(0, 40), Size::new(320, 160))
+                .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
+                .draw(display);
+        }
 
-            // Show local node ID above READY
-            let node_id_str = format!("{:08X}", mesh.node_id().as_u32());
-            let _ = Text::new(&node_id_str, Point::new(110, 55), white).draw(display);
+        // Zone A — callsign + node id (static for the life of the boot).
+        if mode_changed {
+            let node_id_str = format!("{}  {:08X}", mesh.callsign(), mesh.node_id().as_u32());
+            let x = ((320 - (node_id_str.len() as i32) * 10) / 2).max(0);
+            let _ = Text::new(&node_id_str, Point::new(x, 55), white).draw(display);
+        }
+
+        // Zone B — READY + activity badge (y ≈ 80). Flips with orientation.
+        if mode_changed || current.activity != prev.activity {
+            let _ = Rectangle::new(Point::new(0, 62), Size::new(320, 24))
+                .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
+                .draw(display);
             let _ = Text::new("READY", Point::new(125, 80), green).draw(display);
-
-            // Show activity status with color-coded text
             let (activity_str, activity_style) = match activity {
-                imu::Activity::Stationary => ("STILL", gray),
-                imu::Activity::Walking => ("WALK", green),
-                imu::Activity::Running => ("RUN", yellow),
+                imu::Activity::Standing => ("STAND", green),
+                imu::Activity::Prone => ("PRONE", yellow),
                 imu::Activity::PossibleFall => ("FALL!", MonoTextStyle::new(&FONT_10X20, Rgb565::RED)),
             };
             let _ = Text::new(activity_str, Point::new(230, 80), activity_style).draw(display);
+        }
 
-            // Show peer details
+        // Zone C+D — mesh count + peer list (y ≈ 105 to 200). Only peer
+        // membership or connection state drive this; activity flips skip it.
+        let peers_changed = mode_changed
+            || current.peer_ids != prev.peer_ids
+            || current.connected_peers != prev.connected_peers;
+        if peers_changed {
+            let _ = Rectangle::new(Point::new(0, 105), Size::new(320, 95))
+                .into_styled(PrimitiveStyle::with_fill(Rgb565::BLACK))
+                .draw(display);
             if !peer_ids.is_empty() {
-                // Show connected/total count
                 let connected_count = current.connected_peers.len();
                 let total_count = peer_ids.len();
-                let count_str = format!("{}/{} peers:", connected_count, total_count);
-                let _ = Text::new(&count_str, Point::new(100, 120), white).draw(display);
+                let count_str = format!("Mesh: {}/{} peers", connected_count, total_count);
+                let _ = Text::new(&count_str, Point::new(80, 120), white).draw(display);
 
-                // Show up to 3 peer IDs with connection status
                 let mut y = 145;
                 for id in peer_ids.iter().take(3) {
                     let is_connected = current.connected_peers.contains(id);
                     let id_str = format!("{:08X}", id);
                     let style = if is_connected { green } else { gray };
-                    // Center single peer, spread multiple
                     let x = if peer_ids.len() == 1 { 115 } else { 60 };
                     let _ = Text::new(&id_str, Point::new(x, y), style).draw(display);
-                    // Show status indicator
                     let status = if is_connected { " [OK]" } else { " [--]" };
                     let _ = Text::new(status, Point::new(x + 85, y), style).draw(display);
                     y += 25;
@@ -674,7 +730,17 @@ where
                     let _ = Text::new(&format!("+{} more", peer_ids.len() - 3), Point::new(100, y), gray).draw(display);
                 }
             } else {
-                let _ = Text::new("Scanning...", Point::new(100, 130), gray).draw(display);
+                let _ = Text::new("Mesh: no peers", Point::new(85, 130), gray).draw(display);
+            }
+        }
+    }
+
+    // Canned message ticker
+    if current.last_canned_msg != prev.last_canned_msg {
+        if let Some((_code, source, _ts)) = &current.last_canned_msg {
+            let msgs = mesh.get_all_app_documents_of_type::<CannedMessageDocument>();
+            if let Some(latest) = msgs.iter().max_by_key(|m| m.timestamp()) {
+                draw_canned_ticker(display, latest.message_name(), *source);
             }
         }
     }
@@ -811,11 +877,27 @@ fn main() -> anyhow::Result<()> {
     let _ = display.clear(Rgb565::BLUE);
     info!("Display cleared to blue");
 
-    // Initialize PeatMesh for centralized peer management and document sync
+    // Initialize PeatMesh for centralized peer management and document sync.
+    // Uses the same shared WEARTAK genesis as the WearOS watch and ATAK plugin
+    // so encrypted sync documents decode on this node.
     info!("Initializing PeatMesh...");
-    let config = PeatMeshConfig::new(node_id, "ESP32", "DEMO")
+    let genesis_bytes = BASE64_STANDARD
+        .decode(SHARED_GENESIS_BASE64)
+        .expect("SHARED_GENESIS_BASE64 must be valid base64");
+    let genesis = MeshGenesis::decode(&genesis_bytes)
+        .expect("SHARED_GENESIS_BASE64 must decode to a MeshGenesis");
+    info!(
+        "Using SHARED WEARTAK genesis: mesh_id={}",
+        genesis.mesh_id()
+    );
+    // Callsign derives from the low 16 bits of the node id so multiple M5Stacks
+    // on the same mesh still stay distinguishable on a display at a glance.
+    let callsign = format!("SCOUT-{:04X}", node_id.as_u32() as u16);
+    let config = PeatMeshConfig::new(node_id, &callsign, &genesis.mesh_id())
+        .with_encryption(genesis.encryption_secret())
         .with_peripheral_type(PeripheralType::SoldierSensor);
     let mesh = PeatMesh::new(config);
+    mesh.document_registry().try_register::<CannedMessageDocument>();
     info!("PeatMesh created for node {:08X}", node_id.as_u32());
 
     // Initialize NVS store for persistence
@@ -833,9 +915,11 @@ fn main() -> anyhow::Result<()> {
     mesh.clear_emergency();   // Clear document emergency + ACK state
     info!("PeatMesh initialized: {} total taps (events cleared)", mesh.total_count());
 
-    // Initialize BLE
+    // Initialize BLE. The advertised name encodes the mesh_id so WEARTAK peers
+    // recognize this device as part of their mesh during scan/filtering.
     info!("Initializing BLE...");
-    if let Err(e) = nimble::init(node_id) {
+    let ble_device_name = format!("PEAT_{}-{:08X}", genesis.mesh_id(), node_id.as_u32());
+    if let Err(e) = nimble::init(node_id, &ble_device_name) {
         error!("Failed to initialize BLE: {}", e);
         // Continue without BLE for testing
     }
@@ -865,7 +949,7 @@ fn main() -> anyhow::Result<()> {
     update_button_labels(&mut display, false);  // Initial state: ACK greyed out
     let mut display_state = DisplayState::default();
     let acked = get_acked_peers_from_mesh(&mesh);
-    display_state = update_display(&mut display, &mesh, false, battery_pct, "BtnC=EMERG  BtnA=ACK", &display_state, &acked, imu::Activity::Stationary);
+    display_state = update_display(&mut display, &mesh, false, battery_pct, "BtnC=EMERG  BtnA=ACK", &display_state, &acked, imu::Activity::Standing);
     print_status(&mesh, false, "BtnC=EMERG  BtnA=ACK");
 
     // Main loop state
@@ -876,7 +960,7 @@ fn main() -> anyhow::Result<()> {
     // IMU state
     let mut last_imu_read: u32 = 0;
     const IMU_READ_INTERVAL_MS: u32 = 100;  // Read IMU at 10Hz
-    let mut current_activity = imu::Activity::Stationary;
+    let mut current_activity = imu::Activity::Standing;
     let mut fall_detected = false;
 
     // Alert state
@@ -1076,8 +1160,13 @@ fn main() -> anyhow::Result<()> {
         }
         last_button = button;
 
-        // Handle ALL pending documents from BLE (process queue to avoid losing ACKs)
-        while let Some(data) = nimble::take_pending_document() {
+        // Drain at most one pending document per main-loop tick. Each
+        // iteration does a NVS save + gossip_document fanout, both of
+        // which spend time deep in ESP-IDF/NimBLE; processing the whole
+        // queue in a single tick can starve IDLE1 long enough to trip
+        // the task watchdog on CPU 1. The remaining queue gets picked
+        // up next tick (50 ms later).
+        if let Some(data) = nimble::take_pending_document() {
             info!("");
             info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
             info!("!!! RECEIVED {} BYTES FROM BLE !!!", data.len());
@@ -1175,13 +1264,17 @@ fn main() -> anyhow::Result<()> {
                         error!("Failed to save merged doc: {:?}", e);
                     }
 
-                    // GOSSIP: Forward merged state to ALL other peers (multi-hop!)
-                    let encoded = mesh.build_document();
-                    let sent = nimble::gossip_document(&encoded);
-                    info!(">>> Forwarded merged doc to {} peers (multi-hop)", sent);
-
+                    // Skip post-merge multi-hop forward: it fans a
+                    // gossip_document out to every active connection on every
+                    // received doc, and during a sync burst that flooded
+                    // NimBLE's queue badly enough to starve IDLE1 on CPU 1
+                    // and trip the task watchdog (which manifested as the UI
+                    // freezing on its last activity classification). The
+                    // periodic 5 s gossip below propagates state for a
+                    // small mesh; revisit if multi-hop is needed for the
+                    // 48-node demo.
                     needs_redraw = true;
-                    print_status(&mesh, connected, "Merged & forwarded!");
+                    print_status(&mesh, connected, "Merged");
                 } else {
                     info!("No changes from merge (peer had same or less data)");
                 }
@@ -1226,11 +1319,10 @@ fn main() -> anyhow::Result<()> {
             if let Some(mv) = axp_read_battery_voltage(&mut i2c) {
                 let pct = battery_percent_from_voltage(mv);
                 battery_pct = Some(pct);
-                // Convert activity to u8: 0=still, 1=walking, 2=running, 3=fall
+                // Convert activity to u8: 0=standing, 1=prone, 3=fall (2 was Running, retired)
                 let activity_u8 = match current_activity {
-                    imu::Activity::Stationary => 0,
-                    imu::Activity::Walking => 1,
-                    imu::Activity::Running => 2,
+                    imu::Activity::Standing => 0,
+                    imu::Activity::Prone => 1,
                     imu::Activity::PossibleFall => 3,
                 };
                 mesh.update_health_full(pct, activity_u8);

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -66,6 +66,14 @@ const SHARED_GENESIS_BASE64: &str = match option_env!("PEAT_GENESIS_BASE64") {
     None => "BwBXRUFSVEFL4O7thA03dXXBNkT+gG22aTRGICECcX5RHtOgIdLBrb7tU7LTxkFLCLP+De21IALSXAbi6ZR/c3VXW9lKWacbM0YqfK9n5JXqob7/stIM63nBMLzJiFTGl9E6wcF8Gz0gUerY2JsBAAAA",
 };
 
+/// True when the build is using the embedded demo-only genesis (no
+/// `PEAT_GENESIS_BASE64` env var was set at compile time). Surfaces in a
+/// runtime `warn!` at boot so a misconfigured non-demo build is visible
+/// in serial — the compile-time comment alone isn't enough; that's
+/// exactly the failure mode where a real secret can ship on a fielded
+/// node without anyone noticing.
+const USING_FALLBACK_GENESIS: bool = option_env!("PEAT_GENESIS_BASE64").is_none();
+
 // NVS storage
 const NVS_NAMESPACE: &str = "peat";
 const NVS_KEY_COUNTER: &str = "counter";
@@ -906,6 +914,13 @@ fn main() -> anyhow::Result<()> {
     // Uses the same shared WEARTAK genesis as the WearOS watch and ATAK plugin
     // so encrypted sync documents decode on this node.
     info!("Initializing PeatMesh...");
+    if USING_FALLBACK_GENESIS {
+        warn!(
+            "PEAT GENESIS: using embedded DEMO/badge fallback (PEAT_GENESIS_BASE64 \
+             was not set at build time). Do NOT ship this build to a non-demo \
+             deployment — the secret is in repo history forever. See ADR-044."
+        );
+    }
     let genesis_bytes = BASE64_STANDARD
         .decode(SHARED_GENESIS_BASE64)
         .expect("SHARED_GENESIS_BASE64 must be valid base64");
@@ -997,6 +1012,15 @@ fn main() -> anyhow::Result<()> {
     let mut imu_consecutive_fails: u32 = 0;
     const IMU_REINIT_THRESHOLD: u32 = 10; // ~1 s of failures at 10 Hz poll
 
+    // Counter-of-counters: how many re-init attempts in a row have failed
+    // OR succeeded but left the bus broken (next read also fails). After
+    // IMU_REINIT_GIVEUP_STREAK consecutive cycles we escalate to error!
+    // once so the operator sees that the bus is permanently broken,
+    // rather than spamming a warn! every ~1 s forever.
+    let mut imu_reinit_failure_streak: u32 = 0;
+    let mut imu_reinit_giveup_logged = false;
+    const IMU_REINIT_GIVEUP_STREAK: u32 = 5;
+
     // Alert state
     let mut alert_active = false;
     let mut vibration_on = false;
@@ -1039,6 +1063,8 @@ fn main() -> anyhow::Result<()> {
                         imu_consecutive_fails
                     );
                     imu_consecutive_fails = 0;
+                    imu_reinit_failure_streak = 0;
+                    imu_reinit_giveup_logged = false;
                 }
                 let activity = imu_state.update(&accel, now_ms());
 
@@ -1102,20 +1128,38 @@ fn main() -> anyhow::Result<()> {
                 if imu_consecutive_fails == 1 {
                     warn!("IMU: read returned None (first failure)");
                 } else if imu_consecutive_fails == IMU_REINIT_THRESHOLD {
-                    warn!(
-                        "IMU: {} consecutive failed reads, attempting re-init",
-                        imu_consecutive_fails
-                    );
-                    if imu::init(&mut i2c) {
-                        info!("IMU: re-initialized successfully");
-                        imu_consecutive_fails = 0;
-                    } else {
-                        warn!("IMU: re-init failed; will retry on next failure streak");
-                        // Reset counter so the next IMU_REINIT_THRESHOLD
-                        // failures trigger another attempt rather than
-                        // logging a re-init every single tick forever.
-                        imu_consecutive_fails = 0;
+                    if !imu_reinit_giveup_logged {
+                        warn!(
+                            "IMU: {} consecutive failed reads, attempting re-init (streak {})",
+                            imu_consecutive_fails, imu_reinit_failure_streak
+                        );
                     }
+                    let reinit_ok = imu::init(&mut i2c);
+                    if reinit_ok {
+                        info!("IMU: re-initialized successfully");
+                        imu_reinit_failure_streak = 0;
+                        imu_reinit_giveup_logged = false;
+                    } else {
+                        imu_reinit_failure_streak += 1;
+                        if imu_reinit_failure_streak >= IMU_REINIT_GIVEUP_STREAK
+                            && !imu_reinit_giveup_logged
+                        {
+                            error!(
+                                "IMU: {} consecutive re-init attempts have failed — \
+                                 bus is likely permanently broken until next reboot. \
+                                 Subsequent attempts will be silent.",
+                                imu_reinit_failure_streak
+                            );
+                            imu_reinit_giveup_logged = true;
+                        } else if !imu_reinit_giveup_logged {
+                            warn!("IMU: re-init failed; will retry on next failure streak");
+                        }
+                    }
+                    // Reset the read-failure counter either way: on success
+                    // the next read should succeed; on failure we want the
+                    // next IMU_REINIT_THRESHOLD reads to trigger another
+                    // attempt rather than logging every single tick.
+                    imu_consecutive_fails = 0;
                 }
             }
         }

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -48,17 +48,37 @@ use peat_btle::{MeshGenesis, NodeId};
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
 
-/// Shared mesh genesis for WEARTAK encrypted mesh. Matches the
-/// `SHARED_GENESIS_BASE64` constant baked into the WearTAK-CIV app
-/// (app/src/main/java/com/aitech/weartak_civ/service/PeatBtleService.kt).
-/// All nodes — WearOS watch, ATAK plugin, and this M5Stack — must use the
-/// same blob for encrypted sync to interop.
-const SHARED_GENESIS_BASE64: &str =
-    "BwBXRUFSVEFL4O7thA03dXXBNkT+gG22aTRGICECcX5RHtOgIdLBrb7tU7LTxkFLCLP+De21IALSXAbi6ZR/c3VXW9lKWacbM0YqfK9n5JXqob7/stIM63nBMLzJiFTGl9E6wcF8Gz0gUerY2JsBAAAA";
+/// Shared mesh genesis for the WEARTAK encrypted mesh. The decoded blob
+/// contains `MeshGenesis::encryption_secret()` — i.e. it IS the mesh's
+/// long-term root secret. The compile-time fallback below is the demo
+/// genesis matching `wearos-tak-civ/.../PeatBtleService.kt`; for any
+/// non-demo build, override at compile time with
+///   `PEAT_GENESIS_BASE64=<base64> cargo build ...`
+/// so the secret lives in the build environment, not in repo history.
+///
+/// **WARNING:** this fallback genesis is for demo/badge use only. Do not
+/// reuse it for any real deployment — the secret is in repo history
+/// forever, and key rotation would require both a history rewrite and
+/// re-distribution to every node. ADR-044 is the planned path for
+/// real (MLS-based) group key distribution.
+const SHARED_GENESIS_BASE64: &str = match option_env!("PEAT_GENESIS_BASE64") {
+    Some(v) => v,
+    None => "BwBXRUFSVEFL4O7thA03dXXBNkT+gG22aTRGICECcX5RHtOgIdLBrb7tU7LTxkFLCLP+De21IALSXAbi6ZR/c3VXW9lKWacbM0YqfK9n5JXqob7/stIM63nBMLzJiFTGl9E6wcF8Gz0gUerY2JsBAAAA",
+};
 
 // NVS storage
 const NVS_NAMESPACE: &str = "peat";
 const NVS_KEY_COUNTER: &str = "counter";
+
+/// Re-broadcast merged state to every active connection on each received
+/// document (multi-hop relay). False here so the M5Stack's small-mesh
+/// behavior matches what's been validated under sustained load — the
+/// fanout was the worst offender for NimBLE TX queue flooding before the
+/// peripheral-only switch. The 5 s periodic gossip handles convergence
+/// for 1-hop topologies with no relay needed; for the 48-node demo flip
+/// this to true (and re-validate watchdog behavior) so an N-hop chain
+/// converges in ~one round-trip per hop instead of N × 5 s.
+const MULTIHOP_FORWARD: bool = false;
 
 // FT6336U Touch controller on M5Stack Core2
 const FT6336U_ADDR: u8 = 0x38;
@@ -564,10 +584,15 @@ where
         .map(|p| p.node_id.as_u32())
         .collect();
 
-    // Convert activity to u8 for comparison
+    // Convert activity to u8 for diff comparison only — the same mapping
+    // is sent to peers via mesh.update_health_full() so it must avoid
+    // colliding with the legacy enum (0=Stationary, 1=Walking, 2=Running,
+    // 3=PossibleFall) on un-updated decoders. Prone uses 4 — un-updated
+    // peers see "unknown" and skip rendering rather than mis-rendering as
+    // Walking. Standing keeps 0 (semantically aligned with Stationary).
     let activity_u8 = match activity {
         imu::Activity::Standing => 0,
-        imu::Activity::Prone => 1,
+        imu::Activity::Prone => 4,
         imu::Activity::PossibleFall => 3,
     };
 
@@ -1172,13 +1197,21 @@ fn main() -> anyhow::Result<()> {
         }
         last_button = button;
 
-        // Drain at most one pending document per main-loop tick. Each
-        // iteration does a NVS save + gossip_document fanout, both of
-        // which spend time deep in ESP-IDF/NimBLE; processing the whole
-        // queue in a single tick can starve IDLE1 long enough to trip
-        // the task watchdog on CPU 1. The remaining queue gets picked
-        // up next tick (50 ms later).
-        if let Some(data) = nimble::take_pending_document() {
+        // Drain at most DOC_DRAIN_PER_TICK pending documents per main-loop
+        // tick. Each iteration does an NVS save plus (under MULTIHOP_FORWARD)
+        // a gossip_document fanout, both of which spend time deep in
+        // ESP-IDF/NimBLE; processing the whole queue in one tick can starve
+        // IDLE long enough to trip the task watchdog. Two-per-tick keeps the
+        // bound well under the 60 s WDT budget while halving the worst-case
+        // ack-burst feedback latency for emergency-broadcast scenarios. Any
+        // remaining queue gets picked up on the next tick (50 ms later).
+        const DOC_DRAIN_PER_TICK: u8 = 2;
+        let mut drained = 0u8;
+        while drained < DOC_DRAIN_PER_TICK {
+            let Some(data) = nimble::take_pending_document() else {
+                break;
+            };
+            drained += 1;
             info!("");
             info!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
             info!("!!! RECEIVED {} BYTES FROM BLE !!!", data.len());
@@ -1276,15 +1309,19 @@ fn main() -> anyhow::Result<()> {
                         error!("Failed to save merged doc: {:?}", e);
                     }
 
-                    // Skip post-merge multi-hop forward: it fans a
-                    // gossip_document out to every active connection on every
-                    // received doc, and during a sync burst that flooded
-                    // NimBLE's queue badly enough to starve IDLE1 on CPU 1
-                    // and trip the task watchdog (which manifested as the UI
-                    // freezing on its last activity classification). The
-                    // periodic 5 s gossip below propagates state for a
-                    // small mesh; revisit if multi-hop is needed for the
-                    // 48-node demo.
+                    // Post-merge multi-hop forward, gated on MULTIHOP_FORWARD.
+                    // Disabled for the small-mesh demo: the per-doc fanout
+                    // floods NimBLE's TX queue and previously starved IDLE1
+                    // on CPU 1 enough to trip the task watchdog. The 5 s
+                    // periodic gossip is sufficient for 1-hop topologies.
+                    // Re-enable for the 48-node demo so an N-hop chain
+                    // converges in roughly one round-trip per hop instead
+                    // of N × 5 s.
+                    if MULTIHOP_FORWARD {
+                        let encoded = mesh.build_document();
+                        let sent = nimble::gossip_document(&encoded);
+                        info!(">>> Forwarded merged doc to {} peers (multi-hop)", sent);
+                    }
                     needs_redraw = true;
                     print_status(&mesh, connected, "Merged");
                 } else {
@@ -1331,10 +1368,20 @@ fn main() -> anyhow::Result<()> {
             if let Some(mv) = axp_read_battery_voltage(&mut i2c) {
                 let pct = battery_percent_from_voltage(mv);
                 battery_pct = Some(pct);
-                // Convert activity to u8: 0=standing, 1=prone, 3=fall (2 was Running, retired)
+                // Wire-format activity code sent to peers via
+                // mesh.update_health_full(). Avoid colliding with the
+                // legacy enum (0=Stationary, 1=Walking, 2=Running,
+                // 3=PossibleFall) so un-updated peers don't mis-render
+                // Prone as Walking. Prone uses 4; old peers fall through
+                // to "unknown" instead of a wrong label.
+                //   0 = Standing       (legacy: Stationary — semantic match)
+                //   1 = (legacy Walking — no longer emitted)
+                //   2 = (legacy Running — no longer emitted)
+                //   3 = PossibleFall   (unchanged)
+                //   4 = Prone          (new — no legacy collision)
                 let activity_u8 = match current_activity {
                     imu::Activity::Standing => 0,
-                    imu::Activity::Prone => 1,
+                    imu::Activity::Prone => 4,
                     imu::Activity::PossibleFall => 3,
                 };
                 mesh.update_health_full(pct, activity_u8);

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -1001,6 +1001,18 @@ fn main() -> anyhow::Result<()> {
             if let Some(accel) = imu::read_accel(&mut i2c) {
                 let activity = imu_state.update(&accel, now_ms());
 
+                // Periodic accel snapshot (~every 2 s) regardless of activity
+                // change. Lets us validate IMU reads + axis mapping when the
+                // badge looks "stuck" — without this, a steady classification
+                // produces no log line and we can't tell if reads are even
+                // happening or what gravity is on which axis.
+                if loop_count % 40 == 0 {
+                    info!(
+                        "IMU: accel x={:.2} y={:.2} z={:.2} mag={:.2} -> {:?}",
+                        accel.x, accel.y, accel.z, accel.magnitude(), activity
+                    );
+                }
+
                 // Check for activity change
                 if activity != current_activity {
                     info!("Activity: {:?} -> {:?} (accel: x={} y={} z={} mag={})",

--- a/examples/m5stack-core2-peat/src/nimble.rs
+++ b/examples/m5stack-core2-peat/src/nimble.rs
@@ -7,7 +7,7 @@
 
 use core::ffi::{c_int, c_void};
 use core::ptr;
-use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU32, Ordering};
 use std::sync::Mutex;
 
 use esp_idf_svc::sys::*;
@@ -116,6 +116,37 @@ static OUR_MAC: Mutex<[u8; 6]> = Mutex::new([0u8; 6]);
 const MAX_TRACKED_PEERS: usize = 8;
 static PEER_SYNC_TIMES: Mutex<[([u8; 6], u32); MAX_TRACKED_PEERS]> = Mutex::new([([0u8; 6], 0); MAX_TRACKED_PEERS]);
 
+/// Timestamp of the last *failed* connection attempt to a peer (unix-ish secs).
+/// Used to back off from peers that keep disconnecting mid-handshake so the
+/// BLE host task doesn't thrash churning through discovery+disconnect loops
+/// (which starves IDLE0 on CPU 0 and trips the task watchdog).
+static PEER_FAIL_TIMES: Mutex<[([u8; 6], u32); MAX_TRACKED_PEERS]> =
+    Mutex::new([([0u8; 6], 0); MAX_TRACKED_PEERS]);
+
+/// Seconds to skip a peer after a failed/incomplete sync attempt.
+const PEER_FAIL_BACKOFF_SECS: u32 = 15;
+
+/// Wall-clock seconds after ANY failed disconnect during which we won't
+/// initiate a new outbound connection. Per-MAC backoff is fooled by
+/// peers that rotate their random address (which is normal BLE privacy
+/// behavior on most phones / watches), so we additionally throttle the
+/// global connect rate. Each rejected connect attempt → discovery error
+/// → disconnect cycle queues a chunk of NimBLE cleanup work, and a tight
+/// stream of those eventually blocks the host task long enough to trip
+/// the task watchdog.
+const GLOBAL_CONNECT_BACKOFF_SECS: u32 = 5;
+static LAST_FAILED_DISCONNECT_SEC: AtomicU32 = AtomicU32::new(0);
+
+/// When true, we never initiate an outbound BLE connection to a peer;
+/// we only accept incoming connections from peers that scan + connect to
+/// our advertisement (the watch and ATAK plugin both do). Removing the
+/// outbound path eliminates the connect/disconnect/discovery-error
+/// thrash that intermittently locked NimBLE's host task in mbuf
+/// cleanup. Peripheral-only is enough for the M5Stack's role (sensor +
+/// display); if multi-hop relay is needed for the 48-node demo, flip
+/// this and re-validate the soak.
+const PERIPHERAL_ONLY: bool = true;
+
 /// Current peer MAC (the one we're connected/connecting to)
 static CURRENT_PEER_MAC: Mutex<[u8; 6]> = Mutex::new([0u8; 6]);
 
@@ -150,6 +181,39 @@ fn get_peer_last_sync(mac: &[u8; 6]) -> u32 {
         for (peer_mac, sync_time) in peers.iter() {
             if peer_mac == mac {
                 return *sync_time;
+            }
+        }
+    }
+    0
+}
+
+/// Record a failed connection attempt to this peer (disconnect before sync
+/// completed, discovery error, etc.). The peer gets skipped on subsequent
+/// scan results until `PEER_FAIL_BACKOFF_SECS` has elapsed.
+fn record_peer_failure(mac: &[u8; 6], timestamp: u32) {
+    if let Ok(mut fails) = PEER_FAIL_TIMES.lock() {
+        let mut oldest_idx = 0;
+        let mut oldest_time = u32::MAX;
+        for (i, (peer_mac, fail_time)) in fails.iter().enumerate() {
+            if peer_mac == mac {
+                fails[i].1 = timestamp;
+                return;
+            }
+            if *fail_time < oldest_time {
+                oldest_time = *fail_time;
+                oldest_idx = i;
+            }
+        }
+        fails[oldest_idx] = (*mac, timestamp);
+    }
+}
+
+/// Get last failure time for a peer (0 if never failed)
+fn get_peer_last_failure(mac: &[u8; 6]) -> u32 {
+    if let Ok(fails) = PEER_FAIL_TIMES.lock() {
+        for (peer_mac, fail_time) in fails.iter() {
+            if peer_mac == mac {
+                return *fail_time;
             }
         }
     }
@@ -291,6 +355,27 @@ unsafe extern "C" fn gap_event_handler(event: *mut ble_gap_event, _arg: *mut c_v
             let disc_handle = disconnect.conn.conn_handle;
             info!("BLE: Disconnected, handle={}", disc_handle);
 
+            // If this disconnect happened before the sync handshake completed,
+            // register the peer for backoff so we don't immediately reconnect
+            // and thrash the BLE host task (see PEER_FAIL_BACKOFF_SECS) — and
+            // also stamp the global rate-limit so a peer rotating its random
+            // address can't bypass per-MAC backoff and re-trigger a churn
+            // cycle on every new advertisement.
+            if !SYNC_COMPLETE.load(Ordering::SeqCst) {
+                let now = esp_idf_svc::sys::esp_timer_get_time() as u32 / 1_000_000;
+                LAST_FAILED_DISCONNECT_SEC.store(now, Ordering::SeqCst);
+                if let Ok(current) = CURRENT_PEER_MAC.lock() {
+                    if *current != [0u8; 6] {
+                        record_peer_failure(&*current, now);
+                        info!(
+                            "BLE: Recorded failed sync for {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}, {}s peer backoff, {}s global",
+                            current[0], current[1], current[2], current[3], current[4], current[5],
+                            PEER_FAIL_BACKOFF_SECS, GLOBAL_CONNECT_BACKOFF_SECS
+                        );
+                    }
+                }
+            }
+
             // Remove from multi-connection list and track disconnected node ID
             if let Ok(mut conns) = CONNECTIONS.lock() {
                 for conn in conns.iter_mut() {
@@ -334,6 +419,14 @@ unsafe extern "C" fn gap_event_handler(event: *mut ble_gap_event, _arg: *mut c_v
         BLE_GAP_EVENT_DISC => {
             let disc = &event.__bindgen_anon_1.disc;
 
+            // Skip outbound-connect handling entirely in peripheral-only mode.
+            // Peers (watch / ATAK plugin) connect TO us via our advertisement;
+            // we sync via gatt_write_cb (their write to our characteristic)
+            // and notifications, so we don't need to be central.
+            if PERIPHERAL_ONLY {
+                return 0;
+            }
+
             // Check if this device advertises Peat service
             if has_peat_service(disc.data, disc.length_data) {
                 // Get peer MAC address
@@ -343,15 +436,36 @@ unsafe extern "C" fn gap_event_handler(event: *mut ble_gap_event, _arg: *mut c_v
                 let now = esp_idf_svc::sys::esp_timer_get_time() as u32 / 1_000_000;
                 let last_sync = get_peer_last_sync(&peer_mac);
                 let since_sync = now.saturating_sub(last_sync);
+                let last_fail = get_peer_last_failure(&peer_mac);
+                let since_fail = now.saturating_sub(last_fail);
+                let last_global_fail = LAST_FAILED_DISCONNECT_SEC.load(Ordering::SeqCst);
+                let since_global_fail = now.saturating_sub(last_global_fail);
 
-                // 30 second cooldown per peer - prevents thrashing
-                let in_cooldown = last_sync > 0 && since_sync < 30;
+                // 30 second cooldown after successful sync (no need to resync
+                // this peer yet), plus a short per-peer backoff after failed
+                // handshakes, plus a global rate-limit catching peers that
+                // rotate their random address between attempts. All three
+                // together break reconnect thrash that starves the BLE host.
+                let in_sync_cooldown = last_sync > 0 && since_sync < 30;
+                let in_fail_backoff = last_fail > 0 && since_fail < PEER_FAIL_BACKOFF_SECS;
+                let in_global_backoff =
+                    last_global_fail > 0 && since_global_fail < GLOBAL_CONNECT_BACKOFF_SECS;
+                let in_cooldown = in_sync_cooldown || in_fail_backoff || in_global_backoff;
 
                 // Check if already connected to this specific peer
                 let already_connected = is_connected_to_peer(&peer_mac);
 
                 if in_cooldown {
-                    debug!("BLE: Peer in cooldown (synced {}s ago)", since_sync);
+                    if in_global_backoff {
+                        debug!(
+                            "BLE: Global connect-backoff ({}s since last failed disconnect)",
+                            since_global_fail
+                        );
+                    } else if in_fail_backoff {
+                        debug!("BLE: Peer in fail-backoff ({}s since failure)", since_fail);
+                    } else {
+                        debug!("BLE: Peer in cooldown (synced {}s ago)", since_sync);
+                    }
                 } else if already_connected {
                     debug!("BLE: Already connected to this peer");
                 } else if !can_accept_connection() {
@@ -790,22 +904,24 @@ static mut GATT_SVCS: [ble_gatt_svc_def; 2] = unsafe { core::mem::zeroed() };
 static mut GATT_CHARS: [ble_gatt_chr_def; 2] = unsafe { core::mem::zeroed() };
 static mut SVC_UUID: ble_uuid128_t = unsafe { core::mem::zeroed() };
 static mut CHR_UUID: ble_uuid128_t = unsafe { core::mem::zeroed() };
-/// Device name for advertising (e.g., "PEAT_DEMO-12345678")
-static mut DEVICE_NAME: [u8; 20] = [0; 20];
+/// Device name for advertising (e.g., "PEAT_29C916FA-6462A698"). Sized to fit
+/// the longest BLE advertised name we emit: 5 char prefix + 8 char mesh id +
+/// 1 char separator + 8 char node id = 22 bytes. Keep a little headroom.
+static mut DEVICE_NAME: [u8; 32] = [0; 32];
 static mut DEVICE_NAME_LEN: u8 = 0;
 
-/// Initialize NimBLE stack
-pub fn init(node_id: NodeId) -> Result<(), i32> {
+/// Initialize NimBLE stack. `device_name` is copied into a static buffer and
+/// advertised — callers supply `PEAT_<mesh_id>-<node_id>` so peers on the same
+/// mesh can filter discovered devices by the mesh_id tag.
+pub fn init(node_id: NodeId, device_name: &str) -> Result<(), i32> {
     unsafe {
         info!("BLE: Initializing NimBLE");
 
-        // Build device name from node ID (e.g., "PEAT_DEMO-12345678")
-        let name = format!("PEAT_DEMO-{:08X}", node_id.as_u32());
-        let name_bytes = name.as_bytes();
+        let name_bytes = device_name.as_bytes();
         let len = name_bytes.len().min(DEVICE_NAME.len());
         DEVICE_NAME[..len].copy_from_slice(&name_bytes[..len]);
         DEVICE_NAME_LEN = len as u8;
-        info!("BLE: Device name: {}", name);
+        info!("BLE: Device name: {}", device_name);
 
         // Store our MAC for connection arbitration
         let mut mac = [0u8; 6];
@@ -961,6 +1077,13 @@ pub fn start_advertising() -> Result<(), i32> {
 
 /// Start BLE scanning for peers
 pub fn start_scanning() -> Result<(), i32> {
+    // In peripheral-only mode we never connect outbound, so scanning
+    // serves no purpose and just feeds BLE_GAP_EVENT_DISC events into
+    // a handler that early-returns. Skip it entirely so the radio is
+    // free to advertise + service incoming connections.
+    if PERIPHERAL_ONLY {
+        return Ok(());
+    }
     unsafe {
         let mut params: ble_gap_disc_params = core::mem::zeroed();
         params.itvl = 160; // 100ms


### PR DESCRIPTION
## Summary
Brings the M5Stack Core2 example onto the same encrypted WEARTAK mesh as the WearOS watch and ATAK plugin, fixes a chain of BLE-thrash + task-watchdog issues that intermittently froze the device after several minutes of mesh activity, and tightens the IMU + display behavior so the demo doesn't false-trigger EMERGENCY or flicker on every state change. Squashes a series of iterative fixes from a downstream branch into coherent commits.

## Mesh interop
- Decode the shared `SHARED_GENESIS_BASE64` (matching `wearos-tak-civ/.../PeatBtleService.kt`) via `MeshGenesis::decode` and feed `genesis.mesh_id()` + `genesis.encryption_secret()` into `PeatMeshConfig` — same ChaCha20-Poly1305 key as the watch and ATAK plugin (mesh_id `29C916FA`).
- Pass that mesh_id into the BLE advertised device name (`PEAT_29C916FA-<node_id>`) so WEARTAK peers recognize the M5Stack as part of their mesh on scan.
- Add `base64 = \"0.22\"` for genesis decoding.
- `option_env!(\"PEAT_GENESIS_BASE64\")` with a demo-only fallback string + a runtime `warn!` at boot when the fallback is in use, so a misconfigured non-demo build is visible in serial.
- Rename callsign from generic `ESP32` to `SCOUT-<low16 hex of node id>`.

## BLE stability — peripheral-only
- `PERIPHERAL_ONLY = true` in `nimble.rs`. M5Stack stops scanning for peers and never calls `ble_gap_connect()`; advertises and accepts incoming connections only. Bidirectional path retained behind the flag for the 48-node demo.
- Per-peer (15 s) + global (5 s) connect backoffs wired for that case — peers that rotate their random address otherwise bypass per-MAC cooldown.
- `MULTIHOP_FORWARD: bool = false` const co-located with `PERIPHERAL_ONLY`. Re-enables the post-merge gossip fanout for multi-hop topologies; left default-off to preserve small-mesh stability.
- `CONFIG_BT_NIMBLE_MAX_CONNECTIONS` 4 → 2 — halves worst-case mbuf cleanup chain per disconnect.
- Cap the BLE doc-drain at `DOC_DRAIN_PER_TICK = 2` queued docs per main-loop tick (bounded `while` + `let-else` early-break), halves emergency-ack-burst feedback latency vs the previous 1-per-tick while staying well under the 60 s WDT budget.
- TWDT timeout 30 s → 60 s, panic stays off, IDLE0/IDLE1 stay subscribed so a true hang produces a backtrace rather than silent freeze.

## IMU + display polish
- Replace motion-based STILL/WALK/RUN with orientation-based **STAND/PRONE**. Dominant-axis check: Prone iff `|accel.z|` is the largest-magnitude axis AND above 0.5 g floor. Invariant to which physical axis the chip's z is mounted along.
- Wire-format `activity_u8`: Standing=0, PossibleFall=3, Prone=4 (values 1 and 2 reserved for legacy Walking/Running so un-updated decoders fall through to \"unknown\" instead of mis-rendering).
- `Running` retired — intruded on STAND↔PRONE flips because device-handling jerk crossed its threshold during motion before settling.
- Raise fall-impact threshold 3.0 g → 5.0 g + require a 3-sample streak before `PossibleFall`.
- Periodic `IMU: accel ...` snapshot every ~2 s regardless of activity change, plus IMU-read-failure recovery: log on first None, auto-reinit after 10 consecutive failures, escalate to `error!` after 5 consecutive failed re-inits to surface a permanently-broken bus to the operator.
- Zone-invalidated `update_display()`: callsign line, READY+activity row, mesh-count + peer-list region each track their own diff and only repaint when inputs change.
- Replace ambiguous \"Scanning…\" / \"{}/{} peers:\" with explicit \"Mesh: no peers\" / \"Mesh: c/t peers\".

## Path-dep correction
`peat-btle` path was `../../../revolve/peat-btle` (broken on `main` since the repo moved out of the revolve org). Updated to `../../../peat-btle` matching the actual sibling-repo layout, with an inline Cargo.toml comment explaining the layout requirement.

## Known limitations (also documented in the example README)
- `PERIPHERAL_ONLY = true` — two M5Stacks in range of only each other will not link.
- `MULTIHOP_FORWARD = false` — N-hop topologies converge in `~N × 5 s` instead of one round-trip per hop.
- `MAX_CONNECTIONS = 2` — the larger-mesh demo will need this raised, which re-introduces cleanup pressure.
- Demo-only embedded mesh genesis — set `PEAT_GENESIS_BASE64` at build time for any non-demo build.

## Test plan
- [x] `cargo build --release` clean
- [x] Encryption verified end-to-end: M5Stack joins WEARTAK mesh, watch shows it as a peer, sync docs decrypt successfully
- [x] STAND ⇄ PRONE flips correctly on device tilt (gravity-on-y → Standing, gravity-on-z → Prone), no false EMERGENCY on flips
- [x] 10-minute soak (`PERIPHERAL_ONLY=true`, `MULTIHOP_FORWARD=false`): 0 watchdog triggers, balanced 18/18 connect/disconnect, 107 decrypts, 108 periodic gossip rounds, display counter advancing throughout
- [x] Boot \`warn!\` fires when `PEAT_GENESIS_BASE64` is unset at build time
- [ ] **Carry-forward (cross-component / 48-node bench):**
  - [ ] Verify WearOS / ATAK plugin decoders treat `activity_u8 = 4` as unknown (fall through, no panic / mis-render). Optionally register `4 = Prone` in `peat-btle`'s health-document schema per ADR-012.
  - [ ] Dedicated bidirectional-path soak with `PERIPHERAL_ONLY = false` exercising the per-peer + global connect-backoffs before the demo.
  - [ ] Worst-case ack-latency soak with `MULTIHOP_FORWARD = true` on the 48-node bench before flipping the flag.
  - [ ] Re-validate stability with `MAX_CONNECTIONS` bumped back to 4 for the 48-node ceiling.
  - [ ] Investigate AXP2101 / MPU6886 i2c contention root cause (bus-recovery sequence or split bus) — the recovery measure here is the immediate mitigation, not the fix.