### PR TITLE
feat(mdns): dial mDNS-discovered peers on Android (discovered-but-no-dial fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,39 @@ Sub-crates that stay internal (`peat-transport`, `peat-persistence`, `peat-ffi`,
 
 ## [Unreleased]
 
+### Added
+
+- **mDNS-discovered peer dialing (Android)** — the Automerge connection manager
+  now consumes the peat-controlled `_peat._udp` browse
+  (`transport.peat_mdns_events()`) alongside iroh's `MdnsAddressLookup`,
+  converts each discovered peer to a dialable `PeerInfo` (via peat-mesh's new
+  `From<discovery::PeerInfo>` bridge, peat-mesh#268) and dials its advertised
+  concrete addresses with `connect_peer`. Fixes the Android
+  "discovered-but-no-dial" gap: iroh swarm-discovery emits nothing on the
+  wildcard-bound interface there, so nodes advertised but never connected and
+  the peer count stayed at 0. Runs alongside the iroh path on desktop
+  (`get_connection` dedup prevents a double-dial); a non-hex node_id is skipped.
+  (peat-protocol)
+
+### Added — `peat-ffi`
+
+- **Deterministic formation iroh identity for `createNode`** — a canonical
+  formation iroh identity is derived for `createNode`, with an explicit
+  `node_id` for a stable endpoint identity across restarts. Emits an identity
+  base64 fallback log on non-Android too.
+- **`bindAddress` threaded through `createNode`** — the `createNode` JNI
+  entrypoints accept a `bindAddress` so the iroh endpoint binds to the detected
+  LAN IP on Android instead of the wildcard interface.
+- **mDNS reconnect watchdog** — dial-side formation auth now routes through
+  peat-mesh's `respond_to_formation_auth`, with a watchdog that re-dials peers
+  on mDNS reconnect.
+
+### Changed
+
+- **`[patch.crates-io]` peat-mesh re-pinned to peat-mesh#268 merge commit** —
+  carries the mDNS-discovered-peer dial bridge this branch consumes. Drop the
+  override once peat-mesh cuts a release containing #268.
+
 ## [0.9.0-rc.28] - 2026-06-24
 
 ### Added — `peat-ffi`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4109,7 +4109,7 @@ dependencies = [
 [[package]]
 name = "peat-mesh"
 version = "0.9.0-rc.43"
-source = "git+https://github.com/defenseunicorns/peat-mesh?rev=c863d16b358b146067d759e691021bc49d182446#c863d16b358b146067d759e691021bc49d182446"
+source = "git+https://github.com/defenseunicorns/peat-mesh?rev=b5d62aa08737156be5c72b66c8d64f52f2b64e80#b5d62aa08737156be5c72b66c8d64f52f2b64e80"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4712,7 +4712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -4732,7 +4732,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,9 +323,11 @@ proptest = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
 # peat-mesh carrying the Android/_peat formation-identity + _peat._udp browse
-# discovery fix (peat-mesh#266, merged to peat-mesh main but not yet released).
-# Pinned to the merge commit so CI (peat-mesh is public) builds against it.
-# DROP THIS once peat-mesh cuts a release containing #266 and bump the
+# discovery fix, plus the mDNS-discovered-peer dial bridge
+# (impl From<discovery::PeerInfo> for network::PeerInfo) this branch consumes
+# (peat-mesh#268, merged to peat-mesh main but not yet released). Pinned to the
+# merge commit so CI (peat-mesh is public) builds against it.
+# DROP THIS once peat-mesh cuts a release containing #268 and bump the
 # `peat-mesh` dependency floor to that version (see PR #1006 pre-merge checklist).
 [patch.crates-io]
-peat-mesh = { git = "https://github.com/defenseunicorns/peat-mesh", rev = "c863d16b358b146067d759e691021bc49d182446" }
+peat-mesh = { git = "https://github.com/defenseunicorns/peat-mesh", rev = "b5d62aa08737156be5c72b66c8d64f52f2b64e80" }

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,15 @@ ignore = [
     # re-pins to a vulnerable hickory version is caught loudly instead of
     # silently suppressed. peat#924 QA WARNING follow-up.
 
+    # quick-xml DoS (quadratic duplicate-attr check; unbounded namespace-decl
+    # allocation) — transitive via iroh -> plist -> netdev; fix is quick-xml
+    # >=0.41.0, not yet pulled by iroh's netdev chain. peat never feeds
+    # attacker-controlled XML to quick-xml (plist parses only local system
+    # network-interface metadata). Mirrored in .github/workflows/ci.yml
+    # --ignore set. Drop when iroh's netdev chain ships a fixed quick-xml.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic dup-attr DoS; transitive via iroh, not attacker-reachable" },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml namespace-decl allocation DoS; transitive via iroh, not attacker-reachable" },
+
     # Workspace crates
     # RUSTSEC-2025-0141 (bincode unmaintained) — bincode removed from the
     # dependency tree; ignore dropped so a re-introduction is caught.

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -978,8 +978,14 @@ async fn connect_peer_inner(
         return Ok(());
     };
 
-    use peat_protocol::network::perform_initiator_handshake;
-    if let Err(e) = perform_initiator_handshake(&conn, &formation_key).await {
+    // peat-mesh#267: dial-side formation auth must use peat-mesh's
+    // `respond_to_formation_auth` to match the peer's rc.43 acceptor
+    // (`run_formation_auth`). peat-protocol's legacy `perform_initiator_handshake`
+    // speaks an incompatible wire format → peers reject "formation auth failed".
+    if let Err(e) =
+        peat_mesh::storage::mesh_sync_transport::respond_to_formation_auth(&formation_key, &conn)
+            .await
+    {
         conn.close(1u32.into(), b"authentication failed");
         iroh_transport.disconnect(&peer_id).ok();
         return Err(PeatError::ConnectionError {
@@ -2408,8 +2414,10 @@ async fn dial_peer_and_sync(
         return true;
     };
 
-    use peat_protocol::network::perform_initiator_handshake;
-    match perform_initiator_handshake(&conn, &formation_key).await {
+    // peat-mesh#267: use peat-mesh's dial-side handshake (see connect_peer_inner).
+    match peat_mesh::storage::mesh_sync_transport::respond_to_formation_auth(&formation_key, &conn)
+        .await
+    {
         Ok(()) => {
             iroh_transport.emit_peer_connected(peer_id);
             if let Some(coordinator) = storage_backend.sync_coordinator() {

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -1658,6 +1658,27 @@ impl PeatNode {
 #[cfg(feature = "sync")]
 #[uniffi::export]
 pub fn create_node(config: NodeConfig) -> Result<Arc<PeatNode>, PeatError> {
+    // peat-node NODE_ID model: callers that can supply a stable, peer-derivable
+    // node_id (the JNI layer passes the ATAK callsign) go through
+    // `create_node_with_identity`. The uniffi entry point keeps the legacy
+    // storage-instance-dir identity by passing `None`, so Dart/Flutter consumers
+    // are unaffected (no `NodeConfig` field change).
+    create_node_with_identity(config, None)
+}
+
+/// Like [`create_node`] but with an optional explicit `node_id` override for the
+/// deterministic iroh identity (`HKDF(formation_secret, "iroh:" + node_id)`).
+///
+/// peat-node derives its EndpointId from `(PEAT_NODE_SHARED_KEY, PEAT_NODE_NODE_ID)`
+/// so any shared-key holder can compute a peer's id offline (`peat-node derive-id`).
+/// The ATAK plugin mirrors that by passing the device callsign here, instead of the
+/// per-install storage-dir name (which no peer can pre-compute). `None` or an
+/// empty/whitespace value falls back to the legacy storage-instance-dir identity.
+#[cfg(feature = "sync")]
+pub(crate) fn create_node_with_identity(
+    config: NodeConfig,
+    node_id_override: Option<String>,
+) -> Result<Arc<PeatNode>, PeatError> {
     use std::time::Instant;
     let total_start = Instant::now();
 
@@ -1742,19 +1763,29 @@ pub fn create_node(config: NodeConfig) -> Result<Arc<PeatNode>, PeatError> {
     let seed = format!("{}/{}", config.app_id, config.storage_path);
     let storage_path_for_store = storage_path.clone();
 
-    // Stable per-device logical node_id for the canonical formation identity:
-    // the storage directory's **basename** is the identity seed. Formation
-    // peers reconstruct this endpoint's iroh EndpointId from
-    // (formation_secret, node_id), so it must be stable across restarts.
-    // Renaming the storage directory rotates the EndpointId silently.
+    // Logical node_id for the canonical formation identity. Formation peers
+    // reconstruct this endpoint's iroh EndpointId from (formation_secret,
+    // node_id), so it must be stable across restarts. Renaming the storage
+    // directory (the fallback seed) rotates the EndpointId silently.
     // NOTE: upgrading from the legacy seed identity (pre-formation) to this
     // path is a one-time EndpointId rotation — cached peer mappings and
     // route hints from prior sessions go stale at upgrade time.
-    let iroh_node_id = std::path::Path::new(&config.storage_path)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| config.app_id.clone());
+    //
+    // When the caller supplies an explicit node_id via the JNI layer, use
+    // it — matching peat-node's NODE_ID model so a peer can derive this
+    // endpoint's id from (shared_key, node_id) offline (`peat-node
+    // derive-id`). Otherwise fall back to the storage-instance-dir
+    // basename: stable + unique per install, but NOT peer-derivable.
+    let iroh_node_id = node_id_override
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| {
+            std::path::Path::new(&config.storage_path)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| config.app_id.clone())
+        });
     // Raw formation secret = base64-decoded shared key (matches peat-mesh /
     // peat-node). Empty/invalid → fall back to the legacy seed identity.
     let formation_secret: Option<Vec<u8>> = if config.shared_key.trim().is_empty() {
@@ -8730,6 +8761,7 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
     _class: JClass,
     app_id: JString,
     shared_key: JString,
+    node_id: JString,
     storage_path: JString,
     enable_ble: jboolean,
     ble_power_profile: JString,
@@ -8747,6 +8779,20 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
         Ok(s) => s.into(),
         Err(_) => return 0,
     };
+
+    // Nullable: a null/empty `nodeId` falls back to the storage-instance-dir
+    // identity inside `create_node_with_identity`. When set (the ATAK callsign),
+    // the iroh EndpointId becomes HKDF(shared_key, "iroh:"+callsign) — matching
+    // peat-node's NODE_ID and derivable by peers via `peat-node derive-id`.
+    let node_id: Option<String> = env.get_string(&node_id).ok().and_then(|s| {
+        let s: String = s.into();
+        let s = s.trim().to_string();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    });
 
     // Parse BLE power profile (null/empty string means use default)
     let power_profile: Option<String> = env.get_string(&ble_power_profile).ok().and_then(|s| {
@@ -8767,8 +8813,9 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
 
     #[cfg(target_os = "android")]
     android_log(&format!(
-        "createNodeWithConfigJni: app_id={}, storage_path={}, enable_ble={}, power_profile={:?}, bind_address={:?}",
+        "createNodeWithConfigJni: app_id={}, node_id={:?}, storage_path={}, enable_ble={}, power_profile={:?}, bind_address={:?}",
         app_id,
+        node_id,
         storage_path,
         enable_ble != 0,
         power_profile,
@@ -8800,7 +8847,7 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
         transport: transport_config,
     };
 
-    match create_node(config) {
+    match create_node_with_identity(config, node_id) {
         Ok(node) => {
             #[cfg(target_os = "android")]
             android_log("createNodeWithConfigJni: Node created successfully");
@@ -11938,7 +11985,8 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_nativeInit(
         #[cfg(feature = "sync")]
         NativeMethod {
             name: "createNodeWithConfigJni".into(),
-            sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)J"
+            // (appId, sharedKey, nodeId, storagePath, enableBle, blePowerProfile, bindAddress) -> handle
+            sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)J"
                 .into(),
             fn_ptr: Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfigJni as *mut c_void,
         },
@@ -12610,7 +12658,8 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
                 #[cfg(feature = "sync")]
                 NativeMethod {
                     name: "createNodeWithConfigJni".into(),
-                    sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)J"
+                    // (appId, sharedKey, nodeId, storagePath, enableBle, blePowerProfile, bindAddress) -> handle
+                    sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)J"
                         .into(),
                     fn_ptr: Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfigJni
                         as *mut c_void,

--- a/peat-ffi/tests/jni_wrapper_integration.rs
+++ b/peat-ffi/tests/jni_wrapper_integration.rs
@@ -127,17 +127,24 @@ fn jni_wrapper_integration() {
     scenario_create_node_invalid_shared_key_returns_zero(raw);
     scenario_publish_get_roundtrip(raw, handle);
     scenario_get_document_err_throws_runtime_exception(raw, handle);
+
+    // createNodeWithConfigJni exercises the 7-arg arity including
+    // node_id, enable_ble, and bind_address — catches Kotlin↔Rust
+    // signature drift at test time.
+    let (new_config_handle, _new_config_tempdir) =
+        scenario_create_node_with_config_returns_handle(raw);
+
     scenario_native_method_table_audit();
 
-    // Best-effort cleanup. freeNodeJni's contract is fire-and-forget
-    // (returns void); if it would have thrown, -Xcheck:jni would have
-    // aborted the JVM already.
+    // Best-effort cleanup for both handles.
     let env = unsafe { fresh_env(raw) };
     peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), handle);
     let env = unsafe { fresh_env(raw) };
     peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), bind_handle);
     let env = unsafe { fresh_env(raw) };
     peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), config_handle);
+    let env = unsafe { fresh_env(raw) };
+    peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), new_config_handle);
 }
 
 // ---------------------------------------------------------------------
@@ -195,6 +202,65 @@ fn scenario_create_node_returns_handle(raw: *mut jni::sys::JNIEnv) -> (i64, Temp
          NodeConfig setup failed silently. Check whether \
          env.get_string succeeded for all three args.",
     );
+    (handle, tempdir)
+}
+
+// ---------------------------------------------------------------------
+// Scenario: createNodeWithConfigJni — exercises the 7-arg entrypoint
+// with all parameters populated: app_id, shared_key, node_id,
+// storage_path, enable_ble (false), ble_power_profile, bind_address.
+// Catches Kotlin ↔ Rust signature drift at test time rather than
+// consumer link time. The node_id param exercises the deterministic
+// identity path; bind_address "127.0.0.1" exercises normalize_bind_address.
+// ---------------------------------------------------------------------
+fn scenario_create_node_with_config_returns_handle(raw: *mut jni::sys::JNIEnv) -> (i64, TempDir) {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let storage_path = tempdir.path().to_str().expect("utf-8 path").to_string();
+
+    let handle = {
+        let mut env = unsafe { fresh_env(raw) };
+        let app_id = new_jstring(&mut env, APP_ID);
+        let shared_key = new_jstring(&mut env, SHARED_KEY);
+        let node_id = new_jstring(&mut env, "test-node-config");
+        let storage = new_jstring(&mut env, &storage_path);
+        let enable_ble: jboolean = 0;
+        let ble_power_profile = new_jstring(&mut env, "");
+        let bind_address = new_jstring(&mut env, "127.0.0.1");
+        peat_ffi::Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfigJni(
+            env,
+            null_class(),
+            app_id,
+            shared_key,
+            node_id,
+            storage,
+            enable_ble,
+            ble_power_profile,
+            bind_address,
+        )
+    };
+    assert!(
+        handle != 0,
+        "createNodeWithConfigJni returned 0 — 7-arg JNI entrypoint \
+         failed. Check arg ordering (app_id, shared_key, node_id, \
+         storage_path, enable_ble, ble_power_profile, bind_address).",
+    );
+
+    // Verify the loopback bind address took effect.
+    let mut env = unsafe { fresh_env(raw) };
+    let addr_js = peat_ffi::Java_com_defenseunicorns_peat_PeatJni_endpointSocketAddrJni(
+        unsafe { fresh_env(raw) },
+        null_class(),
+        handle,
+    );
+    let addr = jstring_to_rust(&mut env, addr_js)
+        .expect("endpointSocketAddrJni returned null for createNodeWithConfigJni handle");
+    assert!(
+        addr.starts_with("127.0.0.1:"),
+        "createNodeWithConfigJni with bindAddress='127.0.0.1' should \
+         bind to loopback, got {:?}",
+        addr,
+    );
+
     (handle, tempdir)
 }
 
@@ -320,6 +386,7 @@ fn scenario_create_node_with_config_bind_address(raw: *mut jni::sys::JNIEnv) -> 
         let mut env = unsafe { fresh_env(raw) };
         let app_id = new_jstring(&mut env, APP_ID);
         let shared_key = new_jstring(&mut env, SHARED_KEY);
+        let node_id = new_jstring(&mut env, "");
         let storage = new_jstring(&mut env, &storage_path);
         let enable_ble: jboolean = 0;
         let ble_power_profile = new_jstring(&mut env, "");
@@ -329,6 +396,7 @@ fn scenario_create_node_with_config_bind_address(raw: *mut jni::sys::JNIEnv) -> 
             null_class(),
             app_id,
             shared_key,
+            node_id,
             storage,
             enable_ble,
             ble_power_profile,

--- a/peat-ffi/tests/jni_wrapper_integration.rs
+++ b/peat-ffi/tests/jni_wrapper_integration.rs
@@ -144,7 +144,11 @@ fn jni_wrapper_integration() {
     let env = unsafe { fresh_env(raw) };
     peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), config_handle);
     let env = unsafe { fresh_env(raw) };
-    peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(env, null_class(), new_config_handle);
+    peat_ffi::Java_com_defenseunicorns_peat_PeatJni_freeNodeJni(
+        env,
+        null_class(),
+        new_config_handle,
+    );
 }
 
 // ---------------------------------------------------------------------

--- a/peat-protocol/src/sync/automerge.rs
+++ b/peat-protocol/src/sync/automerge.rs
@@ -2695,102 +2695,115 @@ impl PeerDiscovery for IrohPeerDiscovery {
             let availability_check = self.peer_availability_check.clone();
 
             tokio::spawn(async move {
-                use crate::network::formation_handshake::perform_initiator_handshake;
                 use crate::network::PeerInfo as NetworkPeerInfo;
                 use peat_mesh::discovery::DiscoveryEvent as PeatMdnsEvent;
+                use std::collections::{HashMap, HashSet};
 
                 tracing::info!("Starting peat-controlled mDNS browse connection handler");
 
-                while let Some(event) = peat_events.recv().await {
-                    let discovered = match event {
-                        PeatMdnsEvent::PeerFound(peer) | PeatMdnsEvent::PeerUpdated(peer) => peer,
-                        PeatMdnsEvent::PeerLost(node_id) => {
-                            tracing::debug!(
-                                %node_id,
-                                "peat mDNS peer lost (no longer advertising)"
-                            );
-                            continue;
-                        }
-                    };
+                // Remember every dialable peer we've discovered, keyed by
+                // EndpointId. peat-mesh recycles live connections every ~60s
+                // (CONNECTION_RECYCLE_INTERVAL_SECS, an iroh-leak workaround); a
+                // pure event-driven dialer would then sit idle until the next
+                // mDNS re-announce, so the peer count sawtooths down to 0. The
+                // periodic re-dial tick below acts as the reconnect watchdog
+                // (mirroring peat-node) — it re-dials any known peer that has
+                // dropped out of `connected_peers()`, closing the recycle gap.
+                let mut known: HashMap<peat_mesh::network::EndpointId, NetworkPeerInfo> =
+                    HashMap::new();
+                let mut tick = tokio::time::interval(std::time::Duration::from_secs(10));
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
-                    // Bridge the browse descriptor into the dialable form
-                    // (SocketAddrs → strings, node_id preserved) via the
-                    // `From<discovery::PeerInfo>` impl in peat-mesh.
-                    let peer: NetworkPeerInfo = discovered.into();
-
-                    // The node_id must be a hex EndpointId to be dialable; a peer
-                    // that advertised a non-hex id (e.g. a formation id) is
-                    // skipped rather than panicking.
-                    let peer_id = match peer.endpoint_id() {
-                        Ok(id) => id,
-                        Err(e) => {
-                            tracing::debug!(
-                                node_id = %peer.node_id,
-                                error = %e,
-                                "peat mDNS peer has non-hex node_id — skipping"
-                            );
-                            continue;
-                        }
-                    };
-
-                    if transport.get_connection(&peer_id).is_some() {
-                        tracing::debug!(
-                            peer_id = %peer_id,
-                            "Already connected to peat-mDNS-discovered peer"
-                        );
-                        continue;
-                    }
-
-                    // Same circuit-breaker gate as the iroh path (peat#873):
-                    // skip peers the breaker has marked unreachable so we don't
-                    // allocate fresh QUIC handshake state per rediscovery.
-                    if let Some(check) = availability_check.as_ref() {
-                        if !check(&peer_id) {
-                            tracing::debug!(
-                                peer_id = %peer_id,
-                                "Skipping peat-mDNS peer — circuit breaker open (peat#873)"
-                            );
-                            continue;
-                        }
-                    }
-
-                    tracing::info!(
-                        peer_id = %peer_id,
-                        "peat mDNS discovered peer, dialing by advertised address"
-                    );
-                    match transport.connect_peer(&peer).await {
-                        Ok(Some(conn)) => {
-                            match perform_initiator_handshake(&conn, &formation_key_peat).await {
-                                Ok(()) => {
-                                    tracing::info!(
-                                        peer_id = %peer_id,
-                                        "peat mDNS peer connected and authenticated"
-                                    );
-                                    transport.emit_peer_connected(peer_id);
+                loop {
+                    // Each iteration produces a set of (peer_id, peer) to attempt
+                    // — either the just-discovered peer, or, on a tick, every
+                    // known peer not currently connected.
+                    let to_dial: Vec<(peat_mesh::network::EndpointId, NetworkPeerInfo)> = tokio::select! {
+                        event = peat_events.recv() => {
+                            let Some(event) = event else {
+                                tracing::debug!("peat-controlled mDNS browse stream closed");
+                                break;
+                            };
+                            let discovered = match event {
+                                PeatMdnsEvent::PeerFound(p) | PeatMdnsEvent::PeerUpdated(p) => p,
+                                PeatMdnsEvent::PeerLost(node_id) => {
+                                    tracing::debug!(%node_id, "peat mDNS peer lost (no longer advertising)");
+                                    continue;
+                                }
+                            };
+                            // Bridge browse descriptor → dialable PeerInfo (drops
+                            // loopback/link-local addrs).
+                            let peer: NetworkPeerInfo = discovered.into();
+                            match peer.endpoint_id() {
+                                Ok(id) => {
+                                    known.insert(id, peer.clone());
+                                    vec![(id, peer)]
                                 }
                                 Err(e) => {
-                                    tracing::warn!(
-                                        peer_id = %peer_id,
-                                        error = %e,
-                                        "peat mDNS peer failed authentication"
-                                    );
-                                    conn.close(1u32.into(), b"authentication failed");
-                                    transport.disconnect(&peer_id).ok();
+                                    tracing::debug!(node_id = %peer.node_id, error = %e,
+                                        "peat mDNS peer has non-hex node_id — skipping");
+                                    continue;
                                 }
                             }
                         }
-                        Ok(None) => {
-                            tracing::debug!(
-                                peer_id = %peer_id,
-                                "peat mDNS peer connection handled by accept path"
-                            );
+                        _ = tick.tick() => {
+                            // Reconnect watchdog: re-dial known peers that aren't
+                            // in the live connected set (e.g. after a 60s recycle).
+                            let connected: HashSet<peat_mesh::network::EndpointId> =
+                                transport.connected_peers().into_iter().collect();
+                            known
+                                .iter()
+                                .filter(|(id, _)| !connected.contains(*id))
+                                .map(|(id, peer)| (*id, peer.clone()))
+                                .collect()
                         }
-                        Err(e) => {
-                            tracing::debug!(
-                                peer_id = %peer_id,
-                                error = %e,
-                                "Failed to dial peat-mDNS-discovered peer"
-                            );
+                    };
+
+                    for (peer_id, peer) in to_dial {
+                        if transport.get_connection(&peer_id).is_some() {
+                            continue; // already connected
+                        }
+                        // Circuit-breaker gate (peat#873): skip peers the breaker
+                        // has marked unreachable.
+                        if let Some(check) = availability_check.as_ref() {
+                            if !check(&peer_id) {
+                                continue;
+                            }
+                        }
+                        match transport.connect_peer(&peer).await {
+                            Ok(Some(conn)) => {
+                                // Dial-side formation auth MUST use peat-mesh's
+                                // `respond_to_formation_auth` (peat-mesh#267): the
+                                // rc.43 acceptor runs `run_formation_auth`, and
+                                // peat-protocol's legacy `perform_initiator_handshake`
+                                // speaks a different wire format that peers reject.
+                                match peat_mesh::storage::mesh_sync_transport::respond_to_formation_auth(
+                                    &formation_key_peat,
+                                    &conn,
+                                )
+                                .await
+                                {
+                                    Ok(()) => {
+                                        tracing::info!(peer_id = %peer_id,
+                                            "peat mDNS peer connected and authenticated");
+                                        transport.emit_peer_connected(peer_id);
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(peer_id = %peer_id, error = %e,
+                                            "peat mDNS peer failed authentication");
+                                        conn.close(1u32.into(), b"authentication failed");
+                                        transport.disconnect(&peer_id).ok();
+                                    }
+                                }
+                            }
+                            Ok(None) => {
+                                tracing::debug!(peer_id = %peer_id,
+                                    "peat mDNS peer connection handled by accept path");
+                            }
+                            Err(e) => {
+                                tracing::debug!(peer_id = %peer_id, error = %e,
+                                    "Failed to dial peat-mDNS-discovered peer");
+                            }
                         }
                     }
                 }

--- a/peat-protocol/src/sync/automerge.rs
+++ b/peat-protocol/src/sync/automerge.rs
@@ -2728,6 +2728,15 @@ impl PeerDiscovery for IrohPeerDiscovery {
                                 PeatMdnsEvent::PeerFound(p) | PeatMdnsEvent::PeerUpdated(p) => p,
                                 PeatMdnsEvent::PeerLost(node_id) => {
                                     tracing::debug!(%node_id, "peat mDNS peer lost (no longer advertising)");
+                                    if let Ok(bytes) = hex::decode(&node_id) {
+                                        if bytes.len() == 32 {
+                                            let mut arr = [0u8; 32];
+                                            arr.copy_from_slice(&bytes);
+                                            if let Ok(id) = peat_mesh::network::EndpointId::from_bytes(&arr) {
+                                                known.remove(&id);
+                                            }
+                                        }
+                                    }
                                     continue;
                                 }
                             };

--- a/peat-protocol/src/sync/automerge.rs
+++ b/peat-protocol/src/sync/automerge.rs
@@ -2679,6 +2679,125 @@ impl PeerDiscovery for IrohPeerDiscovery {
             });
         }
 
+        // Android / peat-controlled `_peat._udp` browse path. iroh's own
+        // swarm-discovery cannot enumerate the wildcard-bound interface on
+        // Android, so the `mdns_discovery()` stream above yields nothing there
+        // (the node advertises but never discovers). The peat-controlled browse
+        // DOES discover peers; consume its event stream and dial each by its
+        // advertised concrete addresses via `connect_peer` — `connect_by_id`
+        // alone can't resolve them because the iroh address book is empty on
+        // Android. On desktop this runs harmlessly alongside the iroh path: the
+        // `get_connection` dedup below stops it from double-dialing a peer the
+        // iroh path already connected.
+        if let Some(mut peat_events) = self.transport.peat_mdns_events() {
+            let transport = Arc::clone(&self.transport);
+            let formation_key_peat = formation_key.clone();
+            let availability_check = self.peer_availability_check.clone();
+
+            tokio::spawn(async move {
+                use crate::network::formation_handshake::perform_initiator_handshake;
+                use crate::network::PeerInfo as NetworkPeerInfo;
+                use peat_mesh::discovery::DiscoveryEvent as PeatMdnsEvent;
+
+                tracing::info!("Starting peat-controlled mDNS browse connection handler");
+
+                while let Some(event) = peat_events.recv().await {
+                    let discovered = match event {
+                        PeatMdnsEvent::PeerFound(peer) | PeatMdnsEvent::PeerUpdated(peer) => peer,
+                        PeatMdnsEvent::PeerLost(node_id) => {
+                            tracing::debug!(
+                                %node_id,
+                                "peat mDNS peer lost (no longer advertising)"
+                            );
+                            continue;
+                        }
+                    };
+
+                    // Bridge the browse descriptor into the dialable form
+                    // (SocketAddrs → strings, node_id preserved) via the
+                    // `From<discovery::PeerInfo>` impl in peat-mesh.
+                    let peer: NetworkPeerInfo = discovered.into();
+
+                    // The node_id must be a hex EndpointId to be dialable; a peer
+                    // that advertised a non-hex id (e.g. a formation id) is
+                    // skipped rather than panicking.
+                    let peer_id = match peer.endpoint_id() {
+                        Ok(id) => id,
+                        Err(e) => {
+                            tracing::debug!(
+                                node_id = %peer.node_id,
+                                error = %e,
+                                "peat mDNS peer has non-hex node_id — skipping"
+                            );
+                            continue;
+                        }
+                    };
+
+                    if transport.get_connection(&peer_id).is_some() {
+                        tracing::debug!(
+                            peer_id = %peer_id,
+                            "Already connected to peat-mDNS-discovered peer"
+                        );
+                        continue;
+                    }
+
+                    // Same circuit-breaker gate as the iroh path (peat#873):
+                    // skip peers the breaker has marked unreachable so we don't
+                    // allocate fresh QUIC handshake state per rediscovery.
+                    if let Some(check) = availability_check.as_ref() {
+                        if !check(&peer_id) {
+                            tracing::debug!(
+                                peer_id = %peer_id,
+                                "Skipping peat-mDNS peer — circuit breaker open (peat#873)"
+                            );
+                            continue;
+                        }
+                    }
+
+                    tracing::info!(
+                        peer_id = %peer_id,
+                        "peat mDNS discovered peer, dialing by advertised address"
+                    );
+                    match transport.connect_peer(&peer).await {
+                        Ok(Some(conn)) => {
+                            match perform_initiator_handshake(&conn, &formation_key_peat).await {
+                                Ok(()) => {
+                                    tracing::info!(
+                                        peer_id = %peer_id,
+                                        "peat mDNS peer connected and authenticated"
+                                    );
+                                    transport.emit_peer_connected(peer_id);
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        peer_id = %peer_id,
+                                        error = %e,
+                                        "peat mDNS peer failed authentication"
+                                    );
+                                    conn.close(1u32.into(), b"authentication failed");
+                                    transport.disconnect(&peer_id).ok();
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            tracing::debug!(
+                                peer_id = %peer_id,
+                                "peat mDNS peer connection handled by accept path"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                peer_id = %peer_id,
+                                error = %e,
+                                "Failed to dial peat-mDNS-discovered peer"
+                            );
+                        }
+                    }
+                }
+                tracing::debug!("peat-controlled mDNS browse connection handler stopped");
+            });
+        }
+
         // Check if topology-driven connection management is configured
         #[cfg(feature = "automerge-backend")]
         let has_topology_events = {

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,7 +22,7 @@ audit-as-crates-io = true
 [policy.peat-ffi]
 audit-as-crates-io = true
 
-# Temporary: peat-mesh is pinned to a git commit (peat-mesh#266, unreleased)
+# Temporary: peat-mesh is pinned to a git commit (peat-mesh#268, unreleased)
 # via [patch.crates-io] in Cargo.toml. That git version (rc.43) matches a
 # published crates.io version, so cargo-vet needs to be told to audit it as
 # the crates.io crate. Remove when the override is dropped for a released
@@ -36,13 +36,13 @@ audit-as-crates-io = true
 [policy.peat-schema]
 audit-as-crates-io = true
 
-# Temporary: the git-pinned peat-mesh (peat-mesh#266, unreleased) carries
+# Temporary: the git-pinned peat-mesh (peat-mesh#268, unreleased) carries
 # commits not in the published rc.43, so the [[trusted.peat-mesh]] coverage
 # doesn't apply. peat-mesh is a first-party defenseunicorns crate; exempt the
 # pinned commit until it's released and the [patch.crates-io] override is
 # dropped (see PR #1006 pre-merge checklist).
 [[exemptions.peat-mesh]]
-version = "0.9.0-rc.43@git:c863d16b358b146067d759e691021bc49d182446"
+version = "0.9.0-rc.43@git:b5d62aa08737156be5c72b66c8d64f52f2b64e80"
 criteria = "safe-to-deploy"
 
 [[exemptions.arc-swap]]


### PR DESCRIPTION
## Summary

Fixes the Android **"discovered-but-no-dial"** gap: nodes advertised over mDNS but the peer count stayed at 0, because iroh's swarm-discovery emits nothing on Android's wildcard-bound interface. This branch adds a peat-controlled browse→dial path and the deterministic-identity/bind plumbing needed for it to connect.

Depends on **peat-mesh#268** (merged), which added the `From<discovery::PeerInfo> for network::PeerInfo` bridge this code consumes.

## Changes

**`peat-protocol`**
- **mDNS-discovered peer dialing** — the Automerge connection manager now consumes the peat-controlled `_peat._udp` browse (`transport.peat_mdns_events()`) alongside iroh's `MdnsAddressLookup`, converts each discovered peer to a dialable `PeerInfo` (via peat-mesh#268's `From` impl), and dials advertised concrete addresses with `connect_peer` (iroh's address book is empty on Android, so `connect_by_id` can't resolve them). Runs alongside the iroh path on desktop — `get_connection` dedup prevents a double-dial; non-hex node_ids are skipped.

**`peat-ffi`**
- Deterministic formation iroh identity for `createNode` (explicit `node_id`, stable endpoint identity across restarts).
- `bindAddress` threaded through the `createNode` JNI entrypoints so the endpoint binds to the detected LAN IP on Android.
- mDNS reconnect watchdog; dial-side formation auth routes through peat-mesh's `respond_to_formation_auth`.

**Build / supply-chain**
- `[patch.crates-io]` peat-mesh re-pinned from `c863d16` (#266) to the **#268 merge commit `b5d62aa`**; cargo-vet `audit-as-crates-io` exemption updated to match. Drop the override once peat-mesh releases #268.
- `ci(audit)` + `deny.toml`: ignore transitive quick-xml advisories **RUSTSEC-2026-0194/0195** (DoS via `iroh → netdev → plist → quick-xml`; not attacker-reachable; fix needs quick-xml ≥0.41.0 which iroh doesn't yet pull). Pre-existing — not introduced by this branch.

## Testing

- `cargo check -p peat-ffi --all-targets` clean against the #268 git rev (no local `path` override).
- `cargo fmt --all --check` clean.
- `cargo audit` gate passes with the two documented quick-xml ignores.
- On-device: Android peers now discover **and dial** each other over mDNS (peer count > 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
