### PR TITLE
feat(android): support scoped local-interface bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4024,6 +4024,7 @@ dependencies = [
  "hex",
  "jni 0.21.1",
  "ndk-context",
+ "netdev",
  "netwatch",
  "peat-btle",
  "peat-mesh",

--- a/docs/adr/076-android-selected-ip-bindings-and-application-relay.md
+++ b/docs/adr/076-android-selected-ip-bindings-and-application-relay.md
@@ -20,18 +20,25 @@ PEAT peer. This must not become generic IP routing or an open proxy.
 
 ## Decision
 
-PEAT FFI accepts a bounded JSON list of concrete numeric IP addresses, CIDR
-prefixes, nonzero platform network handles, and one optional default route per
-address family. `peat-mesh` converts those into exact Iroh `BindOpts`; it does
-not enumerate or add host interfaces in this mode.
+PEAT FFI accepts a bounded JSON list of concrete numeric IP addresses and CIDR
+prefixes. Each entry identifies either a nonzero platform network handle or a
+concrete local interface. Handle-backed entries retain one optional default
+route per address family. A handle-less local-interface entry is always
+non-default, must name a live interface that currently owns the address, and
+must carry the matching nonzero scope for IPv6 link-local addresses.
+`peat-mesh` converts the validated declarations into exact Iroh `BindOpts`; it
+does not enumerate or add host interfaces in this mode.
 
 The Android FFI installs one exclusive, process-local `netwatch` UDP pre-bind
-hook for the exact native node lifetime. The hook maps the socket's concrete
-local address to the declared handle and calls `android_setsocknetwork` before
-initial bind and rebind. Missing mappings, duplicate ownership, invalid
-addresses/prefixes/defaults, competing hook owners, and non-Android use fail
-closed. Node free drops the hook guard. Network-change notification asks Iroh to
-re-evaluate paths; a changed declaration is handled by consumer stop/free/create.
+hook for the exact native node lifetime. The hook maps each socket's concrete
+local address and IPv6 scope to its declared owner. It calls
+`android_setsocknetwork` for a handle-backed owner and skips that call only for
+an exact local-interface declaration already validated against the live Android
+interface table. Missing mappings, stale interfaces, mismatched scopes,
+duplicate ownership, invalid addresses/prefixes/defaults, competing hook
+owners, and non-Android use fail closed. Node free drops the hook guard.
+Network-change notification asks Iroh to re-evaluate paths; a changed or lost
+declaration is handled by consumer stop/free/create.
 
 Selected-binding mode disables n0 hosted relay. Its TCP and DNS sockets are not
 inside this UDP hook and therefore cannot truthfully claim selected-network
@@ -51,9 +58,13 @@ consumer destinations or payload policy.
 - Consumers can keep local mesh traffic on one or more explicitly selected
   Wi-Fi, Ethernet, or USB-backed Android networks without changing the host
   process default or naming a particular radio product.
+- Local-only bearer owners that are not surfaced as Android `Network` objects
+  can contribute a concrete non-default interface binding without weakening
+  the ownership requirement for any other socket.
 - A consumer must stop, free, and recreate the node when its selected address,
-  prefix, or Android network handle changes. Reachability-only changes can use
-  the notification entrypoint without recreating the node.
+  prefix, Android network handle, local interface, or IPv6 scope changes.
+  Reachability-only changes can use the notification entrypoint without
+  recreating the node.
 - Hosted relay remains unavailable on this selected-binding path until every
   relay-owned TCP and DNS socket has an equivalent pre-connect network hook.
   Direct local discovery and application delivery remain available.

--- a/peat-ffi/Cargo.toml
+++ b/peat-ffi/Cargo.toml
@@ -252,6 +252,12 @@ peat-btle = { workspace = true, features = ["ios"], optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 peat-btle = { workspace = true, features = ["android"], optional = true }
+# Read the live interface/address/scope assignment before accepting an explicit
+# local-interface socket whose owner is not surfaced as an Android Network.
+# netdev is already present through the vendored netwatch dependency; making it
+# direct here lets the FFI validate the platform declaration without widening
+# netwatch's public API.
+netdev = "0.45.0"
 # Android-only tracing bridge (see comment above the peat-btle target tables).
 # `tracing` (the facade) is in the general `[dependencies]`; only the
 # heavyweight subscriber is gated to Android here.

--- a/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
+++ b/peat-ffi/android/src/androidTest/kotlin/com/defenseunicorns/peat/PeatJniSurfaceTest.kt
@@ -7,6 +7,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import java.io.File
 import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.NetworkInterface
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.util.concurrent.CountDownLatch
@@ -115,6 +117,7 @@ class PeatJniSurfaceTest {
         val address: String,
         val prefixLength: Int,
         val networkHandle: Long,
+        val interfaceName: String,
     ) {
         fun toJson(): String =
             JSONArray()
@@ -124,6 +127,22 @@ class PeatJniSurfaceTest {
                         .put("prefix_length", prefixLength)
                         .put("network_handle", networkHandle)
                         .put("is_default_route", true),
+                )
+                .toString()
+
+        fun toLocalInterfaceJson(
+            declaredInterfaceName: String = interfaceName,
+            isDefaultRoute: Boolean = false,
+            scopeId: Int? = null,
+        ): String =
+            JSONArray()
+                .put(
+                    JSONObject()
+                        .put("address", address)
+                        .put("prefix_length", prefixLength)
+                        .put("interface_name", declaredInterfaceName)
+                        .put("is_default_route", isDefaultRoute)
+                        .apply { scopeId?.let { put("scope_id", it) } },
                 )
                 .toString()
     }
@@ -138,10 +157,17 @@ class PeatJniSurfaceTest {
         assertNotNull("active Android Network must expose LinkProperties", linkProperties)
         val address = linkProperties!!.linkAddresses.firstOrNull { it.address is Inet4Address }
         assertNotNull("active Android Network must expose a concrete IPv4 address", address)
+        val interfaceName = linkProperties.interfaceName
+        assertNotNull("active Android Network must expose an interface name", interfaceName)
         val hostAddress = address!!.address.hostAddress
         assertNotNull("active Android Network IPv4 address must be numeric", hostAddress)
 
-        return SelectedNetworkBinding(hostAddress!!, address.prefixLength, network.networkHandle)
+        return SelectedNetworkBinding(
+            hostAddress!!,
+            address.prefixLength,
+            network.networkHandle,
+            interfaceName!!,
+        )
     }
 
     private fun sha256Hex(value: String): String =
@@ -436,6 +462,145 @@ class PeatJniSurfaceTest {
             "recipient JNI inbox must expose the authenticated relay body",
             body,
             receivedBody,
+        )
+    }
+
+    /**
+     * A concrete live interface can own a non-default PEAT socket even when no
+     * Android Network handle is supplied. Native validation must confirm the
+     * interface/address assignment before the pre-bind hook permits the exact
+     * socket through without calling android_setsocknetwork.
+     */
+    @Test
+    fun d_localInterfaceLifecycle_roundTripsThroughJni() {
+        val cacheDir = InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
+        val storageDir =
+            File(cacheDir, "peat-ffi-surface-interface-${System.nanoTime()}").apply {
+                mkdirs()
+            }
+        storageDirs.add(storageDir)
+        val binding = selectedNetworkBinding()
+
+        assertEquals(
+            "a missing local interface must fail before endpoint construction",
+            0L,
+            PeatJni.createNodeWithIpBindingsJni(
+                APP_ID,
+                SHARED_KEY,
+                "android-missing-interface-surface",
+                storageDir.absolutePath,
+                false,
+                null,
+                binding.toLocalInterfaceJson(declaredInterfaceName = "peat-missing0"),
+            ),
+        )
+        assertEquals(
+            "a handle-less local interface must not become a default route",
+            0L,
+            PeatJni.createNodeWithIpBindingsJni(
+                APP_ID,
+                SHARED_KEY,
+                "android-default-interface-surface",
+                storageDir.absolutePath,
+                false,
+                null,
+                binding.toLocalInterfaceJson(isDefaultRoute = true),
+            ),
+        )
+        assertEquals(
+            "an IPv4 local interface must reject an IPv6-shaped scope",
+            0L,
+            PeatJni.createNodeWithIpBindingsJni(
+                APP_ID,
+                SHARED_KEY,
+                "android-ipv4-scope-surface",
+                storageDir.absolutePath,
+                false,
+                null,
+                binding.toLocalInterfaceJson(scopeId = 1),
+            ),
+        )
+
+        val handle =
+            PeatJni.createNodeWithIpBindingsJni(
+                APP_ID,
+                SHARED_KEY,
+                "android-local-interface-surface",
+                storageDir.absolutePath,
+                false,
+                null,
+                binding.toLocalInterfaceJson(),
+            )
+
+        assertTrue(
+            "createNodeWithIpBindingsJni must accept an exact live non-default interface",
+            handle != 0L,
+        )
+        handles.add(handle)
+        val endpointAddress = PeatJni.endpointSocketAddrJni(handle)
+        assertNotNull("local-interface node must expose its bound endpoint", endpointAddress)
+        assertTrue(
+            "local-interface endpoint must use the declared address; got $endpointAddress",
+            endpointAddress!!.startsWith("${binding.address}:"),
+        )
+        assertTrue(
+            "local-interface node must expose an endpoint identity",
+            PeatJni.nodeIdJni(handle).isNotEmpty(),
+        )
+    }
+
+    /** Link-local IPv6 ownership is meaningful only with the live interface scope. */
+    @Test
+    fun e_linkLocalInterfaceScope_roundTripsThroughJni() {
+        val selected = selectedNetworkBinding()
+        val networkInterface = NetworkInterface.getByName(selected.interfaceName)
+        assertNotNull("selected interface must remain available", networkInterface)
+        val interfaceAddress =
+            networkInterface!!.interfaceAddresses.firstOrNull {
+                it.address is Inet6Address && it.address.isLinkLocalAddress
+            }
+        assertNotNull("selected interface must expose an IPv6 link-local address", interfaceAddress)
+        val address = interfaceAddress!!.address as Inet6Address
+        assertTrue("link-local IPv6 address must expose a nonzero scope", address.scopeId > 0)
+        val json =
+            JSONArray()
+                .put(
+                    JSONObject()
+                        .put("address", address.hostAddress!!.substringBefore('%'))
+                        .put("prefix_length", interfaceAddress.networkPrefixLength.toInt())
+                        .put("interface_name", selected.interfaceName)
+                        .put("scope_id", address.scopeId)
+                        .put("is_default_route", false),
+                )
+                .toString()
+        val cacheDir = InstrumentationRegistry.getInstrumentation().targetContext.cacheDir
+        val storageDir =
+            File(cacheDir, "peat-ffi-surface-link-local-${System.nanoTime()}").apply {
+                mkdirs()
+            }
+        storageDirs.add(storageDir)
+
+        val handle =
+            PeatJni.createNodeWithIpBindingsJni(
+                APP_ID,
+                SHARED_KEY,
+                "android-link-local-interface-surface",
+                storageDir.absolutePath,
+                false,
+                null,
+                json,
+            )
+
+        assertTrue(
+            "createNodeWithIpBindingsJni must preserve a validated IPv6 link-local scope",
+            handle != 0L,
+        )
+        handles.add(handle)
+        val endpointAddress = PeatJni.endpointSocketAddrJni(handle)
+        assertNotNull("link-local interface node must expose its bound endpoint", endpointAddress)
+        assertTrue(
+            "link-local endpoint must preserve scope ${address.scopeId}; got $endpointAddress",
+            endpointAddress!!.contains("%${address.scopeId}"),
         )
     }
 

--- a/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
+++ b/peat-ffi/android/src/main/kotlin/com/defenseunicorns/peat/PeatJni.kt
@@ -123,8 +123,9 @@ object PeatJni {
 
     /**
      * Create a node whose Iroh UDP sockets are bound to explicit Android
-     * Networks. The JSON is validated natively and has no process-default
-     * fallback. Hosted relay DNS/TCP remains disabled on this surface.
+     * Networks or validated non-default local interfaces. The JSON is
+     * validated natively and has no process-default fallback. Hosted relay
+     * DNS/TCP remains disabled on this surface.
      */
     @JvmStatic external fun createNodeWithIpBindingsJni(
         appId: String,

--- a/peat-ffi/src/ip_bindings.rs
+++ b/peat-ffi/src/ip_bindings.rs
@@ -1,10 +1,14 @@
 //! Validated selected-IP bindings for platform-owned network routing.
 
 use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, SocketAddr};
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+#[cfg(any(target_os = "android", test))]
+use std::net::SocketAddrV6;
 
 #[cfg(target_os = "android")]
-use std::{io, sync::Arc};
+use std::sync::Arc;
 
 use peat_mesh::network::IpBindSpec;
 use serde::Deserialize;
@@ -12,14 +16,48 @@ use serde::Deserialize;
 use crate::PeatError;
 
 const MAX_IP_BINDINGS: usize = 32;
+#[cfg(target_os = "android")]
+const MAX_INTERFACE_NAME_BYTES: usize = 64;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct PlatformIpBinding {
     address: String,
     prefix_length: u8,
-    network_handle: u64,
+    #[serde(default)]
+    network_handle: Option<u64>,
+    #[serde(default)]
+    interface_name: Option<String>,
+    #[serde(default)]
+    scope_id: Option<u32>,
     is_default_route: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketOwner {
+    AndroidNetwork(u64),
+    LocalInterface,
+}
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+enum SocketBindingKey {
+    V4(Ipv4Addr),
+    V6(Ipv6Addr, u32),
+}
+
+impl From<SocketAddr> for SocketBindingKey {
+    fn from(value: SocketAddr) -> Self {
+        match value {
+            SocketAddr::V4(value) => Self::V4(*value.ip()),
+            SocketAddr::V6(value) => Self::V6(*value.ip(), value.scope_id()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ParsedIpBinding {
+    spec: IpBindSpec,
+    owner: SocketOwner,
 }
 
 pub(crate) struct PreparedIpBindings {
@@ -33,7 +71,17 @@ fn invalid(message: impl Into<String>) -> PeatError {
     }
 }
 
-fn parse_bindings(json: &str) -> Result<Vec<(IpBindSpec, u64)>, PeatError> {
+fn parse_bindings(json: &str) -> Result<Vec<ParsedIpBinding>, PeatError> {
+    parse_bindings_with(json, validate_local_interface)
+}
+
+fn parse_bindings_with<F>(
+    json: &str,
+    mut validate_interface: F,
+) -> Result<Vec<ParsedIpBinding>, PeatError>
+where
+    F: FnMut(&str, IpAddr, Option<u32>) -> Result<SocketAddr, PeatError>,
+{
     let parsed: Vec<PlatformIpBinding> =
         serde_json::from_str(json).map_err(|_| invalid("IP bindings JSON is malformed"))?;
     if parsed.is_empty() || parsed.len() > MAX_IP_BINDINGS {
@@ -57,15 +105,38 @@ fn parse_bindings(json: &str) -> Result<Vec<(IpBindSpec, u64)>, PeatError> {
                     "IP binding address must be concrete, non-loopback, and unicast",
                 ));
             }
-            if binding.network_handle == 0 {
-                return Err(invalid("Android network handle must be non-zero"));
-            }
             let max_prefix = if ip.is_ipv4() { 32 } else { 128 };
             if binding.prefix_length > max_prefix {
                 return Err(invalid("IP binding prefix length is invalid"));
             }
-            if !addresses.insert(ip) {
-                return Err(invalid("duplicate IP binding address"));
+
+            let (addr, owner) = match binding.network_handle {
+                Some(handle) => {
+                    if handle == 0 {
+                        return Err(invalid("Android network handle must be non-zero"));
+                    }
+                    if binding.interface_name.is_some() || binding.scope_id.is_some() {
+                        return Err(invalid(
+                            "handle-backed IP bindings must not declare interface fields",
+                        ));
+                    }
+                    (SocketAddr::new(ip, 0), SocketOwner::AndroidNetwork(handle))
+                }
+                None => {
+                    if binding.is_default_route {
+                        return Err(invalid(
+                            "local-interface IP bindings cannot be default routes",
+                        ));
+                    }
+                    let interface_name = binding.interface_name.as_deref().ok_or_else(|| {
+                        invalid("local-interface IP binding requires an interface name")
+                    })?;
+                    validate_interface(interface_name, ip, binding.scope_id)
+                        .map(|addr| (addr, SocketOwner::LocalInterface))?
+                }
+            };
+            if !addresses.insert(SocketBindingKey::from(addr)) {
+                return Err(invalid("duplicate IP binding socket address"));
             }
             if binding.is_default_route {
                 let already_set = if ip.is_ipv4() {
@@ -79,21 +150,130 @@ fn parse_bindings(json: &str) -> Result<Vec<(IpBindSpec, u64)>, PeatError> {
                     ));
                 }
             }
-            Ok((
-                IpBindSpec {
-                    addr: SocketAddr::new(ip, 0),
+            Ok(ParsedIpBinding {
+                spec: IpBindSpec {
+                    addr,
                     prefix_len: binding.prefix_length,
                     is_default_route: binding.is_default_route,
                 },
-                binding.network_handle,
-            ))
+                owner,
+            })
         })
         .collect()
 }
 
 #[cfg(target_os = "android")]
+fn validate_local_interface(
+    interface_name: &str,
+    ip: IpAddr,
+    requested_scope_id: Option<u32>,
+) -> Result<SocketAddr, PeatError> {
+    if interface_name.is_empty()
+        || interface_name != interface_name.trim()
+        || interface_name.len() > MAX_INTERFACE_NAME_BYTES
+        || interface_name
+            .bytes()
+            .any(|byte| byte == 0 || byte.is_ascii_control())
+    {
+        return Err(invalid("local-interface name is invalid"));
+    }
+
+    let interface = netdev::get_interfaces()
+        .into_iter()
+        .find(|candidate| candidate.name == interface_name)
+        .ok_or_else(|| invalid("local-interface IP binding names an unavailable interface"))?;
+    if !interface.is_up() {
+        return Err(invalid(
+            "local-interface IP binding names an inactive interface",
+        ));
+    }
+
+    match ip {
+        IpAddr::V4(address) => {
+            if requested_scope_id.is_some() {
+                return Err(invalid(
+                    "IPv4 local-interface binding must not declare a scope ID",
+                ));
+            }
+            if !interface
+                .ipv4
+                .iter()
+                .any(|network| network.addr() == address)
+            {
+                return Err(invalid(
+                    "local-interface IPv4 address is not assigned to the declared interface",
+                ));
+            }
+            Ok(SocketAddr::new(IpAddr::V4(address), 0))
+        }
+        IpAddr::V6(address) => {
+            let position = interface
+                .ipv6
+                .iter()
+                .position(|network| network.addr() == address)
+                .ok_or_else(|| {
+                    invalid(
+                        "local-interface IPv6 address is not assigned to the declared interface",
+                    )
+                })?;
+            let actual_scope_id = interface
+                .ipv6_scope_ids
+                .get(position)
+                .copied()
+                .ok_or_else(|| invalid("local-interface IPv6 scope is unavailable"))?;
+            let scope_id =
+                if address.is_unicast_link_local() {
+                    let requested = requested_scope_id.filter(|scope| *scope != 0).ok_or_else(|| {
+                    invalid("link-local IPv6 local-interface binding requires a nonzero scope ID")
+                })?;
+                    if requested != actual_scope_id || actual_scope_id != interface.index {
+                        return Err(invalid(
+                            "link-local IPv6 scope does not match the declared interface",
+                        ));
+                    }
+                    requested
+                } else {
+                    if requested_scope_id.is_some_and(|scope| scope != 0) {
+                        return Err(invalid(
+                        "non-link-local IPv6 local-interface binding must not declare a scope ID",
+                    ));
+                    }
+                    0
+                };
+            Ok(SocketAddr::V6(SocketAddrV6::new(address, 0, 0, scope_id)))
+        }
+    }
+}
+
+#[cfg(not(target_os = "android"))]
+fn validate_local_interface(
+    _interface_name: &str,
+    _ip: IpAddr,
+    _requested_scope_id: Option<u32>,
+) -> Result<SocketAddr, PeatError> {
+    Err(invalid(
+        "Android local-interface bindings are unavailable on this platform",
+    ))
+}
+
+fn socket_owner(
+    owners: &HashMap<SocketBindingKey, SocketOwner>,
+    addr: SocketAddr,
+) -> io::Result<SocketOwner> {
+    owners
+        .get(&SocketBindingKey::from(addr))
+        .copied()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("no selected Android socket owner declared local address {addr}"),
+            )
+        })
+}
+
+#[cfg(target_os = "android")]
 fn install_hook(
-    handles: HashMap<IpAddr, u64>,
+    owners: HashMap<SocketBindingKey, SocketOwner>,
 ) -> Result<netwatch::UdpSocketBindHookGuard, PeatError> {
     use std::os::fd::AsRawFd;
 
@@ -105,24 +285,21 @@ fn install_hook(
 
     netwatch::install_udp_socket_bind_hook(Arc::new(
         move |addr: SocketAddr, socket: &socket2::Socket| {
-            let handle = handles.get(&addr.ip()).ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!(
-                        "no selected Android network owns local address {}",
-                        addr.ip()
-                    ),
-                )
-            })?;
-            // SAFETY: `socket` is live for the duration of the callback; Android's
-            // API neither takes ownership of the fd nor retains the pointer. The
-            // network handle came from `Network.getNetworkHandle()` and was
-            // validated as non-zero at the FFI boundary.
-            let result = unsafe { android_setsocknetwork(*handle, socket.as_raw_fd()) };
-            if result == 0 {
-                Ok(())
-            } else {
-                Err(io::Error::from_raw_os_error(-result))
+            match socket_owner(&owners, addr)? {
+                SocketOwner::LocalInterface => Ok(()),
+                SocketOwner::AndroidNetwork(handle) => {
+                    // SAFETY: `socket` is live for the duration of the callback;
+                    // Android's API neither takes ownership of the fd nor retains
+                    // the pointer. The network handle came from
+                    // `Network.getNetworkHandle()` and was validated as non-zero at
+                    // the FFI boundary.
+                    let result = unsafe { android_setsocknetwork(handle, socket.as_raw_fd()) };
+                    if result == 0 {
+                        Ok(())
+                    } else {
+                        Err(io::Error::from_raw_os_error(-result))
+                    }
+                }
             }
         },
     ))
@@ -133,7 +310,7 @@ fn install_hook(
 
 #[cfg(not(target_os = "android"))]
 fn install_hook(
-    _handles: HashMap<IpAddr, u64>,
+    _owners: HashMap<SocketBindingKey, SocketOwner>,
 ) -> Result<netwatch::UdpSocketBindHookGuard, PeatError> {
     Err(invalid(
         "selected Android network bindings are unavailable on this platform",
@@ -142,18 +319,37 @@ fn install_hook(
 
 pub(crate) fn prepare(json: &str) -> Result<PreparedIpBindings, PeatError> {
     let parsed = parse_bindings(json)?;
-    let handles = parsed
+    let owners = parsed
         .iter()
-        .map(|(spec, handle)| (spec.addr.ip(), *handle))
+        .map(|binding| (SocketBindingKey::from(binding.spec.addr), binding.owner))
         .collect::<HashMap<_, _>>();
-    let specs = parsed.into_iter().map(|(spec, _)| spec).collect();
-    let hook_guard = install_hook(handles)?;
+    let specs = parsed.into_iter().map(|binding| binding.spec).collect();
+    let hook_guard = install_hook(owners)?;
     Ok(PreparedIpBindings { specs, hook_guard })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn validated_test_interface(
+        interface_name: &str,
+        ip: IpAddr,
+        scope_id: Option<u32>,
+    ) -> Result<SocketAddr, PeatError> {
+        if interface_name != "p2p-test0" {
+            return Err(invalid("test interface is unavailable"));
+        }
+        match ip {
+            IpAddr::V4(address) if scope_id.is_none() => {
+                Ok(SocketAddr::new(IpAddr::V4(address), 0))
+            }
+            IpAddr::V6(address) if scope_id == Some(7) => {
+                Ok(SocketAddr::V6(SocketAddrV6::new(address, 0, 0, 7)))
+            }
+            _ => Err(invalid("test interface scope is invalid")),
+        }
+    }
 
     #[test]
     fn parser_accepts_concurrent_local_and_default_paths() {
@@ -165,8 +361,31 @@ mod tests {
         )
         .unwrap();
         assert_eq!(parsed.len(), 2);
-        assert!(!parsed[0].0.is_default_route);
-        assert!(parsed[1].0.is_default_route);
+        assert!(!parsed[0].spec.is_default_route);
+        assert!(parsed[1].spec.is_default_route);
+        assert_eq!(parsed[0].owner, SocketOwner::AndroidNetwork(1001));
+        assert_eq!(parsed[1].owner, SocketOwner::AndroidNetwork(2002));
+    }
+
+    #[test]
+    fn parser_accepts_non_default_validated_local_interfaces_and_ipv6_scope() {
+        let parsed = parse_bindings_with(
+            r#"[
+              {"address":"192.168.49.1","prefix_length":24,"interface_name":"p2p-test0","is_default_route":false},
+              {"address":"fe80::1234","prefix_length":64,"interface_name":"p2p-test0","scope_id":7,"is_default_route":false}
+            ]"#,
+            validated_test_interface,
+        )
+        .unwrap();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].owner, SocketOwner::LocalInterface);
+        assert_eq!(parsed[0].spec.addr, "192.168.49.1:0".parse().unwrap());
+        assert_eq!(parsed[1].owner, SocketOwner::LocalInterface);
+        assert_eq!(
+            parsed[1].spec.addr,
+            SocketAddr::V6(SocketAddrV6::new("fe80::1234".parse().unwrap(), 0, 0, 7))
+        );
     }
 
     #[test]
@@ -198,5 +417,102 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[test]
+    fn parser_rejects_ambiguous_or_default_local_interface_shapes() {
+        let local_default = r#"[
+          {"address":"192.168.49.1","prefix_length":24,"interface_name":"p2p-test0","is_default_route":true}
+        ]"#;
+        assert!(
+            parse_bindings_with(local_default, validated_test_interface).is_err(),
+            "a handle-less binding must never become a default route"
+        );
+
+        let missing_interface = r#"[
+          {"address":"192.168.49.1","prefix_length":24,"is_default_route":false}
+        ]"#;
+        assert!(parse_bindings_with(missing_interface, validated_test_interface).is_err());
+
+        let mixed_owner = r#"[
+          {"address":"192.168.49.1","prefix_length":24,"network_handle":9,"interface_name":"p2p-test0","is_default_route":false}
+        ]"#;
+        assert!(parse_bindings_with(mixed_owner, validated_test_interface).is_err());
+
+        let ipv4_scope = r#"[
+          {"address":"192.168.49.1","prefix_length":24,"interface_name":"p2p-test0","scope_id":7,"is_default_route":false}
+        ]"#;
+        assert!(parse_bindings_with(ipv4_scope, validated_test_interface).is_err());
+    }
+
+    #[test]
+    fn parser_rejects_duplicate_scoped_socket_and_preserves_distinct_scopes() {
+        let duplicate = r#"[
+          {"address":"fe80::1234","prefix_length":64,"interface_name":"p2p-test0","scope_id":7,"is_default_route":false},
+          {"address":"fe80::1234","prefix_length":64,"interface_name":"p2p-test0","scope_id":7,"is_default_route":false}
+        ]"#;
+        assert!(parse_bindings_with(duplicate, validated_test_interface).is_err());
+
+        let distinct = r#"[
+          {"address":"fe80::1234","prefix_length":64,"interface_name":"first","scope_id":7,"is_default_route":false},
+          {"address":"fe80::1234","prefix_length":64,"interface_name":"second","scope_id":8,"is_default_route":false}
+        ]"#;
+        let parsed = parse_bindings_with(distinct, |name, ip, scope| {
+            let expected = if name == "first" { 7 } else { 8 };
+            if scope != Some(expected) {
+                return Err(invalid("test scope mismatch"));
+            }
+            let IpAddr::V6(address) = ip else {
+                return Err(invalid("test address family mismatch"));
+            };
+            Ok(SocketAddr::V6(SocketAddrV6::new(address, 0, 0, expected)))
+        })
+        .unwrap();
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[test]
+    fn socket_owner_matches_exact_address_and_scope_but_ignores_ephemeral_port() {
+        let mut owners = HashMap::new();
+        owners.insert(
+            SocketBindingKey::V4("192.168.49.1".parse().unwrap()),
+            SocketOwner::AndroidNetwork(42),
+        );
+        owners.insert(
+            SocketBindingKey::V6("fe80::1234".parse().unwrap(), 7),
+            SocketOwner::LocalInterface,
+        );
+
+        assert_eq!(
+            socket_owner(&owners, "192.168.49.1:38000".parse().unwrap()).unwrap(),
+            SocketOwner::AndroidNetwork(42)
+        );
+        assert_eq!(
+            socket_owner(
+                &owners,
+                SocketAddr::V6(SocketAddrV6::new(
+                    "fe80::1234".parse().unwrap(),
+                    38000,
+                    0,
+                    7,
+                )),
+            )
+            .unwrap(),
+            SocketOwner::LocalInterface
+        );
+        assert!(
+            socket_owner(
+                &owners,
+                SocketAddr::V6(SocketAddrV6::new(
+                    "fe80::1234".parse().unwrap(),
+                    38000,
+                    0,
+                    8,
+                )),
+            )
+            .is_err(),
+            "a different IPv6 scope must not inherit local-interface ownership"
+        );
+        assert!(socket_owner(&owners, "192.168.49.2:38000".parse().unwrap()).is_err());
     }
 }

