### PR TITLE
docs: clarify gateway runtime and security boundaries

### DIFF
--- a/docs/adr/006-security-authentication-authorization.md
+++ b/docs/adr/006-security-authentication-authorization.md
@@ -1,9 +1,9 @@
 # ADR-006: Security, Authentication, and Authorization for Peat Protocol
 
-**Status**: Proposed (amended 2026-05-18 for FIPS posture per ADR-060)
+**Status**: Proposed (amended 2026-07-21 for the gateway/node authentication boundary)
 **Date**: 2025-11-04
 **Authors**: Codex, Kit Plummer
-**Related**: ADR-005 (Data Sync Abstraction Layer), ADR-004 (Human-Machine Cell Composition), [ADR-060 §5 Cryptographic primitives (FIPS posture)](060-encryption-tiers-rest-and-transit.md#5-cryptographic-primitives-fips-posture)
+**Related**: ADR-005 (Data Sync Abstraction Layer), ADR-004 (Human-Machine Cell Composition), ADR-048 (Membership Certificates), ADR-055 (Peat Gateway), [ADR-060 §5 Cryptographic primitives (FIPS posture)](060-encryption-tiers-rest-and-transit.md#5-cryptographic-primitives-fips-posture)
 
 > **Amendment 2026-05-18 (via PR #870):** ChaCha20-Poly1305 references in this ADR are superseded by **AES-256-GCM** per ADR-060 §5 driver #6 (FIPS-approved primitives only). The original code samples and acceptance criteria below have been updated inline; the original record is preserved in git history. This amendment also resolves the latent contradiction this ADR has carried since its initial draft — the "Compliance Considerations" section already named FIPS 140-2/3 as a target, but the rest of the ADR specified the non-FIPS-approved ChaCha20-Poly1305. ADR-060 §5 is the authoritative primitive list for the peat ecosystem.
 
@@ -1118,9 +1118,28 @@ Failure to resolve a bundle is a fatal error — the reference implementation do
 
 ### Consequences
 
-- **Positive.** Multiple Peat clients share one operational credential file format. Migration between clients (peat-cli ↔ peat-gateway ↔ peat-lite) is config-only.
+- **Positive.** Multiple Peat clients share one version-1 operational credential file format. Migration is config-only only among clients that implement the same FormationKey-only admission semantics.
 - **Negative.** The schema is intentionally minimal; richer use cases (one bundle carrying credentials for multiple formations, embedded device PKI) need follow-up amendments.
 - **Risks.** Operators who hand-edit credential files surface schema errors at load time. The reject-unknown-fields stance flags typos and stale fields rather than silently ignoring them.
+
+### Current Enforcement Boundary (2026-07-21 Amendment)
+
+The version-1 bundle proves possession of a formation-wide secret. It does not identify an individual member and carries no tier, permission, expiry, or revocation claim. Possession of the `shared_key` is therefore sufficient for the current FormationKey challenge and must not be described as equivalent to certificate-authorized membership.
+
+`peat-mesh` defines certificate and certificate-bundle primitives, and its sync handler can perform an additional certificate check when a bundle is explicitly configured. That optional capability does not make certificate validation universal: the operational node bootstrap and the version-1 credential bundle do not yet establish a normative certificate exchange and enforcement path in both connection directions.
+
+Consequently, a certificate issued by an enterprise gateway can be cryptographically valid without its tier, permissions, expiry, or revocation state governing admission in every deployed node. Operator interfaces MUST NOT represent those claims as an enforced mesh authorization boundary until the node runtime wires the corresponding contract.
+
+A follow-up security decision MUST define:
+
+1. whether FormationKey remains a first admission gate or becomes bootstrap/key-wrapping material;
+2. how a peer proves possession of the private key bound to its membership certificate;
+3. bidirectional validation of mesh ID, issuer, expiry, revocation, tier, and permissions before sync and blob transfer;
+4. disconnected revocation and expiration behavior;
+5. credential rotation and migration for existing FormationKey-only deployments; and
+6. the versioned credential-bundle shape once certificate material becomes normative.
+
+ADR-055's managed-runtime cutover is blocked on this decision. Until it lands, the flat `app_id` + `shared_key` bundle remains the documented operational admission format and certificate authorization remains an additional, explicitly configured layer rather than a universal invariant.
 
 ### Related
 

--- a/docs/adr/048-membership-certificates-tactical-trust.md
+++ b/docs/adr/048-membership-certificates-tactical-trust.md
@@ -1,9 +1,9 @@
 # ADR-048: Membership Certificates and Tactical Trust
 
-**Status**: Proposed
+**Status**: Proposed (transport-enforcement boundary clarified 2026-07-21)
 **Date**: 2025-01-29
 **Authors**: Codex, Kit Plummer
-**Related**: ADR-006 (Security Architecture), ADR-044 (E2E Encryption), ADR-039 (peat-btle Mesh Transport)
+**Related**: ADR-006 (Security Architecture), ADR-044 (E2E Encryption), ADR-039 (peat-btle Mesh Transport), ADR-055 (Peat Gateway), ADR-060 (Encryption Tiers)
 
 ## Context
 
@@ -217,6 +217,23 @@ When two mesh nodes discover each other via BLE:
 4. Store in peer registry: `node_id → (public_key, callsign, certificate)`
 
 Unknown or invalid certificates → reject peer, do not sync.
+
+### Transport-Neutral Enforcement Boundary (2026-07-21 Clarification)
+
+The trust model above is transport-neutral even though its original enrollment and discovery examples use BLE. The current substrate representation is `peat_mesh::security::MeshCertificate`; higher-level `MembershipCertificate` types may project to that wire certificate, but there must be one authoritative set of issuer, subject-key, mesh-ID, expiry, tier, permission, and revocation semantics.
+
+Current Iroh document sync uses a mandatory FormationKey challenge. The sync handler supports an optional certificate bundle for an additional accept-side check, but certificate exchange and validation are not yet a universal node-runtime contract. Therefore the "reject peer, do not sync" and hard-cutoff statements above describe the intended end state, not behavior guaranteed by every current `peat-node` deployment.
+
+Before certificate authorization becomes normative, a follow-up decision MUST specify:
+
+1. presentation and proof-of-possession during connection establishment;
+2. validation in both connection directions before document sync and blob transfer;
+3. certificate-bundle and revocation distribution during disconnected operation;
+4. expiry behavior for established connections and reconnects;
+5. the relationship between the formation-wide key and individual certificates; and
+6. compatibility and downgrade behavior for FormationKey-only peers.
+
+ADR-055's gateway may issue certificates and retain root authority material, but a managed formation runtime cannot treat those certificates as its admission boundary until this transport contract is implemented and tested end to end.
 
 ## Consequences
 

--- a/docs/adr/049-hive-mesh-extraction.md
+++ b/docs/adr/049-hive-mesh-extraction.md
@@ -5,7 +5,7 @@
 **Authors**: Kit Plummer, Claude  
 **Organization**: Defense Unicorns (https://defenseunicorns.com)  
 **Priority**: URGENT - Blocking for Defense Unicorns transition  
-**Relates To**: ADR-011 (Automerge + Iroh), ADR-032 (Pluggable Transport), ADR-039 (peat-btle), ADR-041 (Multi-Transport Embedded)
+**Relates To**: ADR-011 (Automerge + Iroh), ADR-032 (Pluggable Transport), ADR-039 (peat-btle), ADR-041 (Multi-Transport Embedded), ADR-075 (Top-Level Rust Facade)
 
 ---
 
@@ -314,18 +314,14 @@ Options:
 2. **MeshProvider moves to peat-mesh** - The trait is part of peat-mesh's public API
 3. **MeshProvider is a wrapper** - peat-protocol defines MeshProvider, which wraps peat-mesh internally
 
-*Recommendation*: Option 1 - MeshProvider trait stays in peat-protocol (it's the Peat-specific interface), peat-mesh implements it. This allows other implementations (Ditto, mock) to also implement MeshProvider.
+**Resolution (2026-07-21)**: The original Option 1 recommendation was rejected during extraction because it would require `peat-mesh` to depend on the higher-level `peat-protocol` crate. The implemented dependency direction is one-way:
 
-```rust
-// In peat-protocol
-pub trait MeshProvider { ... }
-
-// In peat-mesh
-impl MeshProvider for PeatMesh { ... }
-
-// In peat-mesh-ditto (if needed)
-impl MeshProvider for DittoMesh { ... }
+```text
+peat-protocol ──depends on──▶ peat-mesh
+peat-mesh     ──must not────▶ peat-protocol / peat-schema
 ```
+
+Protocol-specific provider traits and adapters remain in `peat-protocol` and wrap or consume the generic `peat-mesh` surface. The Phase 0 result (PR #622) removing all reverse dependencies is authoritative.
 
 #### Q5: Repository Structure
 
@@ -540,6 +536,24 @@ full = ["iroh", "ble"]
 
 ---
 
+## Consumer Dependency Rule (2026-07-21 Amendment)
+
+The extraction establishes the following consumer layers:
+
+```text
+peat-schema    Peat wire and domain types
+peat-mesh      Generic synchronization, transport, storage, and substrate security
+peat-protocol  Peat semantics; compatibility re-exports for mesh and schema
+peat           Canonical Rust facade and tested compatibility set (ADR-075)
+peat-node      Deployable single-formation runtime
+```
+
+General Rust integrations SHOULD use the top-level `peat` facade and its namespaced component exports. Specialized consumers MAY depend directly on the one component crate whose boundary they require. A consumer SHOULD NOT independently pin `peat-mesh`, `peat-schema`, and `peat-protocol`; `peat-protocol` retains its mesh/schema re-exports for compatibility, while ADR-075 makes `peat` the canonical new integration path. An operational consumer that does not require in-process Rust integration SHOULD prefer a versioned runtime service contract when one satisfies its durability and security requirements.
+
+The dependency direction remains strict: `peat-mesh` never imports protocol/schema semantics, and sibling application repositories do not become dependencies of `peat`, `peat-protocol`, or `peat-mesh`.
+
+The "zero Peat-specific semantics" boundary also applies to policy vocabulary. Generic certificate, formation-authentication, and transport primitives may live in `peat-mesh`; Peat-specific hierarchy, role policy, and domain-tier vocabulary belong in `peat-schema` or `peat-protocol`. Existing substrate types that mix generic certificate mechanics with domain-specific tier names require an ownership audit before that public surface is expanded.
+
 ## Consequences
 
 ### Positive
@@ -598,10 +612,11 @@ full = ["iroh", "ble"]
 | TBD | Repository structure | Currently monorepo workspace, separate repo planned |
 | TBD | Transport ownership | peat-mesh owns transport trait + Iroh default |
 | 2026-05-18 | Security primitives FIPS amendment (PR #870) | ChaCha20-Poly1305 superseded by AES-256-GCM in peat-mesh substrate per ADR-060 §5; X25519 flagged as marginal pending FIPS review. The 2026-02-11 Phase 5 row above is preserved as a historical record of what shipped; the FIPS amendment is the forward-looking decision. peat-mesh sibling-repo code changes tracked separately under the cross-repo workflow. |
+| 2026-07-21 | Codify consumer dependency rule and resolve Q4 | ADR-075 defines `peat` as the canonical Rust facade; specialized consumers may select one component boundary; `peat-mesh` has no reverse dependency on protocol/schema |
 
 ---
 
-**Last Updated**: 2026-05-18
+**Last Updated**: 2026-07-21
 **Status**: IMPLEMENTED — All 8 phases complete (PRs #622-#629)
 **Result**: 50,124 lines of standalone mesh code, 1,151 unit tests, zero peat-protocol/peat-schema dependencies
 **Next Action**: README, examples, crates.io publish, Collection convenience API

--- a/docs/adr/055-peat-gateway-enterprise-control-plane.md
+++ b/docs/adr/055-peat-gateway-enterprise-control-plane.md
@@ -4,21 +4,22 @@
 **Date**: 2026-03-10
 **Authors**: Kit Plummer
 **Organization**: (r)evolve - Revolve Team LLC (https://revolveteam.com)
-**Relates To**: ADR-043 (Consumer Interface Adapters), ADR-045 (Zarf/UDS Integration), ADR-048 (Membership Certificates), ADR-049 (Peat-Mesh Extraction), ADR-050 (SDK Integration), ADR-054 (UDS Registry Replication)
+**Relates To**: ADR-006 (Security Architecture), ADR-043 (Consumer Interface Adapters), ADR-045 (Zarf/UDS Integration), ADR-048 (Membership Certificates), ADR-049 (Peat-Mesh Extraction), ADR-050 (SDK Integration), ADR-054 (UDS Registry Replication), ADR-060 (Encryption Tiers), ADR-075 (Top-Level Rust Facade)
 
 **Amendments**:
 - **2026-05-08 — Amendment A: Full-duplex NATS flow.** Adds control-plane ingress (subscriber path) alongside the original CDC egress (publisher) treatment. NATS becomes a bidirectional channel; Kafka and Redis Streams remain egress-only. See "2a. Control-Plane Ingress (Amendment A — NATS)" below. Tracking: peat#839, peat-gateway#91, peat-gateway#94.
 - **2026-05-09 — Amendment B: Subject-schema clarification.** Supersedes Amendment A's two-pattern subject design (`{org}.ctl.>` + `{org}.{app}.ctl.>`), which JetStream rejects with error 10052 because the two patterns overlap (`{org}.ctl.ctl.<x>` matches both). Replaces them with a single per-org pattern `{org}.{app}.ctl.>` plus a reserved sentinel `app_id = "_org"` for org-level lifecycle events (e.g. `acme._org.ctl.formations.create`). The reservation is enforced at the tenant-manager layer — see "2a. Control-Plane Ingress" below for the revised tables. Tracking: peat#842, peat-gateway#91, peat-gateway#106.
+- **2026-07-21 — Amendment C: Control-plane / formation-runtime boundary.** Separates the enterprise control plane and authority boundary from formation-scoped mesh execution. `peat-gateway` retains tenancy, identity federation, authority-key custody, enrollment policy, CDC routing, and workload reconciliation; a formation-scoped `peat-node` owns Automerge/Iroh persistence, discovery, and sync. Direct `peat-mesh` use remains a supported transitional authority path until the managed-runtime service contract satisfies the migration gates below. Tracking: peat#1039.
 
 ---
 
 ## Executive Summary
 
-`peat-mesh-node` is a single-formation, single-authority mesh node for tactical edge deployment. Enterprise and cloud environments need a dedicated, horizontally scalable control plane — `peat-gateway` — providing multi-org tenancy, CDC to external event streams, IDAM/ICAM-federated enrollment, an admin UI, and first-class Zarf/UDS packaging for air-gapped deployment.
+`peat-node` is a single-formation mesh runtime for tactical edge and co-located application deployment. Enterprise and cloud environments need a dedicated, horizontally scalable control plane — `peat-gateway` — providing multi-org tenancy, CDC to external event streams, IDAM/ICAM-federated enrollment, an admin UI, and first-class Zarf/UDS packaging for air-gapped deployment.
 
 ## Context
 
-`peat-mesh-node` participates in one mesh, manages one certificate store, and exposes a broker API for local consumers. This is the right design for a tactical edge node, but enterprise deployments need:
+`peat-node` participates in one formation, owns an Automerge/Iroh runtime, and exposes a Connect/gRPC API for co-located consumers. This is the right design for a formation-scoped data plane, but enterprise deployments need:
 
 - **Multi-tenancy**: Multiple organizations sharing a gateway instance, each with independent formations (app IDs), isolated key material, and separate data paths.
 - **Change Data Capture (CDC)**: CRDT document mutations must flow to external event infrastructure — Kafka, NATS, Redis Streams — for downstream analytics, audit, and integration pipelines.
@@ -28,13 +29,13 @@
 
 **Amended 2026-05-08 (Amendment A)**: The gateway is also a *consumer* of control-plane events on NATS — formation lifecycle, peer enrollment requests, certificate revocations, and IdP claim refreshes can originate from external orchestration systems and arrive over the same broker the gateway publishes CDC events to. NATS therefore needs to be designed as a bidirectional integration, not a one-way sink.
 
-None of these belong in `peat-mesh-node` — they require a dedicated service.
+These enterprise concerns require a dedicated gateway service; they do not belong in the formation-scoped node runtime.
 
 ## Decision
 
 ### Introduce `peat-gateway`
 
-A new standalone repository (`defenseunicorns/peat-gateway`) that depends on `peat-mesh` as a library and provides the enterprise control plane layer. Same pattern as `peat-registry`.
+A new standalone repository (`defenseunicorns/peat-gateway`) provides the enterprise control plane layer. The current implementation consumes `peat-mesh` directly for genesis, certificate, document-observation, and broker contracts. Amendment C narrows the target boundary: direct library integration remains transitional for authority operations, while formation-scoped mesh execution moves behind a managed `peat-node` service contract.
 
 ### Tenancy Model
 
@@ -526,16 +527,58 @@ Base image: Chainguard `glibc-dynamic` for minimal CVE surface (consistent with 
 
 **Separate repo**: `defenseunicorns/peat-gateway`. The gateway has a fundamentally different dependency tree (rdkafka, OIDC client, SAML parser, Postgres driver, admin UI assets), release cycle, and deployment model from the mesh library. Same pattern as `peat-registry`.
 
-```toml
-[dependencies]
-peat-mesh = { version = "0.5", features = ["automerge-backend", "broker"] }
-```
+Dependency selection follows the boundary in Amendment C:
+
+- **Current / transitional authority path:** depend directly on the narrow `peat-mesh` security surface required for genesis and certificate operations.
+- **In-process Peat semantics:** prefer the top-level `peat` facade and its `peat::protocol` namespace per ADR-075. A specialized consumer MAY depend directly on `peat-protocol`, which retains compatibility re-exports of `peat-schema` and `peat-mesh`.
+- **Managed formation runtime:** depend on a published, versioned `peat-node` client/protobuf contract rather than composing another Automerge/Iroh runtime.
+- Consumers SHOULD NOT independently pin `peat-mesh`, `peat-schema`, and `peat-protocol`; general Rust integrations use the tested `peat` compatibility set, while specialized integrations select only the component boundary they require.
+
+### Amendment C: Control Plane and Formation Runtime Boundary
+
+The architecture above records the original in-process design. This amendment supersedes the parts that place formation-scoped Automerge/Iroh execution inside the gateway process. It does not change the gateway's enterprise responsibilities or move root authority material into the node runtime.
+
+#### Responsibility boundary
+
+| Component | Owns | Does not own |
+|---|---|---|
+| `peat-gateway` | Organizations, formation lifecycle, IDAM/ICAM policy, root authority and KMS custody, enrollment decisions, CDC routing, audit, admin APIs, runtime reconciliation | Automerge/Iroh composition after managed-runtime cutover; peer election or role-scoring loops |
+| Formation-scoped `peat-node` | One formation's document store, Iroh endpoint, peer discovery, reconnect, sync lifecycle, and blob distribution | Multi-org policy, root authority custody, enterprise identity decisions |
+| Optional per-node coordinator | Deterministic `peat-protocol` coordination such as election, role scoring, and formation gating | Central enterprise tenancy or cross-peer authoritative decisions |
+
+The gateway MAY reconcile and configure per-formation node workloads. It MUST NOT compute deterministic peer coordination centrally on behalf of the formation; coordination remains peer-equal and co-located with participating nodes.
+
+Root formation authority keys remain in the gateway/KMS trust boundary. A managed node receives only scoped participation and runtime material. The gateway MUST NOT place an unwrapped root authority key in a node data volume or node configuration.
+
+#### Runtime cardinality and ownership
+
+The baseline deployment assigns a dedicated node runtime to each active formation. A node process remains single-formation even when one gateway manages many formations. Deployments MAY run multiple formation participants for availability, but at most one gateway replica owns reconciliation and CDC cursor advancement for a formation at a time. Ownership uses a lease or equivalent fencing mechanism; duplicate observers must not produce uncoordinated cursor advancement.
+
+The gateway reconciles workloads through the deployment platform. It does not spawn child node processes or attempt to add containers dynamically to an existing gateway pod.
+
+#### Managed-runtime service contract
+
+Cutover from direct mesh execution is gated on a versioned contract that provides:
+
+1. **Reusable client artifact** — a published generated client or independently versioned protobuf package; consumers do not copy the node proto.
+2. **Compatibility negotiation** — API version, schema version, mesh/protocol compatibility, and capability reporting.
+3. **Authenticated control channel** — a permissioned Unix socket for strict co-location or mutually authenticated workload identity across pods, scoped to one formation.
+4. **Durable change feed** — an explicit snapshot boundary, opaque resume cursor, tombstone replay, stable event identity, and acknowledgment semantics compatible with at-least-once CDC.
+5. **Credential lifecycle** — scoped provisioning, rotation, revocation, drain, and deletion without exposing root authority material.
+6. **Runtime reconciliation** — stable identity, persistent storage, readiness, ownership fencing, restart recovery, and destructive-deletion semantics.
+7. **Security-model alignment** — a decided relationship between FormationKey admission and membership-certificate enforcement, as tracked by ADR-006, ADR-048, and ADR-060.
+
+`Subscribe`-style snapshot-plus-live delivery without a resume cursor is not sufficient for the gateway's at-least-once CDC guarantee. The CDC contract is intentionally producer-independent: an in-process `DocumentStore` may satisfy it during migration, and a managed node may satisfy it after the gates above are met.
+
+#### Migration state
+
+This amendment defines a target boundary, not an assertion that the cutover is implemented. Until all gates are met, the gateway MAY continue direct `peat-mesh` integration for authority and formation-observation behavior. Callers and operator documentation MUST distinguish the current in-process path from the managed-runtime target.
 
 ## Consequences
 
 ### Positive
 
-- Enterprise deployments get a production-ready control plane without forking `peat-mesh-node`
+- Enterprise deployments get a production-ready control plane without forking or overloading `peat-node`
 - Org-level multi-tenancy enables SaaS and shared-infrastructure deployments
 - CDC enables integration with existing enterprise data pipelines and SIEM/audit systems
 - IDAM integration removes the need for static enrollment tokens in production
@@ -552,6 +595,7 @@ peat-mesh = { version = "0.5", features = ["automerge-backend", "broker"] }
 - Admin UI is a separate frontend stack (SvelteKit) to maintain
 - Zarf packaging and UDS integration adds CI/CD complexity
 - *(Amendment A)* NATS surface is now bidirectional — per-org broker ACL discipline becomes a tenant isolation boundary, increasing operational and review burden
+- *(Amendment C)* Formation-scoped workloads add deployment, PVC, identity, version-compatibility, and lifecycle-reconciliation overhead
 
 ### Risks
 
@@ -560,6 +604,8 @@ peat-mesh = { version = "0.5", features = ["automerge-backend", "broker"] }
 - Multi-org key management (many root keypairs) increases blast radius of gateway compromise — mitigate with KMS delegation
 - Org isolation bugs could leak data across tenants — requires thorough integration testing
 - *(Amendment A)* Misconfigured per-org NATS ACLs could enable cross-tenant control-plane writes — mitigated by defence in depth (broker ACL + in-process `org_id` revalidation) and asserted in functional tests
+- *(Amendment C)* A node service boundary without authenticated RPC or durable replay would weaken tenant isolation and CDC guarantees; cutover is prohibited until the managed-runtime gates are met
+- *(Amendment C)* FormationKey admission and gateway-issued certificate claims are not yet one enforced authorization contract; ADR-006/048/060 must resolve the relationship before certificates are represented as a mesh admission boundary
 
 ## Implementation Phases
 

--- a/docs/adr/060-encryption-tiers-rest-and-transit.md
+++ b/docs/adr/060-encryption-tiers-rest-and-transit.md
@@ -1,9 +1,9 @@
 # ADR-060: Encryption Tiers — At-Rest and In-Transit Across the Peat Stack
 
-**Status**: Proposed
+**Status**: Proposed (membership-authentication boundary clarified 2026-07-21)
 **Date**: 2026-05-18
 **Authors**: Kit Plummer
-**Related**: ADR-006 (Security Architecture), ADR-016 (TTL and Data Lifecycle), ADR-034 (Deletion and Tombstones), ADR-042 (UDP Bypass), ADR-044 (E2E Encryption and Key Management), ADR-049 (peat-mesh Extraction)
+**Related**: ADR-006 (Security Architecture), ADR-016 (TTL and Data Lifecycle), ADR-034 (Deletion and Tombstones), ADR-042 (UDP Bypass), ADR-044 (E2E Encryption and Key Management), ADR-048 (Membership Certificates), ADR-049 (peat-mesh Extraction), ADR-055 (Peat Gateway)
 **Triggered by**: peat-node #55 (filtered observe), peat-mesh #124 (Cipher trait), cross-peer regression discovered while implementing the above
 
 ---
@@ -53,6 +53,14 @@ Adversaries this ADR addresses, with explicit naming:
 | **T6** | Malicious formation member with payload key (insider) | Fully authenticated, fully privileged. ADR-044's MLS / membership-cert work addresses this; out of scope here. |
 
 This ADR's primary contribution is making T3 and **T4** first-class. T4 in particular has been provided accidentally by the old peat-node envelope and would have been silently removed by the proposed peat-mesh #124 refactor. T4 is a real and load-bearing role for tactical deployments — observers, joint-operations partners, archival nodes — and the design must preserve it deliberately rather than by side effect.
+
+### Membership-authentication boundary (2026-07-21 clarification)
+
+T2, T4, and T6 above describe the currently deployed FormationKey gate: possession of the formation-wide secret is sufficient to pass the HMAC challenge. Membership certificates add individual identity, expiry, tier, permission, and revocation claims, but those claims are an authorization boundary only where the node runtime configures and enforces certificate validation.
+
+This ADR does not decide that enforcement protocol. A future certificate-enforced model must subdivide the threat model into at least: a FormationKey holder without a valid certificate, a valid certified member without the payload key, an expired or revoked member, and a certified member with the payload key. The key hierarchy and T3/T4 encryption conclusions remain valid, but FormationKey possession must not be treated as proof that gateway-issued certificate claims were evaluated.
+
+ADR-006 and ADR-048 own the follow-up admission decision; ADR-055 blocks managed-runtime cutover on that alignment.
 
 ---
 
@@ -735,6 +743,8 @@ The cross-repo amendments table above will be removed from this ADR once each ro
 ---
 
 ## Decision log
+
+**2026-07-21**: Clarified that T2, T4, and T6 describe the currently deployed FormationKey admission gate, not universal membership-certificate enforcement. Gateway-issued certificate claims become an authorization boundary only after ADR-006/048 define and node runtimes implement the transport-neutral presentation, proof-of-possession, expiry, and revocation contract required by ADR-055 Amendment C.
 
 **2026-05-18**: Initial draft. Substrate cipher (peat-mesh #124, already coded but not committed) repositioned as Phase A defense-in-depth, deriving its key from FormationKey via HKDF. New per-collection posture axis (`Plaintext` / `FieldValues` / `FullOpacity`) introduced as Phase B. Per-field encryption at the sidecar layer added as Phase B. Attachments deferred to a follow-up ADR. The Phase 2 peat-node working tree from the original "Path Z" approach is to be repurposed: keep the `DocumentStore` migration and the substrate `Cipher` trait, replace the sidecar-side `StoreCipher` with a field-level `FieldCipher`.
 


### PR DESCRIPTION
## Summary

- add ADR-055 Amendment C separating the gateway control plane and authority boundary from formation-scoped mesh execution
- define managed-runtime cutover gates for authenticated RPC, compatibility negotiation, durable CDC replay, credential lifecycle, and runtime ownership
- clarify across ADR-006, ADR-048, and ADR-060 that current FormationKey admission does not universally enforce gateway-issued certificate tier, permission, expiry, or revocation claims
- resolve ADR-049's stale reverse-dependency recommendation and align consumer guidance with ADR-075's top-level `peat` facade

## Why

`peat-gateway` currently composes selected `peat-mesh` contracts directly, while `peat-node` is now the deployable single-formation runtime. The ADRs did not distinguish the current direct path from a managed-runtime target, and they could be read as claiming certificate authorization that the current FormationKey-only node bootstrap does not universally enforce.

This PR documents the target boundary without claiming it is implemented. Root authority custody remains in the gateway/KMS boundary, peer coordination stays decentralized, and direct mesh integration remains allowed until every migration gate is satisfied.

## Scope

Documentation only. Follow-up changes in `peat-gateway` and `peat-node` require separate linked issues and PRs.

## Verification

- `git diff --check`
- `cargo check -p peat`
- changed-file set is limited to `docs/adr/`

Closes #1039