### PR TITLE
ci(qa-review): instruct review agent to call gh pr review exactly once

### DIFF
--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -92,4 +92,7 @@ jobs:
                [ARCH]     — architectural concern requiring human design review; do NOT propose a fix, escalate
              If there are no findings under any tag, post a single line: "No findings."
              NEVER approve or request-changes — comment only.
+             CRITICAL: call `gh pr review` EXACTLY ONCE with the complete, final review body.
+             Do NOT make test, probe, or draft calls to `gh pr review` before posting.
+             Compose the full review body in memory first, then post it in a single call.
           PROMPT


### PR DESCRIPTION
## Summary

The QA review agent has occasionally posted multiple review comments on the same PR — one or more "draft" or "probe" calls to `gh pr review` followed by the final intended review. This wastes runner time and pollutes the PR with intermediate posts that the SHA-based idempotency check doesn't catch (because each draft uses a slightly different body until the final one).

Adds three lines to the prompt's "Post findings" section requiring the agent to compose the full review body in memory first and call `gh pr review` exactly once with the complete, final body:

```
CRITICAL: call `gh pr review` EXACTLY ONCE with the complete, final review body.
Do NOT make test, probe, or draft calls to `gh pr review` before posting.
Compose the full review body in memory first, then post it in a single call.
```

No code change — purely a prompt-level constraint. The workflow file is otherwise unchanged.

## Test plan

- [x] YAML parses cleanly
- [ ] Next QA Review run posts exactly one review comment
- [ ] CI green

## Related

- peat#927 — retry wrapper around the same `claude -p` invocation (independent change; this one fits cleanly underneath or alongside that)