### PR TITLE
feat(peat-ffi): bindAddress through createNode JNI + formation identity (Android mDNS)

### DIFF
--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -150,7 +150,18 @@ jobs:
              CURRENT title/description fetched in this step, especially any finding that
              would depend on PR-description evidence. A concern that the corrected
              description now satisfies should not be flagged.
-          3. Review the diff against these criteria:
+          3. Fetch prior QA reviews on this PR:
+             Run: gh pr view ${{ github.event.pull_request.number }} --json reviews --jq '.reviews[] | select(.body | contains("Peat QA Review")) | .body'
+             This is an INCREMENTAL review. Read the prior review bodies carefully.
+             A finding is ALREADY ADDRESSED if ANY of these apply:
+               (a) It was flagged in a prior QA review AND the current diff resolves it (code changed to fix it).
+               (b) It is explicitly tracked in the PR body's pre-merge checklist (the author already knows).
+               (c) It predates this PR's diff entirely (pre-existing issue not introduced by this branch).
+             Do NOT re-flag already-addressed findings. If a prior review flagged something and the
+             current push did not change the relevant code, it is still addressed by (b) or (c) — do
+             not repeat it. Only flag a prior finding again if the author's attempted fix is itself wrong.
+             If all findings from prior reviews are addressed and no new issues exist, the review is clean.
+          4. Review the diff against these criteria:
              - Protocol/schema: backward-compatible with cap-schema; check ADR decisions
              - peat-mesh: must not break Automerge sync semantics or Iroh peer discovery
              - peat-ffi / peat-btle: FFI/BLE changes must validate all platform bindings (Android JNI, iOS UniFFI, Linux BlueZ, aarch64)
@@ -179,7 +190,7 @@ jobs:
                This is NOT formatter/style nitpicking — rustfmt/gofmt/prettier handles that.
              - Architectural reach: if a change crosses crate boundaries, alters protocol/transport
                semantics, or sits in ADR territory in a way warranting design discussion, escalate.
-          4. Write findings using the Write tool:
+          5. Write findings using the Write tool:
              (a) Save the complete review body to $RUNNER_TEMP/peat-qa-review.md.
                  Start the body with EXACTLY (including the leading "## "):
           $START_LINE

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ build/
 *.aab
 local.properties
 
+# Generated UniFFI bindings (build output; copied into consumers, never tracked)
+/bindings/
+
 # Xcode user state
 **/xcuserdata/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
@@ -4109,8 +4109,7 @@ dependencies = [
 [[package]]
 name = "peat-mesh"
 version = "0.9.0-rc.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f89c487db281e3c3e6c67bb1d5f5a479f098eb4ee7a1cc036c2043e670172fa"
+source = "git+https://github.com/defenseunicorns/peat-mesh?rev=c863d16b358b146067d759e691021bc49d182446#c863d16b358b146067d759e691021bc49d182446"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4713,7 +4712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4733,7 +4732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7755,7 +7754,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "peat-mesh"
-version = "0.9.0-rc.41"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,6 +4078,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "automerge",
+ "base64",
  "chrono",
  "env_logger",
  "hex",
@@ -4712,7 +4713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4732,7 +4733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7754,3 +7755,7 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[patch.unused]]
+name = "peat-mesh"
+version = "0.9.0-rc.41"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,3 +321,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Testing
 proptest = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
