### PR TITLE
fix(peat-ffi): gate dart_ffi BLE bindings so the default build links

### DIFF
--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -38,7 +38,10 @@ name = "peat-ffi"
 # that broke strict (macOS/iOS) cdylib links (and `cargo publish`'s
 # default-feature verify). Gate the dart_ffi entries with the matching cfg.
 # Additive/no ABI change for the full `sync,bluetooth,lite-bridge` build that
-# Android/iOS ship. See peat#986.
+# Android/iOS ship. See peat#986. Also moves `ingest_inbound_lite_frame` into
+# its own `lite-bridge`-gated `#[uniffi::export]` block so `sync,bluetooth`
+# without `lite-bridge` compiles (was E0599: the export macro emitted a call to
+# the per-method-cfg'd-out fn). peat-ffi now builds in every feature combo.
 version = "0.2.6"
 edition = "2021"
 description = "FFI bindings for Peat protocol (Kotlin/Swift via UniFFI)"

--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -28,7 +28,18 @@ name = "peat-ffi"
 #     test-side Err-branch coverage on getDocumentJni.
 # All additive; no JNI ABI break. peat-atak-plugin and peat-mesh
 # consumers continue to link against 0.2.3+ symbols unchanged.
-version = "0.2.5"
+#
+# 0.2.6 (was 0.2.5): fix the default-feature (`sync`-only) cdylib link.
+# src/dart_ffi.rs unconditionally declared/defined the FFI-buffer bindings
+# for the bluetooth-gated PeatNode methods (poll/start/stop_outbound_frames,
+# ingest_inbound_frame, ingest_inbound_lite_frame, publish_document), whose
+# `#[uniffi::export]` definitions are cfg-gated. Under `sync`-only those
+# definitions vanish but the dart_ffi references remained → dangling symbols
+# that broke strict (macOS/iOS) cdylib links (and `cargo publish`'s
+# default-feature verify). Gate the dart_ffi entries with the matching cfg.
+# Additive/no ABI change for the full `sync,bluetooth,lite-bridge` build that
+# Android/iOS ship. See peat#986.
+version = "0.2.6"
 edition = "2021"
 description = "FFI bindings for Peat protocol (Kotlin/Swift via UniFFI)"
 license = "Apache-2.0"

--- a/peat-ffi/src/dart_ffi.rs
+++ b/peat-ffi/src/dart_ffi.rs
@@ -203,18 +203,26 @@ extern "C" {
         s: *mut CallStatus,
     ) -> RustBuf;
     fn uniffi_peat_ffi_fn_method_peatnode_get_tracks(h: u64, s: *mut CallStatus) -> RustBuf;
+    // BLE-bridge methods: gated to match the `#[uniffi::export]` definitions
+    // (cfg(all(sync, bluetooth)), + lite-bridge for the lite variant). Without
+    // these gates, the declarations reference scaffolding fns that don't exist
+    // under the default `sync`-only feature set → dangling symbols on strict
+    // (macOS/iOS) cdylib links. See peat#986.
+    #[cfg(all(feature = "sync", feature = "bluetooth"))]
     fn uniffi_peat_ffi_fn_method_peatnode_ingest_inbound_frame(
         h: u64,
         col: RustBuf,
         data: RustBuf,
         s: *mut CallStatus,
     ) -> RustBuf;
+    #[cfg(all(feature = "sync", feature = "bluetooth", feature = "lite-bridge"))]
     fn uniffi_peat_ffi_fn_method_peatnode_ingest_inbound_lite_frame(
         h: u64,
         col: RustBuf,
         data: RustBuf,
         s: *mut CallStatus,
     ) -> RustBuf;
+    #[cfg(all(feature = "sync", feature = "bluetooth"))]
     fn uniffi_peat_ffi_fn_method_peatnode_publish_document(
         h: u64,
         col: RustBuf,
@@ -233,6 +241,7 @@ extern "C" {
         id: RustBuf,
         s: *mut CallStatus,
     ) -> RustBuf;
+    #[cfg(all(feature = "sync", feature = "bluetooth"))]
     fn uniffi_peat_ffi_fn_method_peatnode_poll_outbound_frames(
         h: u64,
         s: *mut CallStatus,
@@ -250,8 +259,10 @@ extern "C" {
     fn uniffi_peat_ffi_fn_method_peatnode_put_node(h: u64, node: RustBuf, s: *mut CallStatus);
     fn uniffi_peat_ffi_fn_method_peatnode_put_track(h: u64, t: RustBuf, s: *mut CallStatus);
     fn uniffi_peat_ffi_fn_method_peatnode_request_sync(h: u64, s: *mut CallStatus);
+    #[cfg(all(feature = "sync", feature = "bluetooth"))]
     fn uniffi_peat_ffi_fn_method_peatnode_start_outbound_frames(h: u64, s: *mut CallStatus);
     fn uniffi_peat_ffi_fn_method_peatnode_start_sync(h: u64, s: *mut CallStatus);
+    #[cfg(all(feature = "sync", feature = "bluetooth"))]
     fn uniffi_peat_ffi_fn_method_peatnode_stop_outbound_frames(h: u64, s: *mut CallStatus);
     fn uniffi_peat_ffi_fn_method_peatnode_stop_sync(h: u64, s: *mut CallStatus);
     fn uniffi_peat_ffi_fn_method_peatnode_subscribe(h: u64, cb: u64, s: *mut CallStatus) -> u64;
@@ -648,6 +659,7 @@ pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_get_tracks
     ret_rbuf(r, v, &s);
 }
 
+#[cfg(all(feature = "sync", feature = "bluetooth"))]
 #[no_mangle]
 pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_ingest_inbound_frame(
     a: *const Elem,
@@ -663,6 +675,7 @@ pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_ingest_inb
     ret_rbuf(r, v, &s);
 }
 
+#[cfg(all(feature = "sync", feature = "bluetooth", feature = "lite-bridge"))]
 #[no_mangle]
 pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_ingest_inbound_lite_frame(
     a: *const Elem,
@@ -678,6 +691,7 @@ pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_ingest_inb
     ret_rbuf(r, v, &s);
 }
 
+#[cfg(all(feature = "sync", feature = "bluetooth"))]
 #[no_mangle]
 pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_publish_document(
     a: *const Elem,
@@ -738,6 +752,7 @@ pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_peer_trans
     ret_rbuf(r, v, &s);
 }
 
+#[cfg(all(feature = "sync", feature = "bluetooth"))]
 #[no_mangle]
 pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_poll_outbound_frames(
     a: *const Elem,
@@ -824,6 +839,7 @@ pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_request_sy
     ret_void(r, &s);
 }
 
+#[cfg(all(feature = "sync", feature = "bluetooth"))]
 #[no_mangle]
 pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_start_outbound_frames(
     a: *const Elem,
@@ -844,6 +860,7 @@ pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_start_sync
     ret_void(r, &s);
 }
 
+#[cfg(all(feature = "sync", feature = "bluetooth"))]
 #[no_mangle]
 pub unsafe extern "C" fn uniffi_ffibuffer_peat_ffi_fn_method_peatnode_stop_outbound_frames(
     a: *const Elem,

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -9947,6 +9947,34 @@ impl PeatNode {
         Ok(Some(id.to_string()))
     }
 
+    /// Publish a JSON document through the **node layer** — the same path the
+    /// Android `publishDocumentJni` uses — so the write reaches the ADR-059
+    /// fan-out and is emitted over the bridged transports (BLE/Wi-Fi). The
+    /// `id` field in the JSON, when present, becomes the document id
+    /// (returned).
+    ///
+    /// Use this instead of `put_document` when the write must propagate to
+    /// peers via the bridged radios: `put_document`/`put_node` write straight
+    /// to `storage_backend`, which the fan-out does not observe, so those never
+    /// emit a BLE frame. Needed by the iOS bridge (which drives the poll API
+    /// from Dart and has no JNI `publishDocumentJni`).
+    #[cfg(feature = "sync")]
+    pub fn publish_document(&self, collection: String, json: String) -> Result<String, PeatError> {
+        self.runtime
+            .block_on(publish_document_into_node(&self.node, &collection, &json))
+            .map_err(|e| PeatError::SyncError { msg: e.to_string() })
+    }
+}
+
+// `ingest_inbound_lite_frame` lives in its OWN cfg-gated `#[uniffi::export]`
+// block (not the `all(sync, bluetooth)` block above) so that under
+// `sync,bluetooth` WITHOUT `lite-bridge` the whole export — including the
+// generated scaffolding's call to the method — is stripped before the macro
+// runs. With a per-method `#[cfg(lite-bridge)]` inside the broader block, the
+// export macro still emitted a call to the cfg'd-out method (E0599). See peat#986.
+#[cfg(all(feature = "sync", feature = "bluetooth", feature = "lite-bridge"))]
+#[uniffi::export]
+impl PeatNode {
     /// Ingest an inbound BLE frame that arrived on the universal-Document
     /// (peat-lite / `ble-lite`) codec, as opposed to the typed 0xB6 path in
     /// [`ingest_inbound_frame`]. Decodes via the `CollectionGatedLiteBridge`
@@ -9954,7 +9982,6 @@ impl PeatNode {
     /// to the other transports without looping back to BLE. Used for raw
     /// collections (e.g. the `demo` counter) that the typed translator
     /// declines.
-    #[cfg(all(feature = "sync", feature = "bluetooth", feature = "lite-bridge"))]
     pub fn ingest_inbound_lite_frame(
         &self,
         collection: String,
@@ -9982,24 +10009,6 @@ impl PeatNode {
         // Multi-hop: relay this lite frame to our other BLE peers (deduped).
         self.relay_ble_frame(BLE_LITE_BRIDGE, &collection_name, &envelope_bytes);
         Ok(Some(id.to_string()))
-    }
-
-    /// Publish a JSON document through the **node layer** — the same path the
-    /// Android `publishDocumentJni` uses — so the write reaches the ADR-059
-    /// fan-out and is emitted over the bridged transports (BLE/Wi-Fi). The
-    /// `id` field in the JSON, when present, becomes the document id
-    /// (returned).
-    ///
-    /// Use this instead of `put_document` when the write must propagate to
-    /// peers via the bridged radios: `put_document`/`put_node` write straight
-    /// to `storage_backend`, which the fan-out does not observe, so those never
-    /// emit a BLE frame. Needed by the iOS bridge (which drives the poll API
-    /// from Dart and has no JNI `publishDocumentJni`).
-    #[cfg(feature = "sync")]
-    pub fn publish_document(&self, collection: String, json: String) -> Result<String, PeatError> {
-        self.runtime
-            .block_on(publish_document_into_node(&self.node, &collection, &json))
-            .map_err(|e| PeatError::SyncError { msg: e.to_string() })
     }
 }
 


### PR DESCRIPTION
Closes #986.

## Root cause(s)
peat-ffi failed to build/link in some feature combinations:

1. **Default `sync`-only cdylib link** (the #986 symptom). `src/dart_ffi.rs` (the
   Flutter/Dart FFI-buffer shim) **unconditionally** declared the extern
   scaffolding fns and defined the `uniffi_ffibuffer_*` wrappers for the
   bluetooth-gated `PeatNode` methods (`poll/start/stop_outbound_frames`,
   `ingest_inbound_frame`, `ingest_inbound_lite_frame`, `publish_document`).
   Their `#[uniffi::export]` definitions are cfg-gated, so under `sync`-only the
   definitions vanish but dart_ffi's references dangled → broke strict
   (macOS/iOS) cdylib links and `cargo publish`'s default-feature verify.
   (Linux `.so` tolerates undefined symbols, so Android never hit it.)

2. **`sync,bluetooth` without `lite-bridge`** (E0599). `ingest_inbound_lite_frame`
   had a per-method `#[cfg(lite-bridge)]` inside the broader
   `#[cfg(all(sync,bluetooth))] #[uniffi::export]` block, so the export macro
   still emitted a call to the cfg'd-out method.

## Fix
1. Gate each dart_ffi extern declaration + `ffibuffer` definition with the same
   cfg as the method it wraps.
2. Move `ingest_inbound_lite_frame` into its own
   `#[cfg(all(sync,bluetooth,lite-bridge))] #[uniffi::export]` block so the whole
   export (and its generated call) is stripped before the macro runs.

## Verified (macOS) — every feature combo now builds/links
- `--features sync` (default / publish-verify / Android) ✅ (was broken)
- `--features sync,bluetooth` ✅ (was E0599)
- `--features sync,bluetooth,lite-bridge` (Android/iOS ship this) ✅

With the default build linking again, the `--no-verify` added to `release.yml`
in #987 is no longer strictly required (left in place; harmless).

Bumps `peat-ffi` 0.2.5 → 0.2.6.