### PR TITLE
fix: add peat-schema version pin to peat-ffi

### DIFF
--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -144,7 +144,7 @@ jni = "0.21"
 # Peat crates - no ditto-backend for Android cross-compilation
 peat-protocol = { path = "../peat-protocol", version = "=0.9.0-rc.30", default-features = false }
 # Proto-generated types (ADR-074: single source of truth for message schemas)
-peat-schema = { path = "../peat-schema" }
+peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.30" }
 # peat-mesh direct for blob storage (ADR-060). Pulls NetworkedIrohBlobStore
 # which we use behind the peat_mesh::storage::BlobStore trait.
 peat-mesh = { workspace = true, optional = true }


### PR DESCRIPTION
## Summary
- peat-ffi's `peat-schema` dependency was missing a `version` field, causing `cargo publish` to fail with "dependency peat-schema does not specify a version"
- Adds `version = "=0.9.0-rc.30"` to match the peat-protocol pin
- peat-schema and peat-protocol published successfully as rc.30; only peat-ffi 0.2.11 needs re-publish after this merges

## Test plan
- [ ] CI passes (cargo check, clippy, tests)
- [ ] After merge, re-tag or manually trigger the publish workflow to push peat-ffi 0.2.11 to crates.io