### PR TITLE
ci(qa-review): unset empty CLAUDE_CODE_OAUTH_TOKEN for fork PRs

### DIFF
--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -66,6 +66,14 @@ jobs:
           set -uo pipefail
           set +e   # GH Actions defaults to bash -e; -e would abort before rc=$? captures the claude exit code
 
+          # Fork PRs receive an empty secret (GitHub strips secrets from fork
+          # pull_request events). Unset the var so claude falls back to the
+          # runner-local credential (~/.claude/.credentials.json).
+          if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]; then
+            echo "CLAUDE_CODE_OAUTH_TOKEN is empty (expected for fork PRs) — falling back to runner-local credentials"
+            unset CLAUDE_CODE_OAUTH_TOKEN
+          fi
+
           PR_NUMBER="${{ github.event.pull_request.number }}"
           SHORT_SHA="${{ steps.check.outputs.short_sha }}"
 


### PR DESCRIPTION
## Summary
- When `CLAUDE_CODE_OAUTH_TOKEN` is set from `secrets.CLAUDE_CODE_OAUTH_TOKEN` on a fork PR, GitHub strips the secret to empty string
- The empty env var overrides the runner-local credential (`~/.claude/.credentials.json`), causing QA Review to fail
- Unset the var when empty so claude falls back to the local credential

## Test plan
- [x] Fork PRs: secret is empty → var is unset → claude uses runner-local credential
- [x] Non-fork PRs: secret is populated → used as-is (no change in behavior)