### PR TITLE
ci(qa-review): scope Codex token to reads

### DIFF
--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   issues: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   qa-review:

--- a/.github/workflows/qa-review.yml
+++ b/.github/workflows/qa-review.yml
@@ -188,6 +188,7 @@ jobs:
               --property="BindReadOnlyPaths=$codex_bin" \
               --property="BindReadOnlyPaths=$CODEX_HOME" \
               --property="BindReadOnlyPaths=$GITHUB_WORKSPACE" \
+              --property="BindPaths=$RUNNER_TEMP" \
               --property="ReadWritePaths=$RUNNER_TEMP" \
               --property="WorkingDirectory=$GITHUB_WORKSPACE" \
               --setenv="CODEX_HOME=$CODEX_HOME" \


### PR DESCRIPTION
## Summary
- scope the `GITHUB_TOKEN` exposed to Codex to read-only PR access
- retain the runner-local `peat-bot` credential solely for the controlled review-submission step

## Validation
- YAML parse
- `bash -n` on the QA step
- `git diff --check`