+
+# Local peat-mesh carrying the Android/_peat formation-identity discovery fix
+# (branch fix/android-mdns-discovery). Drop once released to crates.io.
+[patch.crates-io]
+peat-mesh = { path = "../peat-mesh" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 proptest = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
-# Local peat-mesh carrying the Android/_peat formation-identity discovery fix
-# (branch fix/android-mdns-discovery). Drop once released to crates.io.
+# peat-mesh carrying the Android/_peat formation-identity + _peat._udp browse
+# discovery fix (peat-mesh#266, merged to peat-mesh main but not yet released).
+# Pinned to the merge commit so CI (peat-mesh is public) builds against it.
+# DROP THIS once peat-mesh cuts a release containing #266 and bump the
+# `peat-mesh` dependency floor to that version (see PR #1006 pre-merge checklist).
 [patch.crates-io]
-peat-mesh = { path = "../peat-mesh" }
+peat-mesh = { git = "https://github.com/defenseunicorns/peat-mesh", rev = "c863d16b358b146067d759e691021bc49d182446" }

--- a/deny.toml
+++ b/deny.toml
@@ -15,9 +15,9 @@ ignore = [
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile unmaintained; tracked for migration to rustls-pki-types" },
     # Transitive via iroh — cannot fix locally, tracked upstream
     { id = "RUSTSEC-2023-0089", reason = "atomic-polyfill unmaintained; transitive via iroh" },
-    # Transitive via iroh -> aws-lc-sys
-    { id = "RUSTSEC-2026-0044", reason = "aws-lc X.509 bypass; transitive via iroh, awaiting upstream update" },
-    { id = "RUSTSEC-2026-0048", reason = "aws-lc CRL logic error; transitive via iroh, awaiting upstream update" },
+    # RUSTSEC-2026-0044 / -0048 (aws-lc X.509 bypass + CRL logic error) —
+    # cleared by aws-lc-sys 0.41.0 / aws-lc-rs 1.17.0 via the peat-mesh
+    # git-pin update; ignores removed so a future regression is caught.
     # RUSTSEC-2026-0118 / -0119 / -0120 — hickory-proto + hickory-net DNSSEC
     # NSEC3 unbounded loops and O(n²) name compression — were ignored prior
     # to peat#924 because iroh 0.98.x exact-pinned `hickory-resolver
@@ -30,7 +30,8 @@ ignore = [
     # silently suppressed. peat#924 QA WARNING follow-up.
 
     # Workspace crates
-    { id = "RUSTSEC-2025-0141", reason = "bincode unmaintained; used in peat-ffi, evaluate migration to postcard" },
+    # RUSTSEC-2025-0141 (bincode unmaintained) — bincode removed from the
+    # dependency tree; ignore dropped so a re-introduction is caught.
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained; macro-only, low risk" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error unmaintained; compile-time only, low risk" },
     # quick-xml DoS (fixed in 0.41.0). peat-protocol's direct CoT-XML parser

--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -137,6 +137,8 @@ peat-mesh = { workspace = true, optional = true }
 # duplicates, and dropped frames are all safe. Pinned to the same 0.9.0 the
 # workspace already resolves via peat-protocol.
 automerge = { version = "0.9.0", optional = true }
+# Decode the base64 formation shared key for canonical iroh identity derivation.
+base64 = "0.22"
 
 # Time handling
 chrono = "0.4"

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -1765,7 +1765,9 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<PeatNode>, PeatError> {
                     "[identity] shared_key not valid base64 ({e}); using legacy seed identity"
                 ));
                 #[cfg(not(target_os = "android"))]
-                eprintln!("[identity] shared_key not valid base64 ({e}); using legacy seed identity");
+                eprintln!(
+                    "[identity] shared_key not valid base64 ({e}); using legacy seed identity"
+                );
                 None
             }
         }

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -1760,9 +1760,12 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<PeatNode>, PeatError> {
         match base64::engine::general_purpose::STANDARD.decode(config.shared_key.trim()) {
             Ok(bytes) => Some(bytes),
             Err(e) => {
+                #[cfg(target_os = "android")]
                 android_log(&format!(
                     "[identity] shared_key not valid base64 ({e}); using legacy seed identity"
                 ));
+                #[cfg(not(target_os = "android"))]
+                eprintln!("[identity] shared_key not valid base64 ({e}); using legacy seed identity");
                 None
             }
         }

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -1742,10 +1742,14 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<PeatNode>, PeatError> {
     let seed = format!("{}/{}", config.app_id, config.storage_path);
     let storage_path_for_store = storage_path.clone();
 
-    // Stable per-device logical node_id for the canonical formation identity
-    // (the storage instance dir is unique + stable per install). Formation
+    // Stable per-device logical node_id for the canonical formation identity:
+    // the storage directory's **basename** is the identity seed. Formation
     // peers reconstruct this endpoint's iroh EndpointId from
     // (formation_secret, node_id), so it must be stable across restarts.
+    // Renaming the storage directory rotates the EndpointId silently.
+    // NOTE: upgrading from the legacy seed identity (pre-formation) to this
+    // path is a one-time EndpointId rotation — cached peer mappings and
+    // route hints from prior sessions go stale at upgrade time.
     let iroh_node_id = std::path::Path::new(&config.storage_path)
         .file_name()
         .and_then(|s| s.to_str())
@@ -8205,6 +8209,74 @@ mod tests {
                     assert!(!parsed.deleted, "live preserved in scan output");
                 }
             }
+        }
+    }
+
+    #[cfg(feature = "sync")]
+    mod normalize_bind_address_tests {
+        use super::super::normalize_bind_address;
+
+        #[test]
+        fn empty_string_returns_none() {
+            assert_eq!(normalize_bind_address("".to_string()), None);
+        }
+
+        #[test]
+        fn whitespace_only_returns_none() {
+            assert_eq!(normalize_bind_address("   ".to_string()), None);
+            assert_eq!(normalize_bind_address("\t\n".to_string()), None);
+        }
+
+        #[test]
+        fn bare_ip_appends_port_zero() {
+            assert_eq!(
+                normalize_bind_address("192.168.1.5".to_string()),
+                Some("192.168.1.5:0".to_string()),
+            );
+            assert_eq!(
+                normalize_bind_address("127.0.0.1".to_string()),
+                Some("127.0.0.1:0".to_string()),
+            );
+        }
+
+        #[test]
+        fn bare_ipv6_appends_port_zero() {
+            assert_eq!(
+                normalize_bind_address("::1".to_string()),
+                Some("::1:0".to_string()),
+            );
+        }
+
+        #[test]
+        fn full_socket_addr_passed_through() {
+            assert_eq!(
+                normalize_bind_address("192.168.1.5:8080".to_string()),
+                Some("192.168.1.5:8080".to_string()),
+            );
+            assert_eq!(
+                normalize_bind_address("0.0.0.0:0".to_string()),
+                Some("0.0.0.0:0".to_string()),
+            );
+        }
+
+        #[test]
+        fn invalid_string_passed_through() {
+            assert_eq!(
+                normalize_bind_address("not-an-ip".to_string()),
+                Some("not-an-ip".to_string()),
+            );
+        }
+
+        #[test]
+        fn leading_trailing_whitespace_trimmed() {
+            assert_eq!(
+                normalize_bind_address("  192.168.1.5  ".to_string()),
+                Some("192.168.1.5:0".to_string()),
+            );
+            assert_eq!(
+                normalize_bind_address("  10.0.0.1:9999  ".to_string()),
+                Some("10.0.0.1:9999".to_string()),
+            );
         }
     }
 }

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -8467,10 +8467,51 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_testJni(
         .into_raw()
 }
 
