### PR TITLE
fix(qa-review): set +e so retry loop runs after claude-p failure

### DIFF
--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -45,6 +45,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -uo pipefail
+          set +e   # GH Actions defaults to bash -e; -e would abort before rc=$? captures the claude exit code
 
           PR_NUMBER="${{ github.event.pull_request.number }}"
           SHORT_SHA="${{ steps.check.outputs.short_sha }}"


### PR DESCRIPTION
## Summary

The retry wrapper that just merged doesn't actually retry. GitHub Actions invokes `bash -e {0}` by default, and my `set -uo pipefail` at the top of the run block ADDS `-u` and `-o pipefail` without clearing `-e`. So when `claude -p` exits non-zero on ECONNRESET, the script aborts BEFORE reaching `rc=$?` and the for-loop never iterates.

Confirmed on the 2026-05-25 19:26–19:32Z run on peat-mesh PR #166 (run [26416164097](https://github.com/defenseunicorns/peat-mesh/actions/runs/26416164097)): attempt 1/3 started, ECONNRESET at 19:32:14, immediate exit code 1 with no "Attempt 1 failed; sleeping 15s before retry" message. The retry never executed.

## Fix

One-line addition: `set +e` right after `set -uo pipefail` to actively disable the inherited `-e` so the explicit `rc=$?` capture and retry path runs as intended.

```diff
            set -uo pipefail
+           set +e   # GH Actions defaults to bash -e; -e would abort before rc=$? captures the claude exit code
            MAX_ATTEMPTS=3
```

Rest of the retry wrapper is unchanged.

## Test plan

- [x] YAML parses cleanly
- [ ] CI green
- [ ] Next ECONNRESET on the runner triggers a visible "Attempt N failed; sleeping 15s" message and progresses to the retry attempt