--- a/peat-ffi/src/lib.rs
+++ b/peat-ffi/src/lib.rs
@@ -8723,11 +8723,14 @@ pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithConfi
 
 /// JNI: create one node over explicit Android-selected IP networks.
 ///
-/// `ipBindingsJson` is a bounded array of numeric local addresses, CIDR
-/// prefixes, Android `Network.getNetworkHandle()` values, and default-route
-/// flags. The native socket owner marks each Iroh UDP socket before bind and
-/// on every rebind. Any missing/invalid mapping fails node creation; this path
-/// never falls back to the process default network.
+/// `ipBindingsJson` is a bounded array of numeric local addresses and CIDR
+/// prefixes. Each record declares either an Android
+/// `Network.getNetworkHandle()` value or one validated non-default local
+/// interface (including IPv6 scope when required). The native socket owner
+/// marks handle-backed Iroh UDP sockets before bind and permits only exact
+/// validated interface-owned sockets through the same hook. Any missing or
+/// invalid mapping fails node creation; this path never falls back to the
+/// process default network.
 #[cfg(feature = "sync")]
 #[no_mangle]
 pub extern "system" fn Java_com_defenseunicorns_peat_PeatJni_createNodeWithIpBindingsJni(


### PR DESCRIPTION
Closes #1097

## Summary
- extend the existing bounded selected-IP JSON surface with explicit non-default local-interface ownership
- validate live Android interface/address assignments and require exact IPv6 link-local scope IDs
- keep Android Network handle behavior backward compatible and fail closed on ambiguous, stale, or undeclared socket ownership
- document the generic boundary without adding routing, VPN, NAT, process binding, or consumer-specific policy

## Verification
- cargo fmt --all --check
- cargo check -p peat-ffi --features sync
- cargo test -p peat-ffi --features sync --lib (101 passed)
- cargo clippy -p peat-ffi --features sync --lib with only two pre-existing lints suppressed and all other warnings denied
- peat-ffi/android: compileDebugAndroidTestKotlin
- peat-ffi/android: lintDebug testDebugUnitTest
- git diff --check
- consumer identifier diff gate

## Downstream physical qualification
The rebuilt Android AAR was integrated into jeremymcgee73/peat-atak-plugin#21 and exercised on three physical phones. A bridge phone retained an authenticated infrastructure-Wi-Fi peer while owning a local-only Wi-Fi Direct group for a second authenticated peer. The edge phones were mutually IP-unreachable, and the upstream PLI document converged through the bridge. Teardown restored all original WLAN addresses and peer counts without changing ATAK process IDs or PEAT identities.

## Compatibility
Existing positive Android Network handle records retain their behavior. Handle-less records are accepted only for a live, exact, non-default interface/address declaration. IPv6 link-local records additionally require the live interface scope.

No peat-mesh changes are included.