### PR TITLE
test(peat-protocol): re-enable three-node mesh convergence

### DIFF
--- a/peat-protocol/tests/multi_node_mesh_e2e.rs
+++ b/peat-protocol/tests/multi_node_mesh_e2e.rs
@@ -38,7 +38,6 @@ const SYNC_OBSERVE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Test 3-node mesh with Automerge+Iroh backend
 #[tokio::test]
-#[ignore = "Tracked by #829: asymmetric sync from non-initiator nodes — Doc 1 from Node 1 propagates to all 3, Doc 2 from Node 2 propagates to nobody. Hypothesis: outbound iroh sync stream is wired only on connect_peer-side, not on responder-handshake completion. Re-enable after #829 lands."]
 async fn test_automerge_three_node_mesh() {
     println!("=== Multi-Node Mesh E2E: Automerge+Iroh 3-Node Mesh ===");
 


### PR DESCRIPTION
## Summary

- re-enable the three-node Automerge/Iroh mesh convergence regression
- preserve the existing assertions that updates originating from both Node 1 and Node 2 reach all three peers
- restore continuous CI coverage for the scenario tracked by #829

## Findings

The ignored test passes consistently against the current peat-mesh dependency and persistent-sync implementation. It passed 50 consecutive isolated executions before the ignore was removed, so no production-code change or timeout/retry workaround is warranted.

## Verification

- 50/50 consecutive isolated executions passed with the test still ignored
- focused re-enabled test passed normally
- `cargo nextest run -p peat-protocol --features automerge-backend --test-threads=1`: 1110 passed, 0 skipped
- `cargo fmt --all -- --check`
- `cargo clippy -p peat-protocol --features automerge-backend --all-targets -- -D warnings`
- ecosystem consumer-identifier additions check: clean

A parallel broad-suite run passed 1109/1110; the sole failure was an unrelated random-port bind collision in `transitive_gossip_hub_and_spoke_converges_peat891`. That test passed immediately in isolation and in the complete serial run.

Closes #829