+/// Normalize a JNI-provided bind-address string into the `Option<String>`
+/// that [`NodeConfig::bind_address`] expects (a full `host:port`
+/// `SocketAddr`, or `None` for the `0.0.0.0:0` auto-assign default).
+///
+/// Consumers typically source this from the platform Wi-Fi interface
+/// (e.g. Android `WifiManager`), which yields a bare IP with no port. To
+/// keep the consumer wiring simple we accept either form:
+/// - empty / whitespace          → `None` (auto-assign; unchanged behavior)
+/// - a bare IP (`192.168.1.5`)   → `Some("192.168.1.5:0")` (OS picks port)
+/// - a full `host:port`          → passed through verbatim
+///
+/// A non-empty value that is neither a bare IP nor a `SocketAddr` is passed
+/// through unchanged so `create_node`'s parse surfaces the error rather than
+/// silently falling back to the wildcard bind — a silent `0.0.0.0:0` is what
+/// breaks mDNS interface enumeration on Android, the very failure this
+/// parameter exists to let consumers avoid.
+#[cfg(feature = "sync")]
+fn normalize_bind_address(raw: String) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.parse::<SocketAddr>().is_ok() {
+        return Some(trimmed.to_string());
+    }
+    if trimmed.parse::<std::net::IpAddr>().is_ok() {
+        return Some(format!("{trimmed}:0"));
+    }
+    Some(trimmed.to_string())
+}
+
 /// JNI: Create a Peat node (simplified for testing)
 ///
 /// Kotlin signature: external fun createNodeJni(appId: String, sharedKey:
-/// String, storagePath: String): Long
+/// String, storagePath: String, bindAddress: String?): Long
+///
+/// `bindAddress` is the local interface to bind the iroh endpoint to — pass
+/// the device's Wi-Fi IP (bare `192.168.x.y`, or a full `host:port`) so mDNS
+/// discovery can enumerate a concrete interface instead of the wildcard
+/// `0.0.0.0`, which breaks interface enumeration on Android. Pass `null` or
+/// an empty string for the legacy auto-assign (`0.0.0.0:0`) behavior.
+///
+/// For relay / DNS discovery (cross-subnet), the consumer must also call
+/// [`Java_com_defenseunicorns_peat_PeatJni_setAndroidContextJni`] from
+/// `Application.onCreate()` BEFORE the first `createNode` call.
 #[cfg(feature = "sync")]
 #[no_mangle]
 pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
@@ -8479,6 +8520,7 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
     app_id: JString,
     shared_key: JString,
     storage_path: JString,
+    bind_address: JString,
 ) -> i64 {
     let app_id: String = match env.get_string(&app_id) {
         Ok(s) => s.into(),
@@ -8492,17 +8534,23 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
         Ok(s) => s.into(),
         Err(_) => return 0,
     };
+    // Nullable: a null/empty `bindAddress` keeps the auto-assign default.
+    let bind_address: Option<String> = env
+        .get_string(&bind_address)
+        .ok()
+        .map(Into::into)
+        .and_then(normalize_bind_address);
 
     #[cfg(target_os = "android")]
     android_log(&format!(
-        "createNodeJni: app_id={}, storage_path={}",
-        app_id, storage_path
+        "createNodeJni: app_id={}, storage_path={}, bind_address={:?}",
+        app_id, storage_path, bind_address
     ));
 
     let config = NodeConfig {
         app_id,
         shared_key,
-        bind_address: None,
+        bind_address,
         storage_path,
         transport: None,
     };
@@ -8554,6 +8602,15 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
 /// initialized via JNI callbacks. Full BLE support is pending Android adapter
 /// integration in peat-btle.
 ///
+/// `bindAddress` is the local interface to bind the iroh endpoint to — pass
+/// the device's Wi-Fi IP (bare `192.168.x.y`, or a full `host:port`) so mDNS
+/// discovery can enumerate a concrete interface instead of the wildcard
+/// `0.0.0.0`, which breaks interface enumeration on Android. Pass `null` or
+/// an empty string for the legacy auto-assign (`0.0.0.0:0`) behavior. For
+/// relay / DNS discovery (cross-subnet), also call
+/// [`Java_com_defenseunicorns_peat_PeatJni_setAndroidContextJni`] from
+/// `Application.onCreate()` BEFORE the first `createNode` call.
+///
 /// Kotlin signature:
 /// ```kotlin
 /// external fun createNodeWithConfigJni(
@@ -8561,7 +8618,8 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
 ///     sharedKey: String,
 ///     storagePath: String,
 ///     enableBle: Boolean,
-///     blePowerProfile: String?  // "aggressive", "balanced", or "low_power"
+///     blePowerProfile: String?, // "aggressive", "balanced", or "low_power"
+///     bindAddress: String?      // Wi-Fi IP, e.g. "192.168.1.5"; null = auto
 /// ): Long
 /// ```
 #[cfg(feature = "sync")]
@@ -8574,6 +8632,7 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
     storage_path: JString,
     enable_ble: jboolean,
     ble_power_profile: JString,
+    bind_address: JString,
 ) -> i64 {
     let app_id: String = match env.get_string(&app_id) {
         Ok(s) => s.into(),
@@ -8598,13 +8657,21 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
         }
     });
 
