### PR TITLE
chore(deps): drop peat-mesh git-pin, bump floor to 0.9.0-rc.44

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4108,8 +4108,9 @@ dependencies = [
 
 [[package]]
 name = "peat-mesh"
-version = "0.9.0-rc.43"
-source = "git+https://github.com/defenseunicorns/peat-mesh?rev=b5d62aa08737156be5c72b66c8d64f52f2b64e80#b5d62aa08737156be5c72b66c8d64f52f2b64e80"
+version = "0.9.0-rc.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2200a9f75b8cb89e47657f6af7eab7540fadf59fdbe4d7a6d7290221185218b7"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4712,7 +4713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -4732,7 +4733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -284,7 +284,7 @@ repository = "https://github.com/defenseunicorns/peat"
 # conflict. rc.31 also carries the internal HierarchyLevel rename
 # (ADR-066 Phase 3) + the iroh rc.0→rc.1 train; both are internal to
 # peat-mesh and require no peat-protocol source change.
-peat-mesh = { version = ">=0.9.0-rc.43, <0.9.1", default-features = false }
+peat-mesh = { version = ">=0.9.0-rc.44, <0.9.1", default-features = false }
 
 # BLE mesh transport (ADR-039). `>=0.4.0, <0.4.1` matches peat-btle
 # 0.4.0 — the Slice-4.b release that deleted the `mesh-translator`
@@ -322,12 +322,3 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 proptest = "1"
 criterion = { version = "0.5", features = ["html_reports"] }
 
-# peat-mesh carrying the Android/_peat formation-identity + _peat._udp browse
-# discovery fix, plus the mDNS-discovered-peer dial bridge
-# (impl From<discovery::PeerInfo> for network::PeerInfo) this branch consumes
-# (peat-mesh#268, merged to peat-mesh main but not yet released). Pinned to the
-# merge commit so CI (peat-mesh is public) builds against it.
-# DROP THIS once peat-mesh cuts a release containing #268 and bump the
-# `peat-mesh` dependency floor to that version (see PR #1006 pre-merge checklist).
-[patch.crates-io]
-peat-mesh = { git = "https://github.com/defenseunicorns/peat-mesh", rev = "b5d62aa08737156be5c72b66c8d64f52f2b64e80" }

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,28 +22,11 @@ audit-as-crates-io = true
 [policy.peat-ffi]
 audit-as-crates-io = true
 
-# Temporary: peat-mesh is pinned to a git commit (peat-mesh#268, unreleased)
-# via [patch.crates-io] in Cargo.toml. That git version (rc.43) matches a
-# published crates.io version, so cargo-vet needs to be told to audit it as
-# the crates.io crate. Remove when the override is dropped for a released
-# peat-mesh (see PR #1006 pre-merge checklist).
-[policy.peat-mesh]
-audit-as-crates-io = true
-
 [policy.peat-protocol]
 audit-as-crates-io = true
 
 [policy.peat-schema]
 audit-as-crates-io = true
-
-# Temporary: the git-pinned peat-mesh (peat-mesh#268, unreleased) carries
-# commits not in the published rc.43, so the [[trusted.peat-mesh]] coverage
-# doesn't apply. peat-mesh is a first-party defenseunicorns crate; exempt the
-# pinned commit until it's released and the [patch.crates-io] override is
-# dropped (see PR #1006 pre-merge checklist).
-[[exemptions.peat-mesh]]
-version = "0.9.0-rc.43@git:b5d62aa08737156be5c72b66c8d64f52f2b64e80"
-criteria = "safe-to-deploy"
 
 [[exemptions.arc-swap]]
 version = "1.9.1"


### PR DESCRIPTION
## Summary

- Remove `[patch.crates-io]` git override for peat-mesh — rc.44 is now published on crates.io
- Bump dependency floor from `>=0.9.0-rc.43` to `>=0.9.0-rc.44` to pick up mDNS discovered-peer dial (#268) and `add_peer_from_hex_id` (#270)

Closes the pre-merge checklist item from PR #1007.