### PR TITLE
feat(peat-ffi): expose canonical Android callback listeners

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -92,8 +92,24 @@ jobs:
         env:
           CC: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/${{ matrix.cc }}
           AR: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
+          LLVM_NM: ${{ steps.setup-ndk.outputs.ndk-path }}/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-nm
         run: |
-          cargo build -p peat-ffi --release --target ${{ matrix.target }}
+          set -euo pipefail
+          cargo build -p peat-ffi --release \
+            --features sync,bluetooth,lite-bridge \
+            --target ${{ matrix.target }}
+
+          LIBRARY="target/${{ matrix.target }}/release/libpeat_ffi.so"
+          for symbol in \
+            Java_com_defenseunicorns_peat_PeatJni_ingestInboundFrameJni \
+            Java_com_defenseunicorns_peat_PeatJni_ingestInboundLiteFrameJni \
+            Java_com_defenseunicorns_peat_PeatJni_subscribeOutboundFramesJni \
+            Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentChangesJni; do
+            if ! "$LLVM_NM" --defined-only "$LIBRARY" | grep -F "$symbol" >/dev/null; then
+              echo "::error::Android library is missing required JNI symbol: $symbol"
+              exit 1
+            fi
+          done
 
       - name: Upload native library
         uses: actions/upload-artifact@v4
@@ -111,7 +127,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler mold
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          protobuf-compiler mold clang libdbus-1-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -122,7 +140,9 @@ jobs:
           key: bindings
 
       - name: Build peat-ffi (host)
-        run: cargo build -p peat-ffi --release
+        run: >-
+          cargo build -p peat-ffi --release
+          --features sync,bluetooth,lite-bridge
 
       - name: Generate Kotlin bindings
         run: |
@@ -156,7 +176,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler mold
+        run: >-
+          sudo apt-get update && sudo apt-get install -y
+          protobuf-compiler mold clang libdbus-1-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/peat-ffi/android/build.gradle.kts
+++ b/peat-ffi/android/build.gradle.kts
@@ -50,7 +50,12 @@ group = "com.defenseunicorns"
 // 0.1.7 (was 0.1.6): decodes canonical nested and sidecar-compatible Track
 // documents without changing the published FFI surface. Ships peat-ffi
 // 0.2.15. See peat#1067 / peat#1068; publication is tracked through peat#1069.