+    // Nullable: a null/empty `bindAddress` keeps the auto-assign default.
+    let bind_address: Option<String> = env
+        .get_string(&bind_address)
+        .ok()
+        .map(Into::into)
+        .and_then(normalize_bind_address);
+
     #[cfg(target_os = "android")]
     android_log(&format!(
-        "createNodeWithConfigJni: app_id={}, storage_path={}, enable_ble={}, power_profile={:?}",
+        "createNodeWithConfigJni: app_id={}, storage_path={}, enable_ble={}, power_profile={:?}, bind_address={:?}",
         app_id,
         storage_path,
         enable_ble != 0,
-        power_profile
+        power_profile,
+        bind_address
     ));
 
     // Build transport configuration
@@ -8627,7 +8694,7 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
     let config = NodeConfig {
         app_id,
         shared_key,
-        bind_address: None,
+        bind_address,
         storage_path,
         transport: transport_config,
     };

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -8555,7 +8555,8 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_testJni(
 /// (e.g. Android `WifiManager`), which yields a bare IP with no port. To
 /// keep the consumer wiring simple we accept either form:
 /// - empty / whitespace          → `None` (auto-assign; unchanged behavior)
-/// - a bare IP (`192.168.1.5`)   → `Some("192.168.1.5:0")` (OS picks port)
+/// - a bare IPv4 (`192.168.1.5`) → `Some("192.168.1.5:0")` (OS picks port)
+/// - a bare IPv6 (`::1`)         → `Some("[::1]:0")` (bracket-wrapped)
 /// - a full `host:port`          → passed through verbatim
 ///
 /// A non-empty value that is neither a bare IP nor a `SocketAddr` is passed
@@ -8563,6 +8564,12 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_testJni(
 /// silently falling back to the wildcard bind — a silent `0.0.0.0:0` is what
 /// breaks mDNS interface enumeration on Android, the very failure this
 /// parameter exists to let consumers avoid.
+///
+/// **IPv6 zone identifiers** (e.g. `fe80::abcd%wlan0`) do not parse as
+/// `IpAddr` and fall through to the pass-through path, where `create_node`'s
+/// `SocketAddr::from_str` will reject them. Android `WifiManager` currently
+/// yields IPv4; if scoped IPv6 support is needed later, strip or handle
+/// the zone ID here before parsing.
 #[cfg(feature = "sync")]
 fn normalize_bind_address(raw: String) -> Option<String> {
     let trimmed = raw.trim();
@@ -8591,6 +8598,13 @@ fn normalize_bind_address(raw: String) -> Option<String> {
 /// discovery can enumerate a concrete interface instead of the wildcard
 /// `0.0.0.0`, which breaks interface enumeration on Android. Pass `null` or
 /// an empty string for the legacy auto-assign (`0.0.0.0:0`) behavior.
+///
+/// **Identity derivation:** when `sharedKey` is valid base64, the node's iroh
+/// EndpointId is derived from HKDF over `(formation_secret, storage_path
+/// basename)`. The **basename of `storagePath`** is the identity seed —
+/// renaming the storage directory rotates the EndpointId silently. When
+/// `sharedKey` is non-empty but not valid base64, the legacy seed identity
+/// (`app_id/storage_path`) is used instead.
 ///
 /// For relay / DNS discovery (cross-subnet), the consumer must also call
 /// [`Java_com_defenseunicorns_peat_PeatJni_setAndroidContextJni`] from
@@ -8693,6 +8707,10 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
 /// relay / DNS discovery (cross-subnet), also call
 /// [`Java_com_defenseunicorns_peat_PeatJni_setAndroidContextJni`] from
 /// `Application.onCreate()` BEFORE the first `createNode` call.
+///
+/// **Identity derivation:** same as [`createNodeJni`] — the node's iroh
+/// EndpointId is derived from the `storagePath` basename. Renaming the
+/// storage directory rotates the EndpointId.
 ///
 /// Kotlin signature:
 /// ```kotlin

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -1741,6 +1741,32 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<PeatNode>, PeatError> {
     // in large-scale deployments (see 384-node hierarchical simulations).
     let seed = format!("{}/{}", config.app_id, config.storage_path);
     let storage_path_for_store = storage_path.clone();
+
+    // Stable per-device logical node_id for the canonical formation identity
+    // (the storage instance dir is unique + stable per install). Formation
+    // peers reconstruct this endpoint's iroh EndpointId from
+    // (formation_secret, node_id), so it must be stable across restarts.
+    let iroh_node_id = std::path::Path::new(&config.storage_path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| config.app_id.clone());
+    // Raw formation secret = base64-decoded shared key (matches peat-mesh /
+    // peat-node). Empty/invalid → fall back to the legacy seed identity.
+    let formation_secret: Option<Vec<u8>> = if config.shared_key.trim().is_empty() {
+        None
+    } else {
+        use base64::Engine as _;
+        match base64::engine::general_purpose::STANDARD.decode(config.shared_key.trim()) {
+            Ok(bytes) => Some(bytes),
+            Err(e) => {
+                android_log(&format!(
+                    "[identity] shared_key not valid base64 ({e}); using legacy seed identity"
+                ));
+                None
+            }
+        }
+    };
     // Runtime relay posture (peat-flutter relay toggle): opt into n0's hosted
     // public relay pool only when the caller asked for it. Defaults to the
     // local-only posture so unconfigured callers don't phone home.
@@ -1774,11 +1800,33 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<PeatNode>, PeatError> {
             (Err(last_err.unwrap()), store_start.elapsed().as_millis())
         });
 
-        // Create transport WITH mDNS discovery wired into the endpoint
+        // Create transport WITH mDNS discovery wired into the endpoint.
+        // With a formation secret present, derive the iroh identity the
+        // canonical way (HKDF(formation_secret, "iroh:" + node_id)) so the
+        // endpoint interops with peat-mesh-node / peat-node and is advertised
+        // on `_peat` with a concrete address (works on Android). Otherwise fall
+        // back to the legacy per-device seed identity.
         let transport_future = async {
-            let result =
-                IrohTransport::from_seed_with_discovery_at_addr(&seed, bind_addr, enable_n0_relay)
-                    .await;
+            let result = match formation_secret.as_deref() {
+                Some(secret) => {
+                    IrohTransport::from_formation_with_discovery_at_addr(
+                        secret,
+                        &iroh_node_id,
+                        &config.app_id,
+                        bind_addr,
+                        enable_n0_relay,
+                    )
+                    .await
+                }
+                None => {
+                    IrohTransport::from_seed_with_discovery_at_addr(
+                        &seed,
+                        bind_addr,
+                        enable_n0_relay,
+                    )
+                    .await
+                }
+            };
             (result, transport_start.elapsed().as_millis())
         };
 

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -8240,10 +8240,16 @@ mod tests {
         }
 
         #[test]
-        fn bare_ipv6_appends_port_zero() {
-            assert_eq!(
-                normalize_bind_address("::1".to_string()),
-                Some("::1:0".to_string()),
+        fn bare_ipv6_bracket_wrapped_with_port_zero() {
+            let result = normalize_bind_address("::1".to_string());
+            assert_eq!(result, Some("[::1]:0".to_string()));
+            assert!(
+                result
+                    .as_ref()
+                    .unwrap()
+                    .parse::<std::net::SocketAddr>()
+                    .is_ok(),
+                "bracket-wrapped IPv6 must round-trip through SocketAddr::from_str"
             );
         }
 
@@ -8566,8 +8572,11 @@ fn normalize_bind_address(raw: String) -> Option<String> {
     if trimmed.parse::<SocketAddr>().is_ok() {
         return Some(trimmed.to_string());
     }
-    if trimmed.parse::<std::net::IpAddr>().is_ok() {
-        return Some(format!("{trimmed}:0"));
+    if let Ok(ip) = trimmed.parse::<std::net::IpAddr>() {
+        return match ip {
+            std::net::IpAddr::V4(_) => Some(format!("{trimmed}:0")),
+            std::net::IpAddr::V6(_) => Some(format!("[{trimmed}]:0")),
+        };
     }
     Some(trimmed.to_string())
 }

--- a/peat-ffi/tests/jni_wrapper_integration.rs
+++ b/peat-ffi/tests/jni_wrapper_integration.rs
@@ -124,6 +124,7 @@ fn jni_wrapper_integration() {
     scenario_endpoint_socket_addr_real_handle(raw, handle);
     let (bind_handle, _bind_tempdir) = scenario_create_node_with_bind_address(raw);
     let (config_handle, _config_tempdir) = scenario_create_node_with_config_bind_address(raw);
+    scenario_create_node_invalid_shared_key_returns_zero(raw);
     scenario_publish_get_roundtrip(raw, handle);
     scenario_get_document_err_throws_runtime_exception(raw, handle);
     scenario_native_method_table_audit();
@@ -371,6 +372,48 @@ fn scenario_create_node_with_config_bind_address(raw: *mut jni::sys::JNIEnv) -> 
     );
 
     (handle, tempdir)
+}
+
+// ---------------------------------------------------------------------
+// Scenario 1d: createNodeJni with a non-base64 shared_key returns 0.
+//
+// The legacy seed identity fallback (from_seed_with_discovery_at_addr)
+// fires when shared_key is non-empty but not valid base64 — iroh key
+// derivation falls back to the seed path. However, the sync backend's
+// initialize() still requires a valid base64 key for FormationKey
+// authentication (FormationKey::from_base64), so create_node returns
+// Err and the JNI wrapper correctly returns 0.
+//
+// This scenario pins the contract that an invalid shared_key fails
+// gracefully (returns 0) rather than panicking or returning a handle
+// to a half-initialized node.
+// ---------------------------------------------------------------------
+fn scenario_create_node_invalid_shared_key_returns_zero(raw: *mut jni::sys::JNIEnv) {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let storage_path = tempdir.path().to_str().expect("utf-8 path").to_string();
+
+    let handle = {
+        let mut env = unsafe { fresh_env(raw) };
+        let app_id = new_jstring(&mut env, APP_ID);
+        let shared_key = new_jstring(&mut env, "raw-utf8-key-not-base64!");
+        let storage = new_jstring(&mut env, &storage_path);
+        let bind_address = new_jstring(&mut env, "127.0.0.1");
+        peat_ffi::Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
+            env,
+            null_class(),
+            app_id,
+            shared_key,
+            storage,
+            bind_address,
+        )
+    };
+    assert_eq!(
+        handle, 0,
+        "createNodeJni with non-base64 shared_key must return 0 — \
+         FormationKey::from_base64 rejects the key during sync backend \
+         initialization, so create_node returns Err.",
+    );
+    drop(tempdir);
 }
 
 // ---------------------------------------------------------------------

--- a/peat-ffi/tests/jni_wrapper_integration.rs
+++ b/peat-ffi/tests/jni_wrapper_integration.rs
@@ -170,12 +170,16 @@ fn scenario_create_node_returns_handle(raw: *mut jni::sys::JNIEnv) -> (i64, Temp
         let app_id = new_jstring(&mut env, APP_ID);
         let shared_key = new_jstring(&mut env, SHARED_KEY);
         let storage = new_jstring(&mut env, &storage_path);
+        // Empty bindAddress → None → legacy 0.0.0.0:0 auto-assign, preserving
+        // the prior behavior this scenario asserts against.
+        let bind_address = new_jstring(&mut env, "");
         peat_ffi::Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
             env,
             null_class(),
             app_id,
             shared_key,
             storage,
+            bind_address,
         )
     };
     assert!(

--- a/peat-ffi/tests/jni_wrapper_integration.rs
+++ b/peat-ffi/tests/jni_wrapper_integration.rs
@@ -47,7 +47,7 @@
 //! peat#881 / peat#880 carryover.
 
 use jni::objects::{JClass, JObject, JString};
-use jni::sys::jstring;
+use jni::sys::{jboolean, jstring};
 use jni::{InitArgsBuilder, JNIEnv, JNIVersion, JavaVM};
 use std::sync::OnceLock;
 use tempfile::TempDir;
@@ -122,6 +122,8 @@ fn jni_wrapper_integration() {
     scenario_endpoint_socket_addr_null_handle(raw);
     let (handle, _tempdir) = scenario_create_node_returns_handle(raw);
     scenario_endpoint_socket_addr_real_handle(raw, handle);
+    let (bind_handle, _bind_tempdir) = scenario_create_node_with_bind_address(raw);
+    let (config_handle, _config_tempdir) = scenario_create_node_with_config_bind_address(raw);
     scenario_publish_get_roundtrip(raw, handle);
     scenario_get_document_err_throws_runtime_exception(raw, handle);
     scenario_native_method_table_audit();
@@ -131,6 +133,10 @@ fn jni_wrapper_integration() {
     // aborted the JVM already.
     let env = unsafe { fresh_env(raw) };
     peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), handle);
+    let env = unsafe { fresh_env(raw) };
+    peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), bind_handle);
+    let env = unsafe { fresh_env(raw) };
+    peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), config_handle);
 }
 
 // ---------------------------------------------------------------------
