### PR TITLE
chore: release 0.9.0-rc.30 (schema, protocol, ffi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,28 @@ Sub-crates that stay internal (`peat-transport`, `peat-persistence`, `peat-ffi`,
 
 ## [Unreleased]
 
+## [0.9.0-rc.30] - 2026-07-08
+
+### Added
+
+- **Kinematics and PositionError on Track/NodeState** ([#1023](https://github.com/defenseunicorns/peat/pull/1023)) —
+  `peat-schema` adds `Kinematics` and `PositionError` messages to `common.proto`,
+  wired into `Track` and `NodeState`. Existing `velocity`, `cep_m`, and
+  `vertical_error_m` fields are deprecated in favour of the new structured types.
+  `peat-protocol` model constructors updated to include the new fields.
+  (peat-schema, peat-protocol)
+
+### Fixed
+
+- **peat-protocol NodeState constructor** — missing `kinematics` and
+  `position_error` fields in `NodeState` initializer caused compile failure
+  against peat-schema 0.9.0-rc.29. (peat-protocol)
+
+### Changed — `peat-ffi`
+
+- **ADR-074 schema alignment** ([#1022](https://github.com/defenseunicorns/peat/pull/1022)) —
+  FFI types shrunk to proto-backed fields only. `peat-ffi` bumped to 0.2.11.
+
 ## [0.9.0-rc.29] - 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,7 +4032,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peat"
-version = "0.9.0-rc.29"
+version = "0.9.0-rc.30"
 
 [[package]]
 name = "peat-btle"
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "peat-ffi"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "peat-persistence"
-version = "0.9.0-rc.29"
+version = "0.9.0-rc.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "peat-protocol"
-version = "0.9.0-rc.29"
+version = "0.9.0-rc.30"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4226,7 +4226,7 @@ dependencies = [
 
 [[package]]
 name = "peat-quickstart"
-version = "0.9.0-rc.29"
+version = "0.9.0-rc.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "peat-schema"
-version = "0.9.0-rc.29"
+version = "0.9.0-rc.30"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4259,7 +4259,7 @@ dependencies = [
 
 [[package]]
 name = "peat-transport"
-version = "0.9.0-rc.29"
+version = "0.9.0-rc.30"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ exclude = ["examples/m5stack-core2-peat"]
 # for the resolution train.
 
 [workspace.package]
-version = "0.9.0-rc.29"
+version = "0.9.0-rc.30"
 edition = "2021"
 authors = ["Kit Plummer <kitplummer@defenseunicorns.com>"]
 license = "Apache-2.0"

--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -70,7 +70,12 @@ name = "peat-ffi"
 # `Option<String>` (SocketAddr isn't UniFFI-liftable) — JNI callers unaffected
 # except a malformed non-empty address now errors instead of silently
 # falling back to ephemeral. See peat#1013, peat#1017.
-version = "0.2.10"
+#
+# 0.2.11 (was 0.2.10): non-additive — ADR-074 schema alignment shrinks FFI
+# types to proto-backed fields only (Track, NodeState gain kinematics/
+# position_error; deprecated velocity/cep_m/vertical_error_m marked).
+# peat-schema 0.9.0-rc.30 adds Kinematics and PositionError to common.proto.
+version = "0.2.11"
 edition = "2021"
 description = "FFI bindings for Peat protocol (Kotlin/Swift via UniFFI)"
 license = "Apache-2.0"
@@ -137,7 +142,7 @@ uniffi = { version = "0.31", features = ["cli", "tokio"] }
 jni = "0.21"
 
 # Peat crates - no ditto-backend for Android cross-compilation
-peat-protocol = { path = "../peat-protocol", version = "=0.9.0-rc.29", default-features = false }
+peat-protocol = { path = "../peat-protocol", version = "=0.9.0-rc.30", default-features = false }
 # Proto-generated types (ADR-074: single source of truth for message schemas)
 peat-schema = { path = "../peat-schema" }
 # peat-mesh direct for blob storage (ADR-060). Pulls NetworkedIrohBlobStore

--- a/peat-protocol/Cargo.toml
+++ b/peat-protocol/Cargo.toml
@@ -23,7 +23,7 @@ categories = ["network-programming"]
 [dependencies]
 # Peat facade: peat-protocol re-exports peat-schema and peat-mesh so
 # downstream consumers can depend on peat-protocol alone.
-peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.29" }
+peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.30" }
 peat-mesh = { workspace = true }
 
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

- Bump workspace version to `0.9.0-rc.30`
- Bump `peat-ffi` to `0.2.11`
- Update internal `=` version pins (`peat-schema` in peat-protocol, `peat-protocol` in peat-ffi)
- Add CHANGELOG entry

### What gets published (tag `v0.9.0-rc.30` after merge)

| Crate | Version | Key changes |
|---|---|---|
| `peat-schema` | 0.9.0-rc.30 | `Kinematics` and `PositionError` in `common.proto`, wired into `Track`/`NodeState` |
| `peat-protocol` | 0.9.0-rc.30 | `NodeState` constructor fix (was broken against rc.29 schema), formation_handshake race fix |
| `peat-ffi` | 0.2.11 | ADR-074 schema alignment — FFI types shrunk to proto-backed fields |

### Why now

`peat-sapient` and `peat-tak` depend on the kinematics/position_error fields via `[patch.crates-io]` git overrides. Publishing rc.30 lets them drop the patches and resolve from crates.io.

## Test plan

- [x] `cargo check -p peat-schema -p peat-protocol -p peat-ffi` passes
- [x] `cargo test -p peat-schema -p peat-protocol` passes (all 24 doc-tests + unit tests)
- [ ] CI gates on this PR
- [ ] After merge: tag `v0.9.0-rc.30` and push to trigger release workflow