### PR TITLE
fix(m5stack): stop ~71 min freeze + IWDT trips, paint center on boot, retry IMU init

### DIFF
--- a/examples/m5stack-core2-peat/sdkconfig.defaults
+++ b/examples/m5stack-core2-peat/sdkconfig.defaults
@@ -57,5 +57,14 @@ CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096
 # WDT triggers don't reboot the device on a transient stall.
 CONFIG_ESP_TASK_WDT_TIMEOUT_S=60
 
+# Interrupt watchdog. Default 300 ms was tripping under sustained BLE
+# controller load (heavy peer RX combined with our 1 Hz health updates
+# and synchronous CCCD writes inside `gatt_disc_dsc_cb`), with the
+# backtrace landing inside the VHCI ISR (`vhci_recv_end`). Bumping to
+# 1000 ms absorbs that controller-stress window without disabling the
+# IWDT — a real ISR hang would still reboot us, just on a more
+# realistic threshold for NimBLE on ESP32.
+CONFIG_ESP_INT_WDT_TIMEOUT_MS=1000
+
 # Optimize for size
 CONFIG_COMPILER_OPTIMIZATION_SIZE=y

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -844,14 +844,20 @@ fn main() -> anyhow::Result<()> {
     )?;
     info!("I2C initialized");
 
-    // Initialize MPU6886 IMU for activity/fall detection
+    // Initialize MPU6886 IMU for activity/fall detection.
+    //
+    // `imu_ok` is mutable because boot-time init can fail transiently
+    // (I2C bus glitch, slow MPU6886 power-up). If that happens we'd be
+    // stuck with activity detection disabled forever, so the main loop
+    // periodically retries `imu::init` (see IMU_BOOT_RETRY_MS) until
+    // it succeeds.
     info!("Initializing IMU...");
-    let imu_ok = imu::init(&mut i2c);
+    let mut imu_ok = imu::init(&mut i2c);
     let mut imu_state = imu::ImuState::default();
     if imu_ok {
         info!("IMU initialized successfully");
     } else {
-        warn!("IMU initialization failed - activity detection disabled");
+        warn!("IMU initialization failed - activity detection disabled (will retry)");
     }
 
     // Initialize AXP (detect hardware version and enable LCD power/backlight)