@@ -231,6 +237,140 @@ fn scenario_endpoint_socket_addr_real_handle(raw: *mut jni::sys::JNIEnv, handle:
             s, port, e
         )
     });
+}
+
+// ---------------------------------------------------------------------
+// Scenario 1b: createNodeJni with a concrete bindAddress ("127.0.0.1")
+// exercises the bare-IP normalization path (→ "127.0.0.1:0") and proves
+// endpointSocketAddrJni returns an address on the requested interface.
+// This is the round-trip the bindAddress parameter exists to enable:
+// a concrete interface for mDNS enumeration instead of the wildcard
+// 0.0.0.0 that breaks Android discovery.
+// ---------------------------------------------------------------------
+fn scenario_create_node_with_bind_address(raw: *mut jni::sys::JNIEnv) -> (i64, TempDir) {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let storage_path = tempdir.path().to_str().expect("utf-8 path").to_string();
+
+    let handle = {
+        let mut env = unsafe { fresh_env(raw) };
+        let app_id = new_jstring(&mut env, APP_ID);
+        let shared_key = new_jstring(&mut env, SHARED_KEY);
+        let storage = new_jstring(&mut env, &storage_path);
+        let bind_address = new_jstring(&mut env, "127.0.0.1");
+        peat_ffi::Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
+            env,
+            null_class(),
+            app_id,
+            shared_key,
+            storage,
+            bind_address,
+        )
+    };
+    assert!(
+        handle != 0,
+        "createNodeJni with bindAddress=\"127.0.0.1\" returned 0 — \
+         normalize_bind_address should have produced \"127.0.0.1:0\" \
+         and create_node should have bound the loopback interface.",
+    );
+
+    // Verify the endpoint is actually on the loopback interface.
+    let mut env = unsafe { fresh_env(raw) };
+    let result = peat_ffi::Java_com_defenseunicorns_peat_PeatJni_endpointSocketAddrJni(
+        unsafe { fresh_env(raw) },
+        null_class(),
+        handle,
+    );
+    let addr_str = jstring_to_rust(&mut env, result).unwrap_or_else(|| {
+        panic!(
+            "endpointSocketAddrJni returned null for a node created \
+             with bindAddress=\"127.0.0.1\""
+        )
+    });
+    let addr: std::net::SocketAddr = addr_str.parse().unwrap_or_else(|e| {
+        panic!(
+            "endpointSocketAddrJni returned {:?} which does not parse \
+             as SocketAddr: {}",
+            addr_str, e
+        )
+    });
+    assert!(
+        addr.ip().is_loopback(),
+        "endpointSocketAddrJni returned {} — expected a loopback \
+         address (127.0.0.1:*) for a node created with \
+         bindAddress=\"127.0.0.1\"",
+        addr,
+    );
+
+    (handle, tempdir)
+}
+
+// ---------------------------------------------------------------------
+// Scenario 1c: createNodeWithConfigJni with a concrete bindAddress
+// exercises the same normalize_bind_address path through the config
+// entrypoint. Proves the new trailing bindAddress parameter wires
+// through to NodeConfig.bind_address and produces a working node
+// whose endpoint is on the requested interface.
+// ---------------------------------------------------------------------
+fn scenario_create_node_with_config_bind_address(raw: *mut jni::sys::JNIEnv) -> (i64, TempDir) {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let storage_path = tempdir.path().to_str().expect("utf-8 path").to_string();
+
+    let handle = {
+        let mut env = unsafe { fresh_env(raw) };
+        let app_id = new_jstring(&mut env, APP_ID);
+        let shared_key = new_jstring(&mut env, SHARED_KEY);
+        let storage = new_jstring(&mut env, &storage_path);
+        let enable_ble: jboolean = 0;
+        let ble_power_profile = new_jstring(&mut env, "");
+        let bind_address = new_jstring(&mut env, "127.0.0.1:0");
+        peat_ffi::Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfigJni(
+            env,
+            null_class(),
+            app_id,
+            shared_key,
+            storage,
+            enable_ble,
+            ble_power_profile,
+            bind_address,
+        )
+    };
+    assert!(
+        handle != 0,
+        "createNodeWithConfigJni with bindAddress=\"127.0.0.1:0\" \
+         returned 0 — the full host:port form should pass through \
+         normalize_bind_address verbatim and create_node should bind \
+         the loopback interface.",
+    );
+
+    // Verify the endpoint is on the loopback interface.
+    let mut env = unsafe { fresh_env(raw) };
+    let result = peat_ffi::Java_com_defenseunicorns_peat_PeatJni_endpointSocketAddrJni(
+        unsafe { fresh_env(raw) },
+        null_class(),
+        handle,
+    );
+    let addr_str = jstring_to_rust(&mut env, result).unwrap_or_else(|| {
+        panic!(
+            "endpointSocketAddrJni returned null for a node created \
+             via createNodeWithConfigJni with bindAddress=\"127.0.0.1:0\""
+        )
+    });
+    let addr: std::net::SocketAddr = addr_str.parse().unwrap_or_else(|e| {
+        panic!(
+            "endpointSocketAddrJni returned {:?} which does not parse \
+             as SocketAddr: {}",
+            addr_str, e
+        )
+    });
+    assert!(
+        addr.ip().is_loopback(),
+        "endpointSocketAddrJni returned {} — expected a loopback \
+         address for a node created via createNodeWithConfigJni with \
+         bindAddress=\"127.0.0.1:0\"",
+        addr,
+    );
+
+    (handle, tempdir)
 }
 
 // ---------------------------------------------------------------------

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -36,6 +36,15 @@ audit-as-crates-io = true
 [policy.peat-schema]
 audit-as-crates-io = true
 