-version = "0.1.7"
+//
+// 0.1.8 (was 0.1.7): additive Android callback APIs. Packages the canonical
+// OutboundFrameListener and DocumentChangeListener contracts and registers
+// their direct-JNI subscribe/unsubscribe methods so plugin-host consumers can
+// send transport frames and receive synchronized documents without polling.
+version = "0.1.8"
 
 android {
     namespace = "com.defenseunicorns.peat.ffi"

--- a/peat-ffi/android/consumer-rules.pro
+++ b/peat-ffi/android/consumer-rules.pro
@@ -1,0 +1,5 @@
+# JNI resolves this interface and callback method by their binary names.
+-keep interface com.defenseunicorns.peat.OutboundFrameListener { *; }
+-keepclassmembers class * implements com.defenseunicorns.peat.OutboundFrameListener {
+    public void onFrame(java.lang.String, java.lang.String, byte[]);
+}

--- a/peat-ffi/android/consumer-rules.pro
+++ b/peat-ffi/android/consumer-rules.pro
@@ -3,3 +3,8 @@
 -keepclassmembers class * implements com.defenseunicorns.peat.OutboundFrameListener {
     public void onFrame(java.lang.String, java.lang.String, byte[]);
 }
+-keep interface com.defenseunicorns.peat.DocumentChangeListener { *; }
+-keepclassmembers class * implements com.defenseunicorns.peat.DocumentChangeListener {
+    public void onChange(java.lang.String, java.lang.String);
+    public void onError(java.lang.String);
+}

--- a/peat-ffi/android/proguard-rules.pro
+++ b/peat-ffi/android/proguard-rules.pro
@@ -1,0 +1,2 @@
+# Library minification is disabled. Consumer callback rules live in
+# consumer-rules.pro and are applied by the consuming Android application.

--- a/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
+++ b/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
@@ -3,6 +3,9 @@ package com.defenseunicorns.peat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
@@ -59,6 +62,11 @@ class PeatJniSurfaceTest {
 
     @After
     fun teardown() {
+        try {
+            PeatJni.unsubscribeDocumentChangesJni()
+        } catch (t: Throwable) {
+            // Best-effort cleanup; don't mask test failures.
+        }
         handles.forEach { handle ->
             try {
                 PeatJni.freeNodeJni(handle)
@@ -409,6 +417,71 @@ class PeatJniSurfaceTest {
     }
 
     /**
+     * Locks the direct-JNI document notification contract into the AAR. This
+     * proves both RegisterNatives descriptors resolve and that a committed
+     * local document reaches the packaged listener on Rust's runtime thread.
+     */
+    @Test
+    fun documentChangeSubscription_registered_andDeliversCommittedKey() {
+        val invalidListener =
+            object : DocumentChangeListener {
+                override fun onChange(collection: String, docId: String) {
+                    fail("handle-0 subscription must not deliver document changes")
+                }
+
+                override fun onError(message: String) {
+                    fail("handle-0 subscription must not deliver errors: $message")
+                }
+            }
+        assertEquals(
+            "subscribeDocumentChangesJni(handle=0) must return false",
+            false,
+            PeatJni.subscribeDocumentChangesJni(0L, invalidListener),
+        )
+        PeatJni.unsubscribeDocumentChangesJni()
+
+        val handle = createNode("document-change")
+        assertTrue("startSyncJni must succeed", PeatJni.startSyncJni(handle))
+        val delivered = CountDownLatch(1)
+        val receivedKey = AtomicReference<Pair<String, String>>()
+        val callbackError = AtomicReference<String>()
+        val listener =
+            object : DocumentChangeListener {
+                override fun onChange(collection: String, docId: String) {
+                    receivedKey.set(collection to docId)
+                    delivered.countDown()
+                }
+
+                override fun onError(message: String) {
+                    callbackError.set(message)
+                    delivered.countDown()
+                }
+            }
+        assertTrue(
+            "valid node must accept document-change subscription",
+            PeatJni.subscribeDocumentChangesJni(handle, listener),
+        )
+
+        val collection = "surface-documents"
+        val documentId = "callback-proof"
+        assertEquals(
+            documentId,
+            PeatJni.publishDocumentJni(
+                handle,
+                collection,
+                """{"id":"$documentId","value":"proof"}""",
+            ),
+        )
+        assertTrue(
+            "document-change callback was not delivered within 5 seconds; error=${callbackError.get()}",
+            delivered.await(5, TimeUnit.SECONDS),
+        )
+        assertNull("document-change callback reported an error", callbackError.get())
+        assertEquals(collection to documentId, receivedKey.get())
+        PeatJni.unsubscribeDocumentChangesJni()
+    }
+
+    /**
      * peat#886 sanity check: the canonical PeatJni.kt shipped in
      * the AAR exposes every method this test suite — and any
      * consumer — calls. If a future refactor renames or removes
@@ -418,9 +491,8 @@ class PeatJniSurfaceTest {
      * Coverage spans the entire PeatJni surface (lifecycle, peer
      * state, sync, generic doc I/O, typed-collection accessors,
      * blob transfer, BLE state, and the test-only fault injector).
-     * Document-change subscription remains outside the canonical class until
-     * its listener is packaged. Outbound-frame subscription is canonical and
-     * therefore appears here.
+     * Both document-change and outbound-frame subscriptions are canonical and
+     * therefore appear here.
      *
      * The test body is a no-op; the value is in the references.
      */
@@ -452,6 +524,8 @@ class PeatJniSurfaceTest {
             ::peatJniRefPublishDocument,
             ::peatJniRefPublishDocumentWithOrigin,
             ::peatJniRefGetDocument,
+            ::peatJniRefSubscribeDocumentChanges,
+            ::peatJniRefUnsubscribeDocumentChanges,
             // Typed collection accessors
             ::peatJniRefGetCells,
             ::peatJniRefGetTracks,
@@ -481,10 +555,10 @@ class PeatJniSurfaceTest {
             // Test-only fault injection
             ::peatJniRefForceStoreError,
         )
-        // 42 PeatJni methods total. If this number changes, the
+        // 44 PeatJni methods total. If this number changes, the
         // count below must change too — and the new method needs
         // its own peatJniRef* shim added above.
-        assertEquals(42, refs.size)
+        assertEquals(44, refs.size)
     }
 
     // -- Reference shims --------------------------------------------------
@@ -541,6 +615,12 @@ class PeatJniSurfaceTest {
     @Suppress("unused")
     private fun peatJniRefGetDocument(h: Long, c: String, d: String): String? =
         PeatJni.getDocumentJni(h, c, d)
+    @Suppress("unused")
+    private fun peatJniRefSubscribeDocumentChanges(h: Long, l: DocumentChangeListener): Boolean =
+        PeatJni.subscribeDocumentChangesJni(h, l)
+    @Suppress("unused")
+    private fun peatJniRefUnsubscribeDocumentChanges() =
+        PeatJni.unsubscribeDocumentChangesJni()
 
     // Typed collection accessors
     @Suppress("unused")

--- a/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
+++ b/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
@@ -366,9 +366,10 @@ class PeatJniSurfaceTest {
     }
 
     /**
-     * peat#978 surface gate: the three JNI entry points added for the
+     * peat#978 / peat#1082 surface gate: the JNI entry points added for the
      * BLE doc-sync fix — `clearGlobalNodeHandleJni`, `ingestInboundFrameJni`,
-     * `ingestInboundLiteFrameJni` — must be REGISTERED (RegisterNatives) so
+     * `ingestInboundLiteFrameJni`, and the outbound-frame subscription — must
+     * be REGISTERED (RegisterNatives) so
      * the AAR's matching `external fun` declarations resolve. A missing
      * registration surfaces here as `UnsatisfiedLinkError` at AAR-test time,
      * not as a downstream consumer link failure.
@@ -378,6 +379,8 @@ class PeatJniSurfaceTest {
      *  - `ingestInbound{,Lite}FrameJni(0, ..)` returns null via the handle-0
      *    guard — confirming String/ByteArray marshalling + the early return
      *    (a null `Arc::from_raw(0)` would otherwise be UB).
+     *  - `subscribeOutboundFramesJni(0, ..)` returns false and unsubscribe is
+     *    an idempotent no-op, proving the canonical listener descriptor links.
      */
     @Test
     fun bleIngestAndClearGlobalHandle_registered_andGuardHandleZero() {
@@ -393,6 +396,16 @@ class PeatJniSurfaceTest {
             "ingestInboundLiteFrameJni(handle=0) must return null via the handle-0 guard",
             PeatJni.ingestInboundLiteFrameJni(0L, "demo", frame),
         )
+
+        val listener = OutboundFrameListener { _, _, _ ->
+            throw AssertionError("handle-0 subscription must never invoke the listener")
+        }
+        assertEquals(
+            "subscribeOutboundFramesJni(handle=0) must return false",
+            false,
+            PeatJni.subscribeOutboundFramesJni(0L, listener),
+        )
+        PeatJni.unsubscribeOutboundFramesJni(0L)
     }
 
     /**
@@ -405,10 +418,9 @@ class PeatJniSurfaceTest {
      * Coverage spans the entire PeatJni surface (lifecycle, peer
      * state, sync, generic doc I/O, typed-collection accessors,
      * blob transfer, BLE state, and the test-only fault injector).
-     * Methods that take consumer-supplied listener interfaces
-     * (subscribeDocumentChangesJni / subscribeOutboundFramesJni
-     * and their unsubscribe pairs) are declared outside this object
-     * per the doc-comment in PeatJni.kt and don't appear here.
+     * Document-change subscription remains outside the canonical class until
+     * its listener is packaged. Outbound-frame subscription is canonical and
+     * therefore appears here.
      *
      * The test body is a no-op; the value is in the references.
      */
@@ -451,6 +463,8 @@ class PeatJniSurfaceTest {
             ::peatJniRefIngestPosition,
             ::peatJniRefIngestInboundFrame,
             ::peatJniRefIngestInboundLiteFrame,
+            ::peatJniRefSubscribeOutboundFrames,
+            ::peatJniRefUnsubscribeOutboundFrames,
             // Blob transfer
             ::peatJniRefEnableBlobTransfer,
             ::peatJniRefBlobAddPeer,
@@ -467,10 +481,10 @@ class PeatJniSurfaceTest {
             // Test-only fault injection
             ::peatJniRefForceStoreError,
         )
-        // 40 PeatJni methods total. If this number changes, the
+        // 42 PeatJni methods total. If this number changes, the
         // count below must change too — and the new method needs
         // its own peatJniRef* shim added above.
-        assertEquals(40, refs.size)
+        assertEquals(42, refs.size)
     }
 
     // -- Reference shims --------------------------------------------------
@@ -554,6 +568,12 @@ class PeatJniSurfaceTest {
     @Suppress("unused")
     private fun peatJniRefIngestInboundLiteFrame(h: Long, c: String, b: ByteArray): String? =
         PeatJni.ingestInboundLiteFrameJni(h, c, b)
+    @Suppress("unused")
+    private fun peatJniRefSubscribeOutboundFrames(h: Long, l: OutboundFrameListener): Boolean =
+        PeatJni.subscribeOutboundFramesJni(h, l)
+    @Suppress("unused")
+    private fun peatJniRefUnsubscribeOutboundFrames(h: Long) =
+        PeatJni.unsubscribeOutboundFramesJni(h)
 
     // Blob transfer
     @Suppress("unused")

--- a/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
+++ b/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
@@ -5,9 +5,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import java.io.File
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
@@ -478,6 +480,68 @@ class PeatJniSurfaceTest {
         )
         assertNull("document-change callback reported an error", callbackError.get())
         assertEquals(collection to documentId, receivedKey.get())
+        PeatJni.unsubscribeDocumentChangesJni()
+    }
+
+    /** A replacement must own the sole observer task and callback target. */
+    @Test
+    fun documentChangeSubscription_replacementDoesNotDuplicateCallbacks() {
+        val handle = createNode("document-change-replacement")
+        assertTrue("startSyncJni must succeed", PeatJni.startSyncJni(handle))
+
+        val collection = "surface-replacement"
+        val documentId = "replacement-proof"
+        val firstCallbacks = AtomicInteger()
+        val secondCallbacks = AtomicInteger()
+        val delivered = CountDownLatch(1)
+        val duplicate = CountDownLatch(2)
+        val callbackError = AtomicReference<String>()
+
+        val firstListener =
+            object : DocumentChangeListener {
+                override fun onChange(collection: String, docId: String) {
+                    if (collection == "surface-replacement" && docId == "replacement-proof") {
+                        firstCallbacks.incrementAndGet()
+                    }
+                }
+
+                override fun onError(message: String) {
+                    callbackError.compareAndSet(null, "first listener: $message")
+                    delivered.countDown()
+                }
+            }
+        val replacementListener =
+            object : DocumentChangeListener {
+                override fun onChange(collection: String, docId: String) {
+                    if (collection == "surface-replacement" && docId == "replacement-proof") {
+                        secondCallbacks.incrementAndGet()
+                        delivered.countDown()
+                        duplicate.countDown()
+                    }
+                }
+
+                override fun onError(message: String) {
+                    callbackError.compareAndSet(null, "replacement listener: $message")
+                    delivered.countDown()
+                }
+            }
+
+        assertTrue(PeatJni.subscribeDocumentChangesJni(handle, firstListener))
+        assertTrue(PeatJni.subscribeDocumentChangesJni(handle, replacementListener))
+        assertEquals(
+            documentId,
+            PeatJni.publishDocumentJni(
+                handle,
+                collection,
+                """{"id":"$documentId","value":"replacement"}""",
+            ),
+        )
+
+        assertTrue("replacement listener did not receive the document", delivered.await(5, TimeUnit.SECONDS))
+        assertNull("document-change callback reported an error", callbackError.get())
+        assertFalse("replacement delivered the same document twice", duplicate.await(500, TimeUnit.MILLISECONDS))
+        assertEquals("replaced listener must not receive the document", 0, firstCallbacks.get())
+        assertEquals("replacement listener must receive exactly once", 1, secondCallbacks.get())
         PeatJni.unsubscribeDocumentChangesJni()
     }
 

--- a/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/DocumentChangeListener.kt
+++ b/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/DocumentChangeListener.kt
@@ -1,0 +1,18 @@
+package com.defenseunicorns.peat
+
+import androidx.annotation.Keep
+
+/**
+ * Receives committed PEAT document changes from the native store.
+ *
+ * Callbacks run on a Rust runtime thread. Implementations must move Android UI
+ * or ATAK dispatcher work onto the appropriate host thread. A notification is
+ * only a key; consumers read the current document through
+ * [PeatJni.getDocumentJni].
+ */
+@Keep
+interface DocumentChangeListener {
+    fun onChange(collection: String, docId: String)
+
+    fun onError(message: String)
+}

--- a/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/OutboundFrameListener.kt
+++ b/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/OutboundFrameListener.kt
@@ -1,0 +1,16 @@
+package com.defenseunicorns.peat
+
+import androidx.annotation.Keep
+
+/**
+ * Receives Rust-encoded outbound frames from the canonical PEAT transport
+ * fan-out. Callbacks run on a Rust runtime thread; implementations must hand
+ * work to their own executor before touching Android radio or UI state.
+ *
+ * The byte payload is opaque to Kotlin. Protocol semantics, serialization,
+ * authentication, deduplication, and relay behavior remain Rust-owned.
+ */
+@Keep
+fun interface OutboundFrameListener {
+    fun onFrame(transportId: String, collection: String, bytes: ByteArray)
+}

--- a/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
+++ b/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
@@ -24,9 +24,9 @@ import androidx.annotation.VisibleForTesting
  * methods on the singleton, and `RegisterNatives` aborts with
  * "jclass has wrong type" SIGABRT at library load.
  *
- * The outbound-frame subscription and its listener are canonical AAR
- * surfaces as of peat#1082. Document-change subscription remains outside
- * this class until its listener contract is packaged the same way.
+ * The outbound-frame and document-change subscriptions and their listeners
+ * are canonical AAR surfaces as of peat#1082 and the follow-up Android receive
+ * integration.
  */
 object PeatJni {
     init {
@@ -209,6 +209,18 @@ object PeatJni {
         collection: String,
         docId: String,
     ): String?
+
+    /**
+     * Subscribe to committed document keys. A second subscription replaces
+     * the first. Callbacks run on PEAT's Rust runtime thread.
+     */
+    @JvmStatic external fun subscribeDocumentChangesJni(
+        handle: Long,
+        listener: DocumentChangeListener,
+    ): Boolean
+
+    /** Stop document-change delivery. Safe to call repeatedly. */
+    @JvmStatic external fun unsubscribeDocumentChangesJni()
 
     // -- Typed collection accessors (CoT-style schema; ADR-049) ------------
 

--- a/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
+++ b/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
@@ -24,13 +24,9 @@ import androidx.annotation.VisibleForTesting
  * methods on the singleton, and `RegisterNatives` aborts with
  * "jclass has wrong type" SIGABRT at library load.
  *
- * Subscription methods (subscribeDocumentChangesJni,
- * subscribeOutboundFramesJni, and their unsubscribe pairs) are NOT
- * declared here because they take consumer-supplied listener
- * interfaces (`DocumentChangeListener`, `OutboundFrameListener`).
- * Consumers that use them declare those externs locally alongside
- * their listener implementations — same as the pre-0.1.2 pattern
- * for those specific methods.
+ * The outbound-frame subscription and its listener are canonical AAR
+ * surfaces as of peat#1082. Document-change subscription remains outside
+ * this class until its listener contract is packaged the same way.
  */
 object PeatJni {
     init {
@@ -249,6 +245,20 @@ object PeatJni {
         collection: String,
         envelopeBytes: ByteArray,
     ): String?
+
+    /**
+     * Subscribe to Rust-encoded outbound frames. A second subscription swaps
+     * the listener without rebuilding the underlying fan-out.
+     *
+     * Call [unsubscribeOutboundFramesJni] before releasing the node handle.
+     */
+    @JvmStatic external fun subscribeOutboundFramesJni(
+        handle: Long,
+        listener: OutboundFrameListener,
+    ): Boolean
+
+    /** Stop outbound-frame delivery. Safe to call repeatedly. */
+    @JvmStatic external fun unsubscribeOutboundFramesJni(handle: Long)
 
     // -- Blob transfer -----------------------------------------------------
 

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -4314,6 +4314,34 @@ mod tests {
             }
         }
 
+        /// The direct-JNI callback is an application-observer surface, not a
+        /// sync-out trigger. It must therefore receive remote-origin writes;
+        /// subscribing to the legacy local-only channel would silently drop
+        /// every document delivered by a peer.
+        #[test]
+        fn jni_document_change_receiver_includes_remote_writes() {
+            let tmp = tempfile::tempdir().unwrap();
+            let node = create_node(test_cfg(tmp.path().to_str().unwrap())).expect("create_node");
+            let mut receiver = subscribe_document_changes_for_jni(&node.store);
+
+            node.store
+                .put_with_origin(
+                    "test:remote-doc",
+                    &automerge::Automerge::new(),
+                    _PeatMeshChangeOrigin::Remote("peerhex".to_string()),
+                )
+                .expect("put remote-origin document");
+
+            let key = node
+                .runtime
+                .block_on(async {
+                    tokio::time::timeout(std::time::Duration::from_secs(2), receiver.recv()).await
+                })
+                .expect("remote observer notification timeout")
+                .expect("remote observer channel closed");
+            assert_eq!(key, "test:remote-doc");
+        }
+
         /// Surface-tier round-trip for `roster_upsert`, which takes a
         /// `RosterEntry` *by argument* — the encode direction the
         /// `roster_remember` round-trip (a `PeerInfo` arg) never exercises.
@@ -10107,7 +10135,11 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentCh
     std::mem::forget(node);
 
     runtime.spawn(async move {
-        let mut rx = store.subscribe_to_changes();
+        // Consumer callbacks must observe both local writes and documents
+        // applied from peers. The legacy change channel is intentionally
+        // local-only to prevent sync echo; the observer channel is the
+        // persisted, all-origin notification surface.
+        let mut rx = subscribe_document_changes_for_jni(&store);
         while DOCUMENT_SUBSCRIPTION_ACTIVE.load(Ordering::SeqCst) {
             tokio::select! {
                 result = rx.recv() => {
@@ -10143,6 +10175,13 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentCh
     });
 
     1 // JNI_TRUE
+}
+
+#[cfg(feature = "sync")]
+fn subscribe_document_changes_for_jni(
+    store: &AutomergeStore,
+) -> tokio::sync::broadcast::Receiver<String> {
+    store.subscribe_to_observer_changes()
 }
 
 /// JNI: Unsubscribe from document change notifications

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -11444,44 +11444,22 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_nativeInit(
                 .into(),
             fn_ptr: Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfigJni as *mut c_void,
         },
-        // peat#925: the four subscription methods
-        // (subscribe/unsubscribeDocumentChangesJni,
-        // subscribe/unsubscribeOutboundFramesJni) are intentionally NOT
-        // registered via nativeInit because their signatures reference
-        // consumer-supplied listener interfaces
-        // (`com/defenseunicorns/peat/DocumentChangeListener`,
-        // `com/defenseunicorns/peat/OutboundFrameListener`) that don't
-        // exist in peat-ffi's own `PeatJni.kt` — see the comment block at
-        // peat-ffi/android/src/main/kotlin/.../PeatJni.kt:27-34 which
-        // documents the "consumers declare these externs locally" pattern.
-        //
-        // The Rust extern fns `Java_com_defenseunicorns_peat_PeatJni_*`
-        // are still exported and reachable via JNI's auto-lookup-by-name
-        // convention: any consumer (peat-atak-plugin, downstream apps)
-        // that declares `external fun subscribeDocumentChangesJni(...)`
-        // alongside its `DocumentChangeListener` interface gets the
-        // function resolved via dlsym at first call.
-        //
-        // Why these were here: ADR-059 Slice 1.b's outbound-frame
-        // wiring was developed against a peat-atak-plugin build that
-        // DID declare the listener interfaces; the `NativeMethod`
-        // entries were copy-pasted from that build's lockstep
-        // registration table without re-checking peat-ffi's own
-        // PeatJni.kt surface.
-        //
-        // What went wrong: `JNI_OnLoad → nativeInit → RegisterNatives`
-        // tries to bind every entry to a corresponding member on
-        // `com.defenseunicorns.peat.PeatJni`. The DocumentChangeListener
-        // / OutboundFrameListener signatures reference Kotlin classes
-        // that don't exist. CheckJNI (active on debug-instrumented
-        // builds, which is the AndroidJUnit harness configuration on
-        // the Galaxy Tab A9+ CI runner) aborts the process on
-        // registration mismatch — `Fatal signal 6 (SIGABRT), code -1
-        // (SI_QUEUE)` in tid == JUnit-runner-tid, ~12ms after
-        // `System.loadLibrary("peat_ffi")` returns. The post-
-        // IrohTransport timing of the abort in earlier logcats was
-        // misleading — the actual fault is during `System.loadLibrary`
-        // which the test harness only logs after the abort propagates.
+        #[cfg(all(feature = "sync", feature = "bluetooth"))]
+        NativeMethod {
+            name: "subscribeOutboundFramesJni".into(),
+            sig: "(JLcom/defenseunicorns/peat/OutboundFrameListener;)Z".into(),
+            fn_ptr: Java_com_defenseunicorns_peat_PeatJni_subscribeOutboundFramesJni
+                as *mut c_void,
+        },
+        #[cfg(all(feature = "sync", feature = "bluetooth"))]
+        NativeMethod {
+            name: "unsubscribeOutboundFramesJni".into(),
+            sig: "(J)V".into(),
+            fn_ptr: Java_com_defenseunicorns_peat_PeatJni_unsubscribeOutboundFramesJni
+                as *mut c_void,
+        },
+        // Document-change subscribe/unsubscribe remain intentionally omitted:
+        // their listener is not yet a canonical class in the Android AAR.
         // Blob transfer (ADR-060)
         #[cfg(feature = "sync")]
         NativeMethod {
@@ -12098,6 +12076,20 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
                     sig: "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)J"
                         .into(),
                     fn_ptr: Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfigJni
+                        as *mut c_void,
+                },
+                #[cfg(all(feature = "sync", feature = "bluetooth"))]
+                NativeMethod {
+                    name: "subscribeOutboundFramesJni".into(),
+                    sig: "(JLcom/defenseunicorns/peat/OutboundFrameListener;)Z".into(),
+                    fn_ptr: Java_com_defenseunicorns_peat_PeatJni_subscribeOutboundFramesJni
+                        as *mut c_void,
+                },
+                #[cfg(all(feature = "sync", feature = "bluetooth"))]
+                NativeMethod {
+                    name: "unsubscribeOutboundFramesJni".into(),
+                    sig: "(J)V".into(),
+                    fn_ptr: Java_com_defenseunicorns_peat_PeatJni_unsubscribeOutboundFramesJni
                         as *mut c_void,
                 },
                 #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -11458,8 +11458,20 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_nativeInit(
             fn_ptr: Java_com_defenseunicorns_peat_PeatJni_unsubscribeOutboundFramesJni
                 as *mut c_void,
         },
-        // Document-change subscribe/unsubscribe remain intentionally omitted:
-        // their listener is not yet a canonical class in the Android AAR.
+        #[cfg(feature = "sync")]
+        NativeMethod {
+            name: "subscribeDocumentChangesJni".into(),
+            sig: "(JLcom/defenseunicorns/peat/DocumentChangeListener;)Z".into(),
+            fn_ptr: Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentChangesJni
+                as *mut c_void,
+        },
+        #[cfg(feature = "sync")]
+        NativeMethod {
+            name: "unsubscribeDocumentChangesJni".into(),
+            sig: "()V".into(),
+            fn_ptr: Java_com_defenseunicorns_peat_PeatJni_unsubscribeDocumentChangesJni
+                as *mut c_void,
+        },
         // Blob transfer (ADR-060)
         #[cfg(feature = "sync")]
         NativeMethod {
@@ -12090,6 +12102,20 @@ pub extern "C" fn JNI_OnLoad(vm: *mut JavaVM, _reserved: *mut c_void) -> jint {
                     name: "unsubscribeOutboundFramesJni".into(),
                     sig: "(J)V".into(),
                     fn_ptr: Java_com_defenseunicorns_peat_PeatJni_unsubscribeOutboundFramesJni
+                        as *mut c_void,
+                },
+                #[cfg(feature = "sync")]
+                NativeMethod {
+                    name: "subscribeDocumentChangesJni".into(),
+                    sig: "(JLcom/defenseunicorns/peat/DocumentChangeListener;)Z".into(),
+                    fn_ptr: Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentChangesJni
+                        as *mut c_void,
+                },
+                #[cfg(feature = "sync")]
+                NativeMethod {
+                    name: "unsubscribeDocumentChangesJni".into(),
+                    sig: "()V".into(),
+                    fn_ptr: Java_com_defenseunicorns_peat_PeatJni_unsubscribeDocumentChangesJni
                         as *mut c_void,
                 },
                 #[cfg(all(feature = "sync", feature = "bluetooth", target_os = "android"))]

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -44,19 +44,86 @@ static PEER_EVENT_MANAGER_CLASS: LazyLock<Mutex<Option<GlobalRef>>> =
 
 // Global reference to the currently-registered DocumentChangeListener instance.
 // Only one subscription is supported at a time (mirrors UniFFI's
-// PeatNode::subscribe constraint). Held as a GlobalRef so it survives across
-// JNI thread attaches.
+// PeatNode::subscribe constraint). The generation ties the listener to its
+// observer task so a replaced task can never dispatch through the new listener
+// or clear it while exiting. Held as a GlobalRef so it survives across JNI
+// thread attaches.
 #[cfg(feature = "sync")]
-static DOCUMENT_CHANGE_LISTENER: LazyLock<Mutex<Option<GlobalRef>>> =
+static DOCUMENT_CHANGE_LISTENER: LazyLock<Mutex<Option<DocumentChangeRegistration>>> =
     LazyLock::new(|| Mutex::new(None));
 
-// Flag controlling the lifetime of the document-change subscription task.
-// Set to true by subscribeDocumentChangesJni, false by
-// unsubscribeDocumentChangesJni. The spawned tokio task polls this on each recv
-// to know whether to exit.
 #[cfg(feature = "sync")]
-static DOCUMENT_SUBSCRIPTION_ACTIVE: LazyLock<std::sync::atomic::AtomicBool> =
-    LazyLock::new(|| std::sync::atomic::AtomicBool::new(false));
+struct DocumentChangeRegistration {
+    generation: u64,
+    listener: GlobalRef,
+}
+
+// Generation-owned lifetime for the document-change observer task. A boolean
+// cannot safely implement replacement: false followed immediately by true can
+// be missed by the old task, leaving two receivers dispatching duplicate
+// callbacks. Every subscribe receives a distinct odd token; unsubscribe and a
+// naturally-finished task advance it to an even (inactive) state.
+#[cfg(feature = "sync")]
+static DOCUMENT_SUBSCRIPTION_GENERATION: SubscriptionGeneration = SubscriptionGeneration::new();
+
+#[cfg(feature = "sync")]
+struct SubscriptionGeneration {
+    state: std::sync::atomic::AtomicU64,
+}
+
+#[cfg(feature = "sync")]
+impl SubscriptionGeneration {
+    const fn new() -> Self {
+        Self {
+            state: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn begin(&self) -> u64 {
+        use std::sync::atomic::Ordering;
+
+        loop {
+            let current = self.state.load(Ordering::SeqCst);
+            let next = current.wrapping_add(1) | 1;
+            if self
+                .state
+                .compare_exchange(current, next, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                return next;
+            }
+        }
+    }
+
+    fn is_active(&self, generation: u64) -> bool {
+        use std::sync::atomic::Ordering;
+
+        generation & 1 == 1 && self.state.load(Ordering::SeqCst) == generation
+    }
+
+    fn invalidate(&self) {
+        use std::sync::atomic::Ordering;
+
+        let _ = self
+            .state
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
+                Some(current.wrapping_add(1) & !1)
+            });
+    }
+
+    fn finish(&self, generation: u64) -> bool {
+        use std::sync::atomic::Ordering;
+
+        self.state
+            .compare_exchange(
+                generation,
+                generation.wrapping_add(1) & !1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            )
+            .is_ok()
+    }
+}
 
 // peat#885 fault-injection flag, test-only. When armed via
 // `forceStoreErrorForTestingJni`, the next `getDocumentJni` call
@@ -4340,6 +4407,33 @@ mod tests {
                 .expect("remote observer notification timeout")
                 .expect("remote observer channel closed");
             assert_eq!(key, "test:remote-doc");
+        }
+
+        #[test]
+        fn document_subscription_generation_replacement_is_owner_safe() {
+            let generations = SubscriptionGeneration::new();
+
+            let first = generations.begin();
+            assert!(generations.is_active(first));
+
+            let second = generations.begin();
+            assert_ne!(first, second);
+            assert!(!generations.is_active(first));
+            assert!(generations.is_active(second));
+
+            assert!(
+                !generations.finish(first),
+                "a replaced task must not deactivate its replacement"
+            );
+            assert!(generations.is_active(second));
+
+            generations.invalidate();
+            assert!(!generations.is_active(second));
+
+            let third = generations.begin();
+            assert!(generations.is_active(third));
+            assert!(generations.finish(third));
+            assert!(!generations.is_active(third));
         }
 
         /// Surface-tier round-trip for `roster_upsert`, which takes a
@@ -10095,8 +10189,6 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentCh
     handle: i64,
     listener: jni::objects::JObject,
 ) -> jboolean {
-    use std::sync::atomic::Ordering;
-
     if handle == 0 {
         #[cfg(target_os = "android")]
         android_log("subscribeDocumentChangesJni: Invalid handle (0)");
@@ -10117,45 +10209,49 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentCh
         }
     };
 
-    // Swap the listener in; drop any previous one.
-    {
-        let mut slot = DOCUMENT_CHANGE_LISTENER.lock().unwrap();
-        *slot = Some(listener_global);
-    }
-
-    // Signal the previous subscription task (if any) to exit before we start
-    // a new one, then mark the new subscription active.
-    DOCUMENT_SUBSCRIPTION_ACTIVE.store(false, Ordering::SeqCst);
-    DOCUMENT_SUBSCRIPTION_ACTIVE.store(true, Ordering::SeqCst);
-
     // Borrow the node without taking ownership of its Arc.
     let node = unsafe { Arc::from_raw(handle as *const PeatNode) };
     let store = Arc::clone(&node.store);
     let runtime = Arc::clone(&node.runtime);
     std::mem::forget(node);
 
+    // Subscribe before returning to the caller so a document committed
+    // immediately after this function returns cannot beat receiver creation.
+    let mut rx = subscribe_document_changes_for_jni(&store);
+
+    // Beginning a new generation invalidates the previous observer task. Tie
+    // the replacement listener to that generation so a stale task can neither
+    // dispatch through it nor clear it on exit.
+    let generation = {
+        let mut slot = DOCUMENT_CHANGE_LISTENER.lock().unwrap();
+        let generation = DOCUMENT_SUBSCRIPTION_GENERATION.begin();
+        *slot = Some(DocumentChangeRegistration {
+            generation,
+            listener: listener_global,
+        });
+        generation
+    };
+
     runtime.spawn(async move {
-        // Consumer callbacks must observe both local writes and documents
-        // applied from peers. The legacy change channel is intentionally
-        // local-only to prevent sync echo; the observer channel is the
-        // persisted, all-origin notification surface.
-        let mut rx = subscribe_document_changes_for_jni(&store);
-        while DOCUMENT_SUBSCRIPTION_ACTIVE.load(Ordering::SeqCst) {
+        while DOCUMENT_SUBSCRIPTION_GENERATION.is_active(generation) {
             tokio::select! {
                 result = rx.recv() => {
+                    if !DOCUMENT_SUBSCRIPTION_GENERATION.is_active(generation) {
+                        break;
+                    }
                     match result {
                         Ok(doc_key) => {
                             let (collection, doc_id) = doc_key
                                 .split_once(':')
                                 .map(|(c, d)| (c.to_string(), d.to_string()))
                                 .unwrap_or_else(|| ("default".to_string(), doc_key.clone()));
-                            dispatch_document_change(&collection, &doc_id);
+                            dispatch_document_change(generation, &collection, &doc_id);
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                            dispatch_document_error(&format!("lagged {} messages", n));
+                            dispatch_document_error(generation, &format!("lagged {} messages", n));
                         }
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            dispatch_document_error("change channel closed");
+                            dispatch_document_error(generation, "change channel closed");
                             break;
                         }
                     }
@@ -10167,10 +10263,10 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_subscribeDocumentCh
             }
         }
 
-        // On exit, drop the listener ref if we were the owning subscription.
-        if !DOCUMENT_SUBSCRIPTION_ACTIVE.load(Ordering::SeqCst) {
-            let mut slot = DOCUMENT_CHANGE_LISTENER.lock().unwrap();
-            *slot = None;
+        // Only the currently-owning task may deactivate and clear its listener.
+        // A replaced task's generation no longer matches and is a no-op here.
+        if DOCUMENT_SUBSCRIPTION_GENERATION.finish(generation) {
+            clear_document_listener(generation);
         }
     });
 
@@ -10188,19 +10284,37 @@ fn subscribe_document_changes_for_jni(
 ///
 /// Kotlin signature: `external fun unsubscribeDocumentChangesJni()`
 ///
-/// Signals the background subscription task to exit on its next iteration.
-/// The listener GlobalRef is dropped by the task on exit (not here) to avoid
-/// a race between unsubscribe and an in-flight dispatch.
+/// Invalidates the background subscription task and removes its listener.
+/// A callback that already cloned the GlobalRef may complete concurrently.
 #[cfg(feature = "sync")]
 #[no_mangle]
 pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_unsubscribeDocumentChangesJni(
     _env: JNIEnv,
     _class: JClass,
 ) {
-    use std::sync::atomic::Ordering;
-    DOCUMENT_SUBSCRIPTION_ACTIVE.store(false, Ordering::SeqCst);
+    let mut slot = DOCUMENT_CHANGE_LISTENER.lock().unwrap();
+    DOCUMENT_SUBSCRIPTION_GENERATION.invalidate();
+    slot.take();
     #[cfg(target_os = "android")]
-    android_log("unsubscribeDocumentChangesJni: subscription marked inactive");
+    android_log("unsubscribeDocumentChangesJni: subscription invalidated");
+}
+
+#[cfg(feature = "sync")]
+fn clear_document_listener(generation: u64) {
+    let mut slot = DOCUMENT_CHANGE_LISTENER.lock().unwrap();
+    if slot
+        .as_ref()
+        .is_some_and(|registration| registration.generation == generation)
+    {
+        *slot = None;
+    }
+}
+
+#[cfg(feature = "sync")]
+fn clone_document_listener(generation: u64) -> Option<GlobalRef> {
+    let slot = DOCUMENT_CHANGE_LISTENER.lock().ok()?;
+    let registration = slot.as_ref()?;
+    (registration.generation == generation).then(|| registration.listener.clone())
 }
 
 /// Snapshot the listener `GlobalRef` from a static slot under its mutex,
@@ -10234,7 +10348,7 @@ fn clone_java_vm() -> Option<jni::JavaVM> {
 /// Dispatch a document-change event to the registered Kotlin listener.
 /// Attaches the current tokio worker thread to the JVM if needed.
 #[cfg(feature = "sync")]
-fn dispatch_document_change(collection: &str, doc_id: &str) {
+fn dispatch_document_change(generation: u64, collection: &str, doc_id: &str) {
     // Snapshot the listener and JavaVM pointer under their locks, then drop
     // the guards BEFORE the unbounded JNI `call_method` (QA #808 IDIOM).
     // Kotlin's `onChange` may re-enter Rust JNI; holding either lock across
@@ -10242,7 +10356,7 @@ fn dispatch_document_change(collection: &str, doc_id: &str) {
     // serialize every translator's dispatch through a single JVM call.
     // GlobalRef is Arc-shaped so cloning is cheap; JavaVM is process-stable
     // so reconstructing from the raw pointer is sound.
-    let Some(listener) = clone_listener(&DOCUMENT_CHANGE_LISTENER) else {
+    let Some(listener) = clone_document_listener(generation) else {
         return;
     };
     let Some(java_vm) = clone_java_vm() else {
@@ -10290,9 +10404,9 @@ fn dispatch_document_change(collection: &str, doc_id: &str) {
 
 /// Dispatch an error message to the registered Kotlin listener.
 #[cfg(feature = "sync")]
-fn dispatch_document_error(message: &str) {
+fn dispatch_document_error(generation: u64, message: &str) {
     // Snapshot then drop locks before JNI work — see dispatch_document_change.
-    let Some(listener) = clone_listener(&DOCUMENT_CHANGE_LISTENER) else {
+    let Some(listener) = clone_document_listener(generation) else {
         return;
     };
     let Some(java_vm) = clone_java_vm() else {


### PR DESCRIPTION
## Summary

- package canonical `OutboundFrameListener` and `DocumentChangeListener` contracts in the peat-ffi Android AAR
- expose and register outbound-frame and document-change subscribe/unsubscribe methods in both JNI registration paths
- deliver all persisted document changes, including remote peer applications, to JNI consumers
- keep protocol, authentication, deduplication, relay, and serialization Rust-owned
- add Android surface coverage and a regression test for remote document callback delivery
- bump the additive Android AAR version to 0.1.8

## Why

Android plugin-host consumers need both sides of the PEAT boundary without maintaining local listener interfaces or JNI declarations that can drift from peat-ffi: opaque outbound transport frames and synchronized document-change notifications.

The physical receive proof exposed an important channel distinction: `subscribe_to_changes()` is the legacy local-write-only notification path, so a document synchronized from a peer was persisted but not delivered to the Android consumer. Commit `701a7fe` moves the JNI consumer listener to `subscribe_to_observer_changes()`, PEAT's all-origin persisted observer channel, while preserving the legacy channel's existing semantics.

## Verification

- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed
- peat-ffi Rust suite: 93 unit tests, 5 application-delivery tests, 4 application-document-query tests, and the Dart shim test passed
- JNI wrapper integration test passed with Android Studio's JDK
- fork [Android Build](https://github.com/jeremymcgee73/peat/actions/runs/32912627291): arm64, armv7, x86_64, Kotlin bindings, and AAR packaging passed
- physical ATAK 5.8 proof: a macOS PEAT peer authenticated directly to a Moto G Play, synchronized a remote PLI document, invoked the corrected JNI callback, and created one ATAK map item with the original CoT UID
- byte-identical follow-up delivery through normal ATAK multicast retained the same single map item and internal serial ID

The sanitized physical qualification record is in the consumer repository: [computer-to-ATAK PEAT receive proof](https://github.com/jeremymcgee73/peat-atak-plugin/blob/main/docs/qualification/2026-08-25-peat-host-receive-proof.md).

The separate supply-chain job may continue to report the pre-existing RUSTSEC-2026-0253 finding in `lru 0.16.3`; this change adds no dependencies.

Closes #1082
