### PR TITLE
chore(release): peat 0.9.0-rc.3 — request_sync android_log observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Sub-crates that stay internal (`peat-transport`, `peat-persistence`, `peat-disco
 
 ## [Unreleased]
 
+## [0.9.0-rc.3] - 2026-05-11
+
+> **Crate-level versions in this release**: workspace bumps `0.9.0-rc.2` → `0.9.0-rc.3`. `peat-ffi` bumps independently `0.2.0` → `0.2.1` (patch: non-breaking observability addition; no ABI surface change).
+
+### Added
+
+- `peat-ffi` `PeatNode::request_sync` now emits Android `__android_log_write` events at INFO covering every invocation: a starting line with the connected-peer count, a per-peer push success / failure line, and a complete line. Closes the observability gap surfaced by the 2026-05-10 bench session — peat-mesh's internal `sync_document_with_peer` failures log via `tracing::warn!` which doesn't reach logcat (no tracing-subscriber installed on Android), so previously `request_sync` could return `Ok(())` while every per-doc push silently failed. The FFI-boundary log makes those silent failures visible at the layer where `android_log` is wired up. Logcat tag: `PeatFFI`, message pattern: `request_sync: starting with N connected peer(s)` / `request_sync: pushed to peer <16-hex-prefix>` / `request_sync: FAILED for peer <16-hex-prefix>: <err>` / `request_sync: complete (N peer(s) attempted)`.
+
 ## [0.9.0-rc.2] - 2026-05-10
 
 > **Crate-level versions in this release**:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3742,7 +3742,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peat"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 
 [[package]]
 name = "peat-btle"
@@ -3782,7 +3782,7 @@ dependencies = [
 
 [[package]]
 name = "peat-discovery"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "peat-ffi"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3871,7 +3871,7 @@ dependencies = [
 
 [[package]]
 name = "peat-persistence"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "peat-protocol"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "peat-schema"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "peat-tak-bridge"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "peat-transport"
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ peat-mesh = { git = "https://github.com/defenseunicorns/peat-mesh", rev = "9a92e
 peat-btle = { git = "https://github.com/defenseunicorns/peat-btle", rev = "d96c4da577887a75353e6e0abd4865ebd9b9cea0" }
 
 [workspace.package]
-version = "0.9.0-rc.2"
+version = "0.9.0-rc.3"
 edition = "2021"
 authors = ["Kit Plummer <kitplummer@defenseunicorns.com>"]
 license = "Apache-2.0"

--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -9,7 +9,7 @@ name = "peat-ffi"
 # so the wire-versioned ABI surface can rev separately from the
 # workspace's CHANGELOG-tracked protocol cadence; see CHANGELOG
 # entry under [0.9.0-rc.2] for the consumer migration contract.
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "FFI bindings for Peat protocol (Kotlin/Swift via UniFFI)"
 license = "Apache-2.0"

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -821,15 +821,49 @@ impl PeatNode {
     pub fn request_sync(&self) -> Result<(), PeatError> {
         if let Some(coordinator) = self.storage_backend.sync_coordinator() {
             let peers = self.iroh_transport.connected_peers();
+            let peer_count = peers.len();
+            // Logcat-visible signal of every request_sync invocation:
+            // peer count + each push's success/failure. peat-protocol's
+            // internal `tracing::info!` doesn't reach logcat because no
+            // tracing-subscriber is installed on Android, so the only
+            // way to observe whether `sync_all_documents_with_peer`
+            // actually ran is to surface it here at the FFI boundary
+            // where `android_log` works.
+            #[cfg(target_os = "android")]
+            android_log(&format!(
+                "request_sync: starting with {} connected peer(s)",
+                peer_count
+            ));
             let coord = Arc::clone(coordinator);
             self.runtime.block_on(async {
                 for peer_id in peers {
-                    if let Err(e) = coord.sync_all_documents_with_peer(peer_id).await {
-                        #[cfg(target_os = "android")]
-                        android_log(&format!("request_sync failed for peer: {}", e));
+                    let peer_hex = hex::encode(peer_id.as_bytes());
+                    match coord.sync_all_documents_with_peer(peer_id).await {
+                        Ok(()) => {
+                            #[cfg(target_os = "android")]
+                            android_log(&format!(
+                                "request_sync: pushed to peer {}",
+                                &peer_hex[..16]
+                            ));
+                            let _ = peer_hex;
+                        }
+                        Err(e) => {
+                            #[cfg(target_os = "android")]
+                            android_log(&format!(
+                                "request_sync: FAILED for peer {}: {}",
+                                &peer_hex[..16],
+                                e
+                            ));
+                            let _ = (peer_hex, e);
+                        }
                     }
                 }
             });
+            #[cfg(target_os = "android")]
+            android_log(&format!(
+                "request_sync: complete ({} peer(s) attempted)",
+                peer_count
+            ));
         }
         Ok(())
     }

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -837,24 +837,27 @@ impl PeatNode {
             let coord = Arc::clone(coordinator);
             self.runtime.block_on(async {
                 for peer_id in peers {
-                    let peer_hex = hex::encode(peer_id.as_bytes());
                     match coord.sync_all_documents_with_peer(peer_id).await {
                         Ok(()) => {
                             #[cfg(target_os = "android")]
-                            android_log(&format!(
-                                "request_sync: pushed to peer {}",
-                                &peer_hex[..16]
-                            ));
-                            let _ = peer_hex;
+                            {
+                                let peer_hex = hex::encode(peer_id.as_bytes());
+                                android_log(&format!(
+                                    "request_sync: pushed to peer {}",
+                                    &peer_hex[..16]
+                                ));
+                            }
                         }
-                        Err(e) => {
+                        Err(_e) => {
                             #[cfg(target_os = "android")]
-                            android_log(&format!(
-                                "request_sync: FAILED for peer {}: {}",
-                                &peer_hex[..16],
-                                e
-                            ));
-                            let _ = (peer_hex, e);
+                            {
+                                let peer_hex = hex::encode(peer_id.as_bytes());
+                                android_log(&format!(
+                                    "request_sync: FAILED for peer {}: {}",
+                                    &peer_hex[..16],
+                                    _e
+                                ));
+                            }
                         }
                     }
                 }

--- a/peat-protocol/Cargo.toml
+++ b/peat-protocol/Cargo.toml
@@ -23,7 +23,7 @@ categories = ["network-programming"]
 [dependencies]
 # Peat facade: peat-protocol re-exports peat-schema and peat-mesh so
 # downstream consumers can depend on peat-protocol alone.
-peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.2" }
+peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.3" }
 peat-mesh = { workspace = true }
 
 tokio = { workspace = true }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -67,8 +67,24 @@ criteria = "safe-to-deploy"
 version = "0.9.0-rc.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.peat-schema]]
+version = "0.9.0-rc.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.peat-schema]]
+version = "0.9.0-rc.3"
+criteria = "safe-to-deploy"
+
 [[exemptions.peat-protocol]]
 version = "0.9.0-rc.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.peat-protocol]]
+version = "0.9.0-rc.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.peat-protocol]]
+version = "0.9.0-rc.3"
 criteria = "safe-to-deploy"
 
 # ADR-059 Amendment 4 Slice 4.d interim git-rev consumption.


### PR DESCRIPTION
## Summary

Workspace `0.9.0-rc.2` → `0.9.0-rc.3`. `peat-ffi` `0.2.0` → `0.2.1` (patch — non-breaking observability, no ABI surface change).

## Why a new RC the morning after rc.2 landed

The 2026-05-10 bench session merged rc.2 + the plugin companion (#26) and confirmed the JNI rename rolled cleanly. Mid-bench debugging then uncovered a real cross-mesh sync gap: tablet publishes a marker, `request_sync` fires every 30s and reports success, but the marker doesn't propagate to phone peers despite both sides being iroh-paired.

Root cause is hidden inside peat-mesh's `sync_all_documents_with_peer` → per-doc `sync_document_with_peer` loop. Per-doc failures log via `tracing::warn!`, which is **invisible on Android** — no `tracing-subscriber` is installed on the FFI consumer, so `request_sync` can return `Ok(())` while every per-doc push silently fails.

This PR adds `android_log` calls at the FFI boundary (`PeatNode::request_sync`) so we can SEE the failure point on the next bench cycle.

## Changes

- `peat-ffi/src/lib.rs` `PeatNode::request_sync` — adds three `android_log` event lines: starting (peer count), per-peer success/failure (16-hex-prefix peer ID), complete.
- Workspace + `peat-ffi` + `peat-protocol` intra-workspace `peat-schema` pin bumped to rc.3 / 0.2.1.
- `CHANGELOG.md` new `[0.9.0-rc.3] - 2026-05-11` section.

## Wire shape (logcat tag `PeatFFI`)

```
request_sync: starting with 1 connected peer(s)
request_sync: pushed to peer 61fe5e79654f20ba
request_sync: complete (1 peer(s) attempted)
```

or on per-peer failure:

```
request_sync: starting with 2 connected peer(s)
request_sync: FAILED for peer 61fe5e79654f20ba: <error>
request_sync: pushed to peer e648641b754f0519
request_sync: complete (2 peer(s) attempted)
```

## Test plan

- [x] `cargo check -p peat-ffi --features bluetooth` — green
- [x] Locally validated against tablet + phone1 — the new lines appear in logcat every 30s
- [ ] CI green on the PR
- [ ] After merge: tag `v0.9.0-rc.3`, rebuild plugin `.so`, deploy to 3-device bench, capture per-peer `request_sync:` output and pinpoint where the silent sync failure happens

## Follow-up (not in scope)

The actual sync gap is still hidden inside peat-mesh's `sync_document_with_peer` — invisible from this PR's vantage point. Once rc.3 is on the bench and we can see whether `pushed to peer` or `FAILED for peer` fires for the markers collection, we'll know whether the fix lives in peat-mesh (push logic) or peat-protocol (receive logic). This PR is the diagnostic that unblocks that fix.