### PR TITLE
ci(qa-review): wrap claude-p invocation in 3-attempt retry with idempotency guard

### DIFF
--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -44,6 +44,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -uo pipefail
+
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          SHORT_SHA="${{ steps.check.outputs.short_sha }}"
+
+          MAX_ATTEMPTS=3
+          rc=0
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+          echo "::group::QA Review attempt ${attempt}/${MAX_ATTEMPTS}"
+
+          # Idempotency: if a prior attempt already posted the review for this SHA,
+          # treat as success. `gh pr review --comment` posts to the PR's reviews
+          # endpoint, so check --json reviews here. The "Check for existing review"
+          # step at job start uses --json comments for backwards-compat with an
+          # older posting path — kept separate from this in-step idempotency check.
+          if gh pr view "$PR_NUMBER" --json reviews \
+               | jq -e --arg tag "Peat QA Review (SHA: ${SHORT_SHA})" \
+                    '.reviews[] | select(.body | contains($tag))' >/dev/null 2>&1; then
+            echo "Review for SHA ${SHORT_SHA} already posted; treating as success."
+            echo "::endgroup::"
+            exit 0
+          fi
+
           cat <<'PROMPT' | claude -p --allowedTools 'Bash(gh pr diff *),Bash(gh pr view *),Bash(gh pr review *)'
           You are the QA review agent for the Peat Protocol ecosystem.
 
@@ -93,3 +117,19 @@ jobs:
              If there are no findings under any tag, post a single line: "No findings."
              NEVER approve or request-changes — comment only.
           PROMPT
+          rc=$?
+
+          echo "::endgroup::"
+
+          if [ "$rc" -eq 0 ]; then
+            exit 0
+          fi
+
+          if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            echo "Attempt ${attempt} failed (claude -p exit ${rc}); sleeping 15s before retry..."
+            sleep 15
+          fi
+          done
+
+          echo "All ${MAX_ATTEMPTS} QA Review attempts failed (likely transient API errors)."
+          exit 1


### PR DESCRIPTION
## Summary

Mirror of peat-mesh#163. Surfaced 2026-05-25 on peat-mesh PR #162: a transient `ECONNRESET` from the claude CLI's outbound call to api.anthropic.com killed the QA Review job mid-execution. The workspace repo's qa-review.yml is structurally simpler than the per-repo mirrors (single PROMPT heredoc, no incremental-vs-fresh branching), but uses the same `claude -p` CLI on the same self-hosted runner — so the same failure mode applies.

Wraps the single `claude -p` invocation in a `for attempt in 1..3` loop with 15 s sleep between attempts. Prompt heredoc body unchanged.

## Idempotency note

Each iteration re-runs `gh pr view --json reviews | jq | contains("Peat QA Review (SHA: ${SHORT_SHA})")`. This intentionally uses `--json reviews` while the existing `Check for existing review` step at job start uses `--json comments`:

- `gh pr review --comment` (the actual posting command) writes to the PR's **reviews** endpoint.
- The pre-existing `Check for existing review` step uses `--json comments`, which predates the review-based posting path. Fixing that is out of scope for this PR.
- The new in-step guard uses `--json reviews` because that's where the review actually lives.

Both checks coexist without conflict; this PR doesn't alter the pre-existing one.

## Shell pragmatics

- `set -uo pipefail` (not `-e`) so explicit `rc=$?` captures the claude exit code without aborting.
- 3 attempts × ~10–12 min per attempt fits comfortably under `timeout-minutes: 30`.

## Test plan

- [x] YAML parses cleanly
- [x] `bash -n` against the extracted run block — syntax clean
- [ ] CI green
- [ ] Next ECONNRESET on this runner is absorbed silently

## Related

- peat-mesh#163 (original)
- peat-node#95
- peat-btle#64