### PR TITLE
chore: prepare 0.9.0-rc.33 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Sub-crates that stay internal (`peat-transport`, `peat-persistence`, `peat-ffi`,
 
 ## [Unreleased]
 
+## [0.9.0-rc.33] - 2026-08-04
+
+### Added
+
+- Re-export `peat-mesh 0.9.0-rc.61`, including opt-in grouped durable
+  commits across document keys with explicit queue-delay, entry-count, and
+  serialized-byte bounds. Immediate durability remains the default.
+
 ### Fixed
 
 - **FFI peer authentication uses one formation-auth protocol**
@@ -31,9 +39,10 @@ Sub-crates that stay internal (`peat-transport`, `peat-persistence`, `peat-ffi`,
 
 ### Pinned
 
-- Advance `peat-mesh` to `>=0.9.0-rc.59, <0.9.1` for the public canonical
-  acceptor API, and align peat-protocol's test-only Iroh pin to `1.0.2`.
-  Default feature selection is unchanged.
+- Advance `peat-mesh` to `>=0.9.0-rc.61, <0.9.1` for canonical formation
+  authentication, authenticated path replacement, enforced per-collection
+  coalescing deadlines, and grouped durable commits. Align peat-protocol's
+  test-only Iroh pin to `1.0.2`; default feature selection is unchanged.
 
 ## [0.9.0-rc.32] - 2026-08-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3988,7 +3988,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "peat"
-version = "0.9.0-rc.32"
+version = "0.9.0-rc.33"
 
 [[package]]
 name = "peat-btle"
@@ -4065,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "peat-mesh"
-version = "0.9.0-rc.60"
+version = "0.9.0-rc.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a58dbce91e4ede433f961d01ed0fe15c99635591854afc93b33a2ba32c8b0"
+checksum = "7cbd37c1134b78765934332aee72e43942e5d16aa92ba9b3676b275fd9680cb5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4089,6 +4089,7 @@ dependencies = [
  "mdns-sd",
  "negentropy",
  "p256",
+ "parking_lot",
  "peat-btle",
  "peat-lite",
  "postcard",
@@ -4111,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "peat-persistence"
-version = "0.9.0-rc.32"
+version = "0.9.0-rc.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4136,7 +4137,7 @@ dependencies = [
 
 [[package]]
 name = "peat-protocol"
-version = "0.9.0-rc.32"
+version = "0.9.0-rc.33"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4182,7 +4183,7 @@ dependencies = [
 
 [[package]]
 name = "peat-quickstart"
-version = "0.9.0-rc.32"
+version = "0.9.0-rc.33"
 dependencies = [
  "anyhow",
  "clap",
@@ -4198,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "peat-schema"
-version = "0.9.0-rc.32"
+version = "0.9.0-rc.33"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4215,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "peat-transport"
-version = "0.9.0-rc.32"
+version = "0.9.0-rc.33"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ exclude = ["examples/m5stack-core2-peat"]
 # for the resolution train.
 
 [workspace.package]
-version = "0.9.0-rc.32"
+version = "0.9.0-rc.33"
 edition = "2021"
 authors = ["Kit Plummer <kitplummer@defenseunicorns.com>"]
 license = "Apache-2.0"
@@ -294,10 +294,10 @@ repository = "https://github.com/defenseunicorns/peat"
 # `respond_to_formation_auth`. peat-protocol removes its incompatible
 # parallel handshake and calls both transport-owned halves directly.
 #
-# Floor bumped to rc.60 (2026-08-03) — peat-mesh#361 replaces aged
-# authenticated Iroh paths after interface changes and removes reconnect sinks
-# when translators are unregistered.
-peat-mesh = { version = ">=0.9.0-rc.60, <0.9.1", default-features = false }
+# Floor bumped to rc.61 (2026-08-04) — peat-mesh#363/#364 honor
+# collection-specific coalescing deadlines and add opt-in cross-key grouped
+# durable commits with bounded delay, entry count, and bytes.
+peat-mesh = { version = ">=0.9.0-rc.61, <0.9.1", default-features = false }
 
 # BLE mesh transport (ADR-039). `>=0.4.0, <0.4.1` matches peat-btle
 # 0.4.0 — the Slice-4.b release that deleted the `mesh-translator`

--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -165,9 +165,9 @@ uniffi = { version = "0.31", features = ["cli", "tokio"] }
 jni = "0.21"
 
 # Peat crates - no ditto-backend for Android cross-compilation
-peat-protocol = { path = "../peat-protocol", version = "=0.9.0-rc.32", default-features = false }
+peat-protocol = { path = "../peat-protocol", version = "=0.9.0-rc.33", default-features = false }
 # Proto-generated types (ADR-074: single source of truth for message schemas)
-peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.32" }
+peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.33" }
 # peat-mesh direct for blob storage (ADR-060). Pulls NetworkedIrohBlobStore
 # which we use behind the peat_mesh::storage::BlobStore trait.
 peat-mesh = { workspace = true, optional = true }

--- a/peat-protocol/Cargo.toml
+++ b/peat-protocol/Cargo.toml
@@ -23,7 +23,7 @@ categories = ["network-programming"]
 [dependencies]
 # Peat facade: peat-protocol re-exports peat-schema and peat-mesh so
 # downstream consumers can depend on peat-protocol alone.
-peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.32" }
+peat-schema = { path = "../peat-schema", version = "=0.9.0-rc.33" }
 peat-mesh = { workspace = true }
 
 tokio = { workspace = true }


### PR DESCRIPTION
## Summary

- bump the Peat workspace and published Rust crates to `0.9.0-rc.33`
- advance the public `peat-mesh` floor to `>=0.9.0-rc.61, <0.9.1`
- publish the merged canonical formation-auth cleanup plus the rc.61 coalescing-deadline and grouped-durability surface
- retain unchanged default features and exact internal schema/protocol release alignment
- update the lockfile to the registry-published rc.61 checksum and direct `parking_lot` dependency

## Verification

- `cargo check --workspace --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --workspace --exclude peat-ffi -- -D warnings`
- `cargo test --workspace --exclude peat-ffi --features automerge-backend` — 1,349 passed, 39 ignored
- lite feature-tree gate — no `automerge`, `redb`, `iroh-blobs`, or `negentropy`
- `peat-schema` publish dry-run — packaged and verified
- `peat-protocol` publish dry-run — packaged, then reached the expected pre-publication `peat-schema = 0.9.0-rc.33` index miss
- consumer-specific addition gate — empty

Tracks #1062. Keep the issue open through squash merge, signed tag creation, crates.io sparse-index confirmation, GitHub prerelease confirmation, and downstream peat-node coordination.

Dependencies: defenseunicorns/peat-mesh#365, defenseunicorns/peat-mesh#366, and published `peat-mesh v0.9.0-rc.61`.