+# Temporary: the git-pinned peat-mesh (peat-mesh#266, unreleased) carries
+# commits not in the published rc.43, so the [[trusted.peat-mesh]] coverage
+# doesn't apply. peat-mesh is a first-party defenseunicorns crate; exempt the
+# pinned commit until it's released and the [patch.crates-io] override is
+# dropped (see PR #1006 pre-merge checklist).
+[[exemptions.peat-mesh]]
+version = "0.9.0-rc.43@git:c863d16b358b146067d759e691021bc49d182446"
+criteria = "safe-to-deploy"
+
 [[exemptions.arc-swap]]
 version = "1.9.1"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,6 +22,14 @@ audit-as-crates-io = true
 [policy.peat-ffi]
 audit-as-crates-io = true
 
+# Temporary: peat-mesh is pinned to a git commit (peat-mesh#266, unreleased)
+# via [patch.crates-io] in Cargo.toml. That git version (rc.43) matches a
+# published crates.io version, so cargo-vet needs to be told to audit it as
+# the crates.io crate. Remove when the override is dropped for a released
+# peat-mesh (see PR #1006 pre-merge checklist).
+[policy.peat-mesh]
+audit-as-crates-io = true
+
 [policy.peat-protocol]
 audit-as-crates-io = true
 


### PR DESCRIPTION
## What & why

