### PR TITLE
fix(peat-ffi): align Android discovery JNI contract

### DIFF
--- a/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
+++ b/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
@@ -79,7 +79,7 @@ class PeatJniSurfaceTest {
             mkdirs()
         }
         storageDirs.add(storageDir)
-        val handle = PeatJni.createNodeJni(APP_ID, SHARED_KEY, storageDir.absolutePath)
+        val handle = PeatJni.createNodeJni(APP_ID, SHARED_KEY, storageDir.absolutePath, "127.0.0.1")
         assertTrue(
             "createNodeJni returned 0 for $label (check logcat for PeatRust tag)",
             handle != 0L,
@@ -179,6 +179,52 @@ class PeatJniSurfaceTest {
                 "Kotlin Any → JNI jobject → NewGlobalRef → ndk_context::initialize_android_context " +
                 "round-trip is intact",
             PeatJni.verifyAndroidContextJni(),
+        )
+    }
+
+    /**
+     * Pins a mobile-app consumer entrypoint: explicit logical identity plus
+     * a concrete Wi-Fi interface address. Successful creation proves the
+     * seven-argument Kotlin descriptor matches the registered Rust JNI method;
+     * the endpoint assertion proves `bindAddress` reaches the Iroh bind.
+     */
+    @Test
+    fun b_createNodeWithConfigJni_acceptsIdentityAndConcreteBindAddress() {
+        val cacheDir =
+            InstrumentationRegistry.getInstrumentation()
+                .targetContext
+                .cacheDir
+        val storageDir =
+            File(cacheDir, "peat-ffi-surface-config-${System.nanoTime()}").apply {
+                mkdirs()
+            }
+        storageDirs.add(storageDir)
+
+        val handle =
+            PeatJni.createNodeWithConfigJni(
+                APP_ID,
+                SHARED_KEY,
+                "android-surface-config",
+                storageDir.absolutePath,
+                false,
+                null,
+                "127.0.0.1",
+            )
+        assertTrue(
+            "createNodeWithConfigJni returned 0 for the seven-argument consumer path",
+            handle != 0L,
+        )
+        handles.add(handle)
+
+        val endpointAddress = PeatJni.endpointSocketAddrJni(handle)
+        assertNotNull("configured node must expose its bound endpoint", endpointAddress)
+        assertTrue(
+            "bindAddress must reach the Iroh endpoint; got $endpointAddress",
+            endpointAddress!!.startsWith("127.0.0.1:"),
+        )
+        assertTrue(
+            "explicit nodeId must produce a non-empty formation endpoint identity",
+            PeatJni.nodeIdJni(handle).isNotEmpty(),
         )
     }
 
@@ -441,10 +487,10 @@ class PeatJniSurfaceTest {
     @Suppress("unused")
     private fun peatJniRefTestJni(): String = PeatJni.testJni()
     @Suppress("unused")
-    private fun peatJniRefCreateNode(): Long = PeatJni.createNodeJni("a", "b", "c")
+    private fun peatJniRefCreateNode(): Long = PeatJni.createNodeJni("a", "b", "c", null)
     @Suppress("unused")
     private fun peatJniRefCreateNodeWithConfig(): Long =
-        PeatJni.createNodeWithConfigJni("a", "b", "c", false, null)
+        PeatJni.createNodeWithConfigJni("a", "b", null, "c", false, null, null)
     @Suppress("unused")
     private fun peatJniRefGetGlobalNodeHandle(): Long = PeatJni.getGlobalNodeHandleJni()
     @Suppress("unused")

--- a/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
+++ b/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
@@ -112,14 +112,17 @@ object PeatJni {
         appId: String,
         sharedKey: String,
         storagePath: String,
+        bindAddress: String?,
     ): Long
 
     @JvmStatic external fun createNodeWithConfigJni(
         appId: String,
         sharedKey: String,
+        nodeId: String?,
         storagePath: String,
         enableBle: Boolean,
         blePowerProfile: String?,
+        bindAddress: String?,
     ): Long
 
     @JvmStatic external fun getGlobalNodeHandleJni(): Long

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -7712,15 +7712,16 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeJni(
 /// [`Java_com_defenseunicorns_peat_PeatJni_setAndroidContextJni`] from
 /// `Application.onCreate()` BEFORE the first `createNode` call.
 ///
-/// **Identity derivation:** same as [`createNodeJni`] — the node's iroh
-/// EndpointId is derived from the `storagePath` basename. Renaming the
-/// storage directory rotates the EndpointId.
+/// **Identity derivation:** `nodeId`, when non-null and non-empty, is the
+/// formation-derived identity seed. Otherwise the storage-directory basename
+/// preserves the legacy identity.
 ///
 /// Kotlin signature:
 /// ```kotlin
 /// external fun createNodeWithConfigJni(
 ///     appId: String,
 ///     sharedKey: String,
+///     nodeId: String?,         // null/empty = storage-directory basename
 ///     storagePath: String,
 ///     enableBle: Boolean,
 ///     blePowerProfile: String?, // "aggressive", "balanced", or "low_power"
@@ -10613,7 +10614,8 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_nativeInit(
         #[cfg(feature = "sync")]
         NativeMethod {
             name: "createNodeJni".into(),
-            sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)J".into(),
+            sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)J"
+                .into(),
             fn_ptr: Java_com_defenseunicorns_peat_PeatJni_createNodeJni as *mut c_void,
         },
         #[cfg(feature = "sync")]
@@ -11257,7 +11259,8 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
                 #[cfg(feature = "sync")]
                 NativeMethod {
                     name: "createNodeJni".into(),
-                    sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)J".into(),
+                    sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)J"
+                        .into(),
                     fn_ptr: Java_com_defenseunicorns_peat_PeatJni_createNodeJni as *mut c_void,
                 },
                 #[cfg(feature = "sync")]


### PR DESCRIPTION
## Summary
- align `createNodeJni` native registration with its four-argument Kotlin/Rust ABI
- expose the already-implemented `nodeId` and `bindAddress` arguments in the canonical Android wrapper
- exercise both node-creation entrypoints with concrete bind addresses at the Android JNI surface tier

## Verification
- `cargo test -p peat-ffi --features sync --test jni_wrapper_integration -- --nocapture`
- `cargo test --workspace`
- `cargo build`
- `cd peat-ffi/android && ./gradlew assembleDebug assembleAndroidTest`
- `cargo fmt --all --check`

`cargo clippy --workspace --all-targets -- -D warnings` remains blocked by existing peat-ffi warnings: deprecated Track fields, `CallStatus::new` without `Default`, and `unwrap_or_else(Automerge::new)`.

Supports #1004. Do not close it until the same-LAN Android↔desktop discovery and bidirectional Automerge acceptance test passes.

Consumer follow-up: defenseunicorns/peat-atak-plugin#38.