### PR TITLE
fix(peat-protocol): mDNS advertise the actual bound IP, not a route heuristic (#894)

### DIFF
--- a/peat-protocol/src/discovery/peer.rs
+++ b/peat-protocol/src/discovery/peer.rs
@@ -182,18 +182,6 @@ impl MdnsDiscovery {
         })
     }
 
-    /// Get local IP address for mDNS advertisement
-    fn get_local_ip() -> anyhow::Result<String> {
-        use std::net::UdpSocket;
-
-        // Connect to a public DNS server to determine our local interface IP
-        // This doesn't actually send any data, just determines routing
-        let socket = UdpSocket::bind("0.0.0.0:0")?;
-        socket.connect("8.8.8.8:80")?;
-        let addr = socket.local_addr()?;
-        Ok(addr.ip().to_string())
-    }
-
     /// Stop mDNS discovery and unregister service
     ///
     /// This gracefully shuts down the mDNS daemon, unregistering the service
@@ -222,34 +210,49 @@ impl DiscoveryStrategy for MdnsDiscovery {
         let endpoint_id = self.endpoint.id();
         let node_id_hex = hex::encode(endpoint_id.as_bytes());
 
-        // Publish the actual bound UDP port. Consumers reconstruct a
+        // Both the advertised IP and the port are drawn from the actual
+        // Iroh-bound socket, so they always agree. Consumers reconstruct a
         // SocketAddr via `format!("{ip}:{port}", info.get_port())` and feed it
-        // to `transport.connect_peer`, which dials by IP:port — so port 0
-        // produces `<ip>:0`, and quinn's sendmsg returns EINVAL.
-        let port = self
+        // to `transport.connect_peer`, which dials by IP:port — so any
+        // mismatch between advertised tuple and listening tuple produces an
+        // un-routable dial (Issue #889 was the port=0 form of this; Issue
+        // #894 was the IP form where the 8.8.8.8 route heuristic published a
+        // LAN IP even when the QUIC listener was bound to 127.0.0.1).
+        //
+        // When the endpoint reports multiple IP transports (the
+        // `--bind 0.0.0.0` case on a multi-interface host), prefer a
+        // non-loopback address — that's the one remote peers can reach.
+        // Fall back to whatever is first if only loopback is bound, which
+        // is exactly what `--bind 127.0.0.1:PORT` looks like.
+        let ip_socks: Vec<std::net::SocketAddr> = self
             .endpoint
             .addr()
             .addrs
             .iter()
-            .find_map(|a| match a {
-                TransportAddr::Ip(sock) => Some(sock.port()),
+            .filter_map(|a| match a {
+                TransportAddr::Ip(sock) => Some(*sock),
                 _ => None,
             })
+            .collect();
+        let bound = ip_socks
+            .iter()
+            .find(|s| !s.ip().is_loopback())
+            .or_else(|| ip_socks.first())
+            .copied()
             .ok_or_else(|| {
                 anyhow::anyhow!(
                     "mDNS advertise: endpoint has no bound IP socket; cannot publish a usable record"
                 )
             })?;
+        let local_ip = bound.ip().to_string();
+        let port = bound.port();
 
         // Create TXT properties
         let mut properties = StdHashMap::new();
         properties.insert("node_id".to_string(), node_id_hex.clone());
         properties.insert("version".to_string(), "1".to_string());
 
-        // Get local IP address for mDNS advertisement
-        let local_ip = Self::get_local_ip().unwrap_or_else(|_| "127.0.0.1".to_string());
-
-        tracing::debug!("mDNS: Using local IP address: {}", local_ip);
+        tracing::debug!("mDNS: Advertising bound socket {bound}");
 
         // Create service info
         // ServiceInfo::new(service_type, instance_name, host_name, host_ipv4, port, properties)

--- a/peat-protocol/tests/peer_discovery_e2e.rs
+++ b/peat-protocol/tests/peer_discovery_e2e.rs
@@ -580,6 +580,25 @@ async fn test_mdns_zero_config_discovery() {
     // transport.connect_peer feeds to quinn → sendmsg EINVAL → no connection
     // ever forms. The original mDNS code hard-coded port 0 under the (wrong)
     // assumption that Iroh dials by endpoint_id alone.
+    //
+    // Pin peat#894: advertised IP must be non-unspecified (not 0.0.0.0 / ::)
+    // and must come from the Iroh-bound socket, not the 8.8.8.8 route
+    // heuristic. The pre-fix code published whichever interface IP would
+    // route to 8.8.8.8 regardless of the actual bind — so `--bind 127.0.0.1`
+    // advertised the LAN IP and remote peers dialed an IP the QUIC listener
+    // wasn't bound to. With the fix, the advertised IP appears in the
+    // node's own endpoint.addr().addrs (since both nodes here are on the
+    // same host, A's bound IPs are the universe of valid advertised IPs).
+    let a_bound_ips: std::collections::HashSet<std::net::IpAddr> = transport_a
+        .endpoint()
+        .addr()
+        .addrs
+        .iter()
+        .filter_map(|a| match a {
+            iroh::TransportAddr::Ip(s) => Some(s.ip()),
+            _ => None,
+        })
+        .collect();
     for peer in peers_a.iter().chain(peers_b.iter()) {
         for addr in &peer.addresses {
             let sock: std::net::SocketAddr = addr.parse().unwrap_or_else(|e| {
@@ -589,6 +608,18 @@ async fn test_mdns_zero_config_discovery() {
                 sock.port() != 0,
                 "mDNS-advertised port must be non-zero, got {addr:?} for peer {:?}",
                 peer.name
+            );
+            assert!(
+                !sock.ip().is_unspecified(),
+                "mDNS-advertised IP must not be unspecified (0.0.0.0/::), got {addr:?} for peer {:?}",
+                peer.name
+            );
+            assert!(
+                a_bound_ips.contains(&sock.ip()),
+                "mDNS-advertised IP {} is not in this host's bound set {:?} — \
+                 fix may have regressed to a route-heuristic IP that doesn't match the actual bind",
+                sock.ip(),
+                a_bound_ips
             );
         }
     }


### PR DESCRIPTION
Follow-up to #889 / PR #893. With the `port = 0` bug fixed, mDNS-discovered peers connected when nodes bound to `0.0.0.0` — but `--bind 127.0.0.1` still failed because the mDNS advertised IP was picked by the 8.8.8.8 outbound-route trick instead of the actual bind.

## What changed

- Both the advertised IP and the port now come from a single source — the first `TransportAddr::Ip` in `endpoint.addr().addrs` — so they always agree with the bind.
- When the endpoint reports multiple IP transports (the `--bind 0.0.0.0` case on a multi-interface host), prefer a non-loopback address; fall back to loopback when that's all that's bound (matches `--bind 127.0.0.1:PORT`).
- `get_local_ip()` (the 8.8.8.8 socket trick) is removed entirely — no remaining call site.

## What's tested

`tests/peer_discovery_e2e.rs::test_mdns_zero_config_discovery` grows two new assertions per discovered address, both per the team policy that bug fixes ship with reproducing tests:

- The advertised IP is not unspecified (`0.0.0.0` / `::`).
- The advertised IP appears in the discoverer's own `endpoint.addr().addrs` set — i.e. it's an IP this host is actually bound to, not a route-heuristic guess. This is the specific assertion that would have failed against the pre-fix code whenever the default-route IP differed from the bound IP.

Both assertions would have failed in the field-report environment (laptop with the 8.8.8.8 route on a different interface from the bound socket).

## Test plan

- [x] `cargo test -p peat-protocol --lib discovery::peer::` — 3/3 pass
- [x] `cargo test -p peat-protocol --test peer_discovery_e2e test_mdns_zero_config_discovery` — passes with the new IP assertions
- [x] `cargo clippy --workspace --release --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean (enforced by pre-commit hook)
- [ ] Cross-build + verify on rpi-ci with `--bind 127.0.0.1:39001 --mdns` (the literal QUICKSTART Scenario 3) — verification will follow in a comment once the Pi run completes.

Closes #894.