@@ -1021,6 +1027,14 @@ fn main() -> anyhow::Result<()> {
     let mut imu_reinit_giveup_logged = false;
     const IMU_REINIT_GIVEUP_STREAK: u32 = 5;
 
+    // If boot-time `imu::init` failed, retry it from the main loop so a
+    // transient I2C/power glitch at startup doesn't permanently disable
+    // activity detection. Retry every 30 s — fast enough to recover
+    // before the operator notices a frozen STAND/PRONE, slow enough not
+    // to spam the bus.
+    let mut last_imu_boot_retry: u32 = 0;
+    const IMU_BOOT_RETRY_MS: u32 = 30_000;
+
     // Alert state
     let mut alert_active = false;
     let mut vibration_on = false;
@@ -1050,6 +1064,18 @@ fn main() -> anyhow::Result<()> {
         for node_id in nimble::take_disconnected_node_ids() {
             info!(">>> Peer disconnected: {:08X}", node_id);
             needs_redraw = true;
+        }
+
+        // If IMU init failed at boot, try again periodically. Without
+        // this, a transient I2C glitch at startup leaves activity
+        // detection permanently off — the badge displays the last
+        // known activity (often STAND) forever, which looks "frozen".
+        if !imu_ok && current_time.saturating_sub(last_imu_boot_retry) >= IMU_BOOT_RETRY_MS {
+            last_imu_boot_retry = current_time;
+            if imu::init(&mut i2c) {
+                info!("IMU: post-boot init retry succeeded — activity detection enabled");
+                imu_ok = true;
+            }
         }
 
         // Read IMU and detect activity/falls (every 100ms)

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -993,7 +993,18 @@ fn main() -> anyhow::Result<()> {
     // Draw static UI once, then update dynamic parts
     draw_static_ui(&mut display, node_id.as_u32());
     update_button_labels(&mut display, false);  // Initial state: ACK greyed out
-    let mut display_state = DisplayState::default();
+    // Seed `prev` with `alert_active = true` so the first `update_display`
+    // call sees a mode transition (true → false) and paints every zone
+    // — callsign, READY+activity badge, and peer list. Without this the
+    // default `prev` matches the initial `current` exactly (both
+    // alert_active=false, activity=0, no peers, no battery), the diff
+    // collapses every zone branch, and the center of the screen stays
+    // blank until something — typically an IMU-driven activity flip when
+    // the operator picks the badge up — finally changes a tracked field.
+    let mut display_state = DisplayState {
+        alert_active: true,
+        ..DisplayState::default()
+    };
     let acked = get_acked_peers_from_mesh(&mesh);
     display_state = update_display(&mut display, &mesh, false, battery_pct, "BtnC=EMERG  BtnA=ACK", &display_state, &acked, imu::Activity::Standing);
     print_status(&mesh, false, "BtnC=EMERG  BtnA=ACK");

--- a/examples/m5stack-core2-peat/src/main.rs
+++ b/examples/m5stack-core2-peat/src/main.rs
@@ -1048,7 +1048,20 @@ fn main() -> anyhow::Result<()> {
     loop {
         let button = read_button(&mut i2c);
         let connected = nimble::is_connected();
-        let current_time = unsafe { esp_idf_svc::sys::esp_timer_get_time() as u32 / 1000 };
+        // Divide the i64 µs counter as u64 *before* casting to u32 so the
+        // ms value doesn't wrap every ~71.6 min (which is what `as u32`
+        // before `/1000` did). With `as u64 / 1000 as u32`, ms wraps at
+        // ~49.7 days — past any plausible badge uptime — and all the
+        // `saturating_sub` time gates below stay correct.
+        //
+        // Symptom of the old form: after the first 71 min, `current_time`
+        // jumps backward to a small value while `last_imu_read` (and the
+        // other "last_*" timestamps) still hold the big pre-wrap number,
+        // so every gated path (IMU reads, periodic gossip, redraw,
+        // vibration toggle) silently stops firing — the badge looks
+        // frozen on its last classification while buttons (un-gated) keep
+        // working.
+        let current_time = (unsafe { esp_idf_svc::sys::esp_timer_get_time() as u64 } / 1000) as u32;
 
         // Check for connection state changes
         if nimble::take_connection_changed() {


### PR DESCRIPTION
## Summary

Four fixes for the M5Stack badge — all unmasked or amplified by the same root cause (the time-wrap bug in `current_time`). Soaked **2h 43min** on demo hardware with the full stack applied; zero freezes, zero IWDT trips.

### 1. `current_time` wrapped every 71.6 min — the actual freeze
`let current_time = esp_timer_get_time() as u32 / 1000` truncated the i64 microsecond counter to u32 *before* dividing, so `current_time` wrapped every 2³² µs ≈ 71.6 min of uptime. After the first wrap, `current_time` jumped backward to a small value while every `last_*` timestamp still held its big pre-wrap value, and `current_time.saturating_sub(last_*)` collapsed to 0 — every time-gated path (IMU reads, periodic gossip, redraw, vibration toggle) silently stopped firing.

Field symptom: display stuck on the last classification (typically `STAND`), mesh gossip silent, peer connection going stale, but buttons (un-gated) still responsive.

Fix: cast to u64 *before* the divide; the resulting ms count wraps at ~49.7 days. `now_ms()` already got this right.

### 2. Interrupt WDT trips in NimBLE VHCI ISR
With the wrap fixed, the periodic paths (health 1 Hz, gossip 0.2 Hz, IMU 10 Hz) all started firing again, and the BLE controller saw sustained load. The default 300 ms interrupt WDT started tripping. Decoded backtrace:

```
vhci_recv_end <- r_vhci_isr <- _xt_lowint1
  <- vhci_set_interrupt <- esp_vhci_host_send_packet
  <- ble_hs_hci_acl_tx <- ble_l2cap_tx <- ble_att_tx
  <- ble_gattc_write_flat
  <- m5stack_core2_peat::nimble::subscribe_to_notifications
  <- m5stack_core2_peat::nimble::gatt_disc_dsc_cb
```

An inbound FIND_INFO response landed in our descriptor-discovery callback, the callback synchronously issued a CCCD write, that pushed ACL TX through VHCI, and the controller ISR ran past the IWDT threshold. Heavy decrypt-fail RX from a peer with a stale mesh key was likely the amplifying load.

Fix: bump `CONFIG_ESP_INT_WDT_TIMEOUT_MS` from 300 to 1000. The deeper fix — deferring the CCCD subscribe out of `gatt_disc_dsc_cb` so we don't nest ACL TX inside an RX-handler callback — is left as a follow-up.

### 3. Center zone blank on cold boot
`update_display` is fully zoned. On boot, `display_state = DisplayState::default()` matched the first computed `current` exactly, every zone diff short-circuited, and the center stayed black until an IMU-driven activity flip changed a tracked field.

Fix: seed `prev.alert_active = true` so the first call sees a `mode_changed` transition (true → false) and paints every zone — callsign, READY + activity badge, peer list.

### 4. Retry IMU init from main loop when boot init fails
Separate, rarer freeze mode: `imu::init` failing at boot (transient I2C glitch, slow MPU6886 power-up) left `imu_ok = false` for the lifetime of the boot.

Fix: from the main loop, retry `imu::init` every 30 s while `imu_ok` is `false`. On success, flip `imu_ok = true` and let the existing read/recovery path take over.

## Test plan
- [x] Built and flashed; soaked 2h 43min on demo hardware. No `Guru Meditation`, no `rst:`, no `panic`. IMU reads at 10 Hz, mesh doc version progressing as expected.
- [x] Center zone paints on cold reset without needing to flip the device.
- [ ] Continue overnight soak ahead of demo to confirm no late-onset issues (heap, accumulated automerge history) over 12+ hour windows.