### PR TITLE
chore(release): workspace 0.9.0-rc.28 + peat-ffi AAR 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,46 @@ Sub-crates that stay internal (`peat-transport`, `peat-persistence`, `peat-ffi`,
 
 ## [Unreleased]
 
+## [0.9.0-rc.28] - 2026-06-24
+
+### Added — `peat-ffi`
+
+- **Persistent peer roster** (#1000) — `RosterStore` (JSON on disk) tracks known
+  group members across restarts. Exposed via six new UniFFI surface methods:
+  `roster_remember`, `roster_upsert`, `roster_remove`, `roster_get`,
+  `roster_list`, `roster_list_by_group`. Also adds the `RosterEntry` UniFFI
+  Record. Stored as plain JSON (non-secret reachability hints only; no FIPS
+  concern).
+- **Per-peer reconnect supervisor** (#1000) — dial state machine
+  (`Idle → Connecting → Connected → Backoff`) with exponential backoff (2 s
+  base, 5 min cap) plus deterministic per-peer jitter to de-correlate
+  thundering-herd re-dials. Three new UniFFI surface methods:
+  `reconnect_known_peers` (gentle, honours backoff), `wake_reconnect` (clears
+  backoffs — call on foreground / network-up events), `on_peer_observed` (hint
+  that a specific roster member is reachable now). Concurrent in-flight dials
+  are bounded at `MAX_CONCURRENT_RECONNECT_DIALS = 8`.
+- **Cross-transport reconnect dedup** (#1000) — the supervisor's connected set
+  is the union of iroh peers and any roster member with a live link on any
+  transport (BLE, etc.), so a peer already reachable over BLE is not also dialed
+  over iroh/relay.
+- **Origin-tagged `DocumentChange`** (#1000) — new required field
+  `origin: ChangeOrigin` on the UniFFI `DocumentChange` Record. `ChangeOrigin`
+  is a new UniFFI enum with variants `Local` (own publish) and
+  `Remote { peer_id }` (sync from a peer). Enables consumers to notify only on
+  remote changes. **Coordinated binding regen required** — paired with
+  peat-flutter#13.
+- **Four Dart C-ABI shims** (#1000) — hand-rolled `#[no_mangle] extern "C"`
+  functions reformatting flat `FFIBuffer` arrays for `roster_remember`,
+  `reconnect_known_peers`, `wake_reconnect`, and `on_peer_observed`. Sit
+  alongside the existing shims in `dart_ffi.rs`.
+- **Contributor workflow guardrails** (#1000) — `CLAUDE.md` and `SKILL.md` now
+  require fork contributors to sync to upstream `main` before opening a PR, run
+  the verification checklist, and pass the consumer-reference grep gate.
+
+### Pinned
+
+- `peat-mesh` `>=0.9.0-rc.43, <0.9.1` (unchanged from rc.27).
+
 ## [0.9.0-rc.27] - 2026-06-20
 
 ### Fixed — `peat-protocol`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,7 +4032,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peat"
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 
 [[package]]
 name = "peat-btle"
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "peat-ffi"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4153,7 +4153,7 @@ dependencies = [
 
 [[package]]
 name = "peat-persistence"
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "peat-protocol"
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4224,7 +4224,7 @@ dependencies = [
 
 [[package]]
 name = "peat-quickstart"
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 dependencies = [
  "anyhow",
  "clap",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "peat-schema"
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "peat-tak-bridge"
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "peat-transport"
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ exclude = ["examples/m5stack-core2-peat"]
 # for the resolution train.
 
 [workspace.package]
-version = "0.9.0-rc.27"
+version = "0.9.0-rc.28"
 edition = "2021"
 authors = ["Kit Plummer <kitplummer@defenseunicorns.com>"]
 license = "Apache-2.0"

--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -49,7 +49,17 @@ name = "peat-ffi"
 # opt-in `relay-n0-hosted` feature passthrough. Backward compatible; existing
 # consumers link against the 0.2.7 surface unchanged. Ships in the Maven AAR
 # 0.1.3 cut. See peat#995.
-version = "0.2.8"
+#
+# 0.2.9 (was 0.2.8): additive — persistent peer roster (`RosterStore`, six new
+# UniFFI exports: roster_remember/upsert/remove/get/list/list_by_group + new
+# `RosterEntry` Record), per-peer reconnect supervisor (dial state machine +
+# exponential backoff + cross-transport dedup, three new UniFFI exports:
+# reconnect_known_peers/wake_reconnect/on_peer_observed), origin-tagged
+# `DocumentChange` (new `origin: ChangeOrigin` field — **coordinated binding
+# regen required**, paired with peat-flutter#13), and four Dart C-ABI shims
+# for the new reconnect surface. Concurrent reconnect dials bounded at 8 via
+# `tokio::sync::Semaphore`. Ships in the Maven AAR 0.1.4 cut. See peat#1000.
+version = "0.2.9"
 edition = "2021"
 description = "FFI bindings for Peat protocol (Kotlin/Swift via UniFFI)"
 license = "Apache-2.0"
@@ -116,7 +126,7 @@ uniffi = { version = "0.31", features = ["cli", "tokio"] }
 jni = "0.21"
 
 # Peat crates - no ditto-backend for Android cross-compilation
-peat-protocol = { path = "../peat-protocol", version = "=0.9.0-rc.27", default-features = false }
+peat-protocol = { path = "../peat-protocol", version = "=0.9.0-rc.28", default-features = false }
 # peat-mesh direct for blob storage (ADR-060). Pulls NetworkedIrohBlobStore
 # which we use behind the peat_mesh::storage::BlobStore trait.
 peat-mesh = { workspace = true, optional = true }

--- a/peat-ffi/android/build.gradle.kts
+++ b/peat-ffi/android/build.gradle.kts
@@ -30,7 +30,15 @@ group = "com.defenseunicorns"
 // (fire-and-forget connect for UI callers that must not freeze on the
 // dial) plus the opt-in `relay-n0-hosted` feature passthrough. No JNI
 // ABI break; existing consumers link unchanged. See peat#995.
-version = "0.1.3"
+//
+// 0.1.4 (was 0.1.3): additive — persistent peer roster (six new UniFFI
+// exports), per-peer reconnect supervisor with backoff + cross-transport
+// dedup (three new UniFFI exports), origin-tagged DocumentChange (new
+// ChangeOrigin enum + required origin field — coordinated binding regen
+// required, paired with peat-flutter#13), and four Dart C-ABI shims for
+// the new reconnect surface. No JNI ABI break; existing JNI consumers
+// link unchanged. See peat#1000.
+version = "0.1.4"
 
 android {
     namespace = "com.defenseunicorns.peat.ffi"

--- a/peat-protocol/Cargo.toml
+++ b/peat-protocol/Cargo.toml
@@ -23,7 +23,7 @@ categories = ["network-programming"]
 [dependencies]
 # Peat facade: peat-protocol re-exports peat-schema and peat-mesh so
 # downstream consumers can depend on peat-protocol alone.
-peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.27" }
+peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.28" }
 peat-mesh = { workspace = true }
 
 tokio = { workspace = true }


### PR DESCRIPTION
## Context

Version bump following the merge of #1000 (reconnect supervisor, persistent roster, origin-tagged change events, Dart C-ABI shims).

## Scope

- Workspace: `0.9.0-rc.27` → `0.9.0-rc.28`
- `peat-ffi` Rust crate: `0.2.8` → `0.2.9`
- `peat-ffi` Maven AAR: `0.1.3` → `0.1.4`
- `peat-protocol` peat-schema pin: `=0.9.0-rc.27` → `=0.9.0-rc.28`
- CHANGELOG entry added for `[0.9.0-rc.28]`

No code changes — version and metadata only.

## Acceptance Criteria

- [ ] CI green
- [ ] Merge triggers tags `v0.9.0-rc.28` (crates.io) and `peat-ffi-v0.1.4` (Maven AAR)

## Constraints

- `peat-mesh` pin unchanged (`>=0.9.0-rc.43, <0.9.1`)
- `DocumentChange.origin` is a breaking FFI Record change — coordinated with peat-flutter#13 (must land before the AAR consumer bumps)

## Dependencies

- #1000 (merged) — all code landed
- peat-flutter#13 — Dart binding regen consumes the new AAR