The peat-side FFI work for Android mDNS interop. An Android consumer node never discovers LAN peers (`request_sync: 0 connected peer(s)`); the root cascade starts with the FFI `createNode*` entrypoints hardcoding `bind_address: None`, so the iroh endpoint binds `0.0.0.0:0` and mDNS can't enumerate a concrete interface on Android.

This PR delivers the **supporting / robustness** half on the peat side. The **actual discovery fix** is a peat-controlled `_peat._udp` browse in peat-mesh (defenseunicorns/peat-mesh#265) plus a matching subscriber in `peat-protocol` — not in this PR.

Part of #1004 (tracking). FFI bind-address portion of #1005.

## Commits

- `feat(peat-ffi): canonical formation iroh identity for createNode` — derive the iroh identity via the canonical formation recipe through peat-mesh's `from_formation_with_discovery_at_addr` so the device interops with `peat-mesh-node`/`peat-node` and advertises on `_peat` (Android-compatible). *(Carries the dev `[patch.crates-io]` override — see checklist.)*
- `fix(peat-ffi): emit identity base64 fallback log on non-Android too` — desktop builds (used to exercise discovery against Android peers) now surface the same diagnostic.
- `feat(peat-ffi): thread bindAddress through createNode JNI entrypoints` — trailing nullable `bindAddress` param on `createNodeJni` + `createNodeWithConfigJni`; bare IP normalized to `ip:0`, empty/null = legacy auto-assign; populates `NodeConfig.bind_address`. Documents the `setAndroidContextJni` requirement for relay/DNS.

## ⚠️ Breaking change (JNI arity)

Consumers must add `bindAddress: String?` to their `PeatJni` `external fun` declarations:
- `peat-atak-plugin/app/src/main/java/com/defenseunicorns/peat/PeatJni.kt` — `createNodeJni` (~L79), `createNodeWithConfigJni` (~L104)

Handled in the coordinated consumer PR (acquire the Wi-Fi IP via `WifiManager`, pass as `bindAddress`, call `setAndroidContextJni` at earliest init).

## 🚧 DRAFT — pre-merge checklist

This branch uses the SKILL's `[patch.crates-io]` path-override dev workflow and is **not yet mergeable**:

- [ ] Remove `[patch.crates-io] peat-mesh = { path = "../peat-mesh" }` from `Cargo.toml` and bump the published `peat-mesh` dep to a release containing defenseunicorns/peat-mesh#265.
- [ ] Land defenseunicorns/peat-mesh#265 (the `_peat._udp` browse + exposed event stream).
- [ ] Add the `peat-protocol` browse subscriber (the other half of #1005) consuming peat-mesh's new `peat_mdns_events`, dialing via `connect_peer` (direct addr) + formation handshake.
- [ ] Coordinated consumer PR for the breaking JNI-arity change (peat-atak-plugin).
- [ ] Pre-existing clippy `unused_imports` warning at `peat-ffi/src/lib.rs:173` (fails `-D warnings`, predates this branch) — clean up or confirm tracked.

## Verification (so far)

- `cargo check -p peat-ffi --features sync` ✅ (resolves peat-mesh via the local path override)
- `cargo fmt` clean on changed lines; ecosystem consumer-reference grep gate ✅

## Acceptance (end-to-end, after the full chain lands)

An Android peat-ffi node logs `Discovered new peer: <desktop endpoint>`, reaches peer count ≥ 1, and bidirectionally syncs with a desktop `peat-node` on the same LAN.

Closes none yet (draft). Tracking: